### PR TITLE
Repair the rest of what Google's export does to frontmatter

### DIFF
--- a/backend/integrations/google/indexer.py
+++ b/backend/integrations/google/indexer.py
@@ -19,6 +19,7 @@ API silently drops Shared Drive items.
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from datetime import datetime
@@ -27,6 +28,7 @@ from uuid import UUID
 import httpx
 
 from ...services import source_service
+from ...services.skill_service import FRONTMATTER_SCAN_BYTES, declared_skill
 from ..storage import get_valid_token
 
 logger = logging.getLogger(__name__)
@@ -122,6 +124,101 @@ def unescape_exported_markdown(markdown: str) -> str:
     hard break, and the frontmatter parser already ignores them.
     """
     return _EXPORT_ESCAPE_RE.sub(r"\1", markdown)
+
+
+_ESCAPED_RULE_RE = re.compile(r"^\\(-{3,})[ \t]*$", re.MULTILINE)
+# Still-escaped delimiters are accepted here because a leading BOM blocks the
+# MULTILINE ^ above from ever seeing the first line.
+_DELIMITER_RE = re.compile(r"\\?-{3,}[ \t]*")
+# A bare * or _ in the export is the exporter's styling markup (bold, italic):
+# the author's own characters always arrive backslash-escaped, which the
+# lookbehind preserves for the unescape pass to restore.
+_EMPHASIS_RE = re.compile(r"(?<!\\)[*_]+")
+# Docs curls typed quotes by default; both pairs mean "the author quoted this".
+_QUOTE_PAIRS = (("\u201c", "\u201d"), ("\u2018", "\u2019"), ('"', '"'))
+
+
+def repair_exported_markdown(markdown: str) -> str:
+    r"""Everything the extractor undoes about Google's markdown export.
+
+    Two passes with distinct jobs. The frontmatter block is repaired
+    *structurally* — escaped delimiters restored, styled keys unstyled, curly
+    wrapping quotes re-encoded via json.dumps, a leading BOM or blank paragraph
+    dropped — and the rewrite is kept ONLY when the result declares a valid
+    skill: prose that merely opens with a horizontal rule is the author's text,
+    not frontmatter. Everything outside that block gets one level of
+    backslash-escaping stripped (unescape_exported_markdown).
+
+    The order is load-bearing twice over. The repair must see the raw export,
+    because it tells the exporter's styling markup (bare `*`/`_`) from the
+    author's own characters (escaped) — a distinction the unescape erases. And
+    the unescape must never run over the repaired block, because json.dumps may
+    itself emit backslashes that are now the value's real content.
+    """
+    text = _ESCAPED_RULE_RE.sub(r"\1", markdown)
+    head, tail = text[:FRONTMATTER_SCAN_BYTES], text[FRONTMATTER_SCAN_BYTES:]
+    split = _split_repaired_frontmatter(head)
+    if split is not None:
+        block, rest_lines = split
+        body = "\n".join(rest_lines)
+        candidate = block
+        if rest_lines:
+            candidate += "\n" + unescape_exported_markdown(body + tail)
+        else:
+            candidate += unescape_exported_markdown(tail)
+        if declared_skill(candidate[:FRONTMATTER_SCAN_BYTES]) is not None:
+            return candidate
+    return unescape_exported_markdown(text)
+
+
+def _split_repaired_frontmatter(head: str) -> tuple[str, list[str]] | None:
+    """The head's repaired frontmatter block and the lines after it, or None.
+
+    A leading BOM or empty first paragraph — one invisible keystroke in a Doc —
+    is dropped so the block sits at the top, where every parser and the
+    `content LIKE '---%'` prefilter expect it. Delimiter lines are normalized
+    to exactly `---` so the repaired span and the span parse_frontmatter reads
+    are the same span.
+    """
+    lines = head.lstrip("\ufeff").split("\n")
+    start = 0
+    while start < len(lines) and not lines[start].strip():
+        start += 1
+    if start >= len(lines) or not _DELIMITER_RE.fullmatch(lines[start]):
+        return None
+    closing = next(
+        (i for i in range(start + 1, len(lines)) if _DELIMITER_RE.fullmatch(lines[i])), None
+    )
+    if closing is None:
+        return None
+    repaired = [_repair_frontmatter_line(line) for line in lines[start + 1 : closing]]
+    return "\n".join(["---", *repaired, "---"]), lines[closing + 1 :]
+
+
+def _repair_frontmatter_line(line: str) -> str:
+    r"""One `key: value` line, as the author wrote it in the Doc.
+
+    Emphasis markers go because frontmatter has no formatting — a key the
+    author styled is still just the key. Backslashes go because the escaping is
+    the exporter's. The order is load-bearing: bare `*`/`_` are markup only
+    because the author's own are still escaped when emphasis is stripped.
+    """
+    line = _EXPORT_ESCAPE_RE.sub(r"\1", _EMPHASIS_RE.sub("", line))
+    key, colon, value = line.partition(":")
+    if not colon:
+        return line
+    return f"{key.strip()}: {_requoted_value(value.strip())}"
+
+
+def _requoted_value(value: str) -> str:
+    """A value the author wrapped in quotes, re-encoded as the JSON string the
+    frontmatter parser expects. json.dumps, not hand-built quoting: the interior
+    is the author's literal text, and it may contain quotes or backslashes of
+    its own. A curly quote inside the sentence is their text and stays curly."""
+    for opening, closing in _QUOTE_PAIRS:
+        if len(value) >= 2 and value.startswith(opening) and value.endswith(closing):
+            return json.dumps(value[1:-1], ensure_ascii=False)
+    return value
 
 
 async def _require_readable_folder(client: httpx.AsyncClient, folder_id: str) -> None:
@@ -499,7 +596,7 @@ async def extract_drive_text(
         from ...services.file_extraction import extract_text, is_pdf
 
         if mime == MIME_GOOGLE_DOC:
-            text = unescape_exported_markdown(await _export(client, file_id, "text/markdown"))
+            text = repair_exported_markdown(await _export(client, file_id, "text/markdown"))
         elif mime == MIME_GOOGLE_SHEET:
             # XLSX export keeps every visible sheet (Drive's CSV export drops
             # everything except the first).

--- a/backend/migrations/versions/0187_repair_drive_skill_frontmatter.py
+++ b/backend/migrations/versions/0187_repair_drive_skill_frontmatter.py
@@ -1,0 +1,164 @@
+"""Repair Google-export damage in already-extracted Drive documents.
+
+The extraction-time repair (repair_exported_frontmatter) only runs when a
+document is re-extracted, and extraction is keyed on Drive's own modifiedTime —
+so a document damaged before the repair shipped stays damaged until its author
+happens to edit it. This carries the stored rows forward once.
+
+The logic is a frozen copy of the frontmatter half of the extraction-time
+repair (repair_exported_markdown), per this directory's convention: a migration
+must keep producing the same result even after the live code moves on. The
+body-unescape half is deliberately NOT backfilled: stored rows don't record
+whether their text came from a Docs markdown export (where a backslash is the
+exporter's) or a PDF/plain-file extraction (where it may be the author's), so
+bodies heal on the document's next edit-driven re-extraction instead.
+
+A row is rewritten only when the repair turns it into a valid skill declaration
+it wasn't before, or when it already declared a skill whose values are wrapped
+in the curly quotes only Docs' exporter produces. A document that already
+declares a clean skill — e.g. a hand-authored SKILL.md synced from a Drive
+folder — stays exactly as its author wrote it.
+
+Revision ID: 0187
+Revises: 0186
+"""
+
+import json
+import re
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "0187"
+down_revision = "0186"
+branch_labels = None
+depends_on = None
+
+FRONTMATTER_SCAN_BYTES = 8192
+MAX_SKILL_NAME_LENGTH = 64
+MAX_SKILL_DESCRIPTION_LENGTH = 1024
+
+_ESCAPED_RULE_RE = re.compile(r"^\\(-{3,})[ \t]*$", re.MULTILINE)
+_DELIMITER_RE = re.compile(r"\\?-{3,}[ \t]*")
+_EMPHASIS_RE = re.compile(r"(?<!\\)[*_]+")
+_MARKDOWN_ESCAPE_RE = re.compile(r"\\([!\"#$%&'()*+,\-./:;<=>?@\[\\\]^_`{|}~])")
+_QUOTE_PAIRS = (("\u201c", "\u201d"), ("\u2018", "\u2019"), ('"', '"'))
+_CURLY_PAIRS = (("\u201c", "\u201d"), ("\u2018", "\u2019"))
+
+
+def _repair(markdown: str) -> str:
+    text_ = _ESCAPED_RULE_RE.sub(r"\1", markdown)
+    head, tail = text_[:FRONTMATTER_SCAN_BYTES], text_[FRONTMATTER_SCAN_BYTES:]
+    repaired_head = _repaired_head(head)
+    if repaired_head is None:
+        return text_
+    candidate = repaired_head + tail
+    if not _declares_skill(candidate[:FRONTMATTER_SCAN_BYTES]):
+        return text_
+    return candidate
+
+
+def _repaired_head(head: str) -> str | None:
+    lines = head.lstrip("\ufeff").split("\n")
+    start = 0
+    while start < len(lines) and not lines[start].strip():
+        start += 1
+    if start >= len(lines) or not _DELIMITER_RE.fullmatch(lines[start]):
+        return None
+    closing = next(
+        (i for i in range(start + 1, len(lines)) if _DELIMITER_RE.fullmatch(lines[i])), None
+    )
+    if closing is None:
+        return None
+    repaired = [_repair_line(line) for line in lines[start + 1 : closing]]
+    return "\n".join(["---", *repaired, "---", *lines[closing + 1 :]])
+
+
+def _repair_line(line: str) -> str:
+    line = _MARKDOWN_ESCAPE_RE.sub(r"\1", _EMPHASIS_RE.sub("", line))
+    key, colon, value = line.partition(":")
+    if not colon:
+        return line
+    value = value.strip()
+    for opening, closing in _QUOTE_PAIRS:
+        if len(value) >= 2 and value.startswith(opening) and value.endswith(closing):
+            value = json.dumps(value[1:-1], ensure_ascii=False)
+            break
+    return f"{key.strip()}: {value}"
+
+
+def _frontmatter(md: str) -> dict | None:
+    if not md.startswith("---"):
+        return None
+    end = md.find("\n---", 3)
+    if end == -1:
+        return None
+    meta: dict = {}
+    for line in md[3:end].strip("\n").splitlines():
+        line = line.rstrip()
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        key, _, val = line.partition(":")
+        val = val.strip()
+        if val.startswith('"') and val.endswith('"'):
+            try:
+                val = str(json.loads(val))
+            except ValueError:
+                return None
+        meta[key.strip()] = val
+    return meta
+
+
+def _declares_skill(md: str) -> bool:
+    meta = _frontmatter(md)
+    if meta is None:
+        return False
+    name = meta.get("name", "").strip()
+    description = meta.get("description", "").strip()
+    return (
+        0 < len(name) <= MAX_SKILL_NAME_LENGTH
+        and 0 < len(description) <= MAX_SKILL_DESCRIPTION_LENGTH
+    )
+
+
+def _curly_wrapped(meta: dict) -> bool:
+    return any(
+        len(value) >= 2 and value.startswith(opening) and value.endswith(closing)
+        for value in meta.values()
+        if isinstance(value, str)
+        for opening, closing in _CURLY_PAIRS
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    rows = bind.execute(
+        text(
+            "SELECT id, content FROM drive_documents "
+            "WHERE deleted_at IS NULL AND content IS NOT NULL "
+            "  AND left(content, 64) LIKE '%---%'"
+        )
+    ).mappings()
+    for row in rows:
+        content = row["content"]
+        repaired = _repair(content)
+        if repaired == content:
+            continue
+        if not _declares_skill(repaired[:FRONTMATTER_SCAN_BYTES]):
+            continue
+        current = _frontmatter(content[:FRONTMATTER_SCAN_BYTES])
+        already_a_skill = _declares_skill(content[:FRONTMATTER_SCAN_BYTES])
+        if already_a_skill and not (current and _curly_wrapped(current)):
+            continue
+        bind.execute(
+            text(
+                "UPDATE drive_documents SET content = :content, "
+                "content_hash = md5(:content), embed_stale = TRUE, updated_at = now() "
+                "WHERE id = :row_id"
+            ),
+            {"content": repaired, "row_id": row["id"]},
+        )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/tests/test_drive_extraction_pipeline.py
+++ b/backend/tests/test_drive_extraction_pipeline.py
@@ -622,7 +622,7 @@ def test_a_frontmatter_block_written_in_a_doc_survives_google_s_export():
         'description: "Use when a customer reports boost loss."  \n\\---  \n\nCheck the wastegate.\n'
     )
 
-    repaired = indexer.unescape_exported_markdown(exported)
+    repaired = indexer.repair_exported_markdown(exported)
 
     meta = skill_service.declared_skill(repaired)
     assert meta is not None
@@ -647,3 +647,198 @@ def test_an_author_s_own_backslash_survives_one_level_of_unescaping():
     (`\\-` exports as `\\\\-`), so stripping one level returns exactly what the
     author wrote."""
     assert indexer.unescape_exported_markdown("a \\\\- b\n") == "a \\- b\n"
+
+
+def _skill_from_export(exported: str) -> dict | None:
+    return skill_service.declared_skill(indexer.repair_exported_markdown(exported))
+
+
+def test_quotes_the_author_typed_in_a_doc_are_curly():
+    """Docs curls a typed quote by default, so the example we hand a customer
+    comes back as `name: \u201cTurbochargers\u201d` — which parses, and names the skill
+    with the quotes still in it."""
+    meta = _skill_from_export(
+        "\\---  \nname: \u201cTurbochargers\u201d  \n"
+        "description: \u201cUse when a customer reports boost loss.\u201d  \n\\---  \n\nCheck it.\n"
+    )
+
+    assert meta is not None
+    assert meta["name"] == "Turbochargers"
+    assert meta["description"] == "Use when a customer reports boost loss."
+
+
+def test_an_apostrophe_inside_a_value_stays_curly():
+    """Only the wrapping pair is straightened. A curly apostrophe mid-sentence
+    is the author's own text, and rewriting it would be us editing their words."""
+    meta = _skill_from_export(
+        '\\---  \nname: "Turbochargers"  \n'
+        "description: \u201cUse when the customer\u2019s VIN is known.\u201d  \n\\---  \n\nCheck it.\n"
+    )
+
+    assert meta is not None
+    assert meta["description"] == "Use when the customer\u2019s VIN is known."
+
+
+def test_an_underscore_in_a_description_does_not_cost_the_skill():
+    """Google escapes an underscore that could read as emphasis. Inside a quoted
+    value that `\\_` is invalid JSON, so the parser used to reject the block and
+    the document silently stopped being a skill over one character."""
+    meta = _skill_from_export(
+        '\\---  \nname: "Turbochargers"  \n'
+        'description: "Use when the customer gives a part\\_number or VIN\\_code."  \n'
+        "\\---  \n\nCheck it.\n"
+    )
+
+    assert meta is not None
+    assert meta["description"] == "Use when the customer gives a part_number or VIN_code."
+
+
+def test_a_key_the_author_styled_is_still_the_key():
+    """Bolding `name:` in the Doc exports as `**name:**`, which partitions to a
+    key nobody is looking for. Frontmatter has no formatting in it."""
+    meta = _skill_from_export(
+        '\\---  \n**name:** "Turbochargers"  \n'
+        '**description:** "Use when a customer reports boost loss."  \n\\---  \n\nCheck it.\n'
+    )
+
+    assert meta is not None
+    assert meta["name"] == "Turbochargers"
+    assert meta["description"] == "Use when a customer reports boost loss."
+
+
+def test_an_empty_first_paragraph_does_not_hide_the_block():
+    """A blank line above the block is one keystroke in a Doc and invisible in
+    the editor. It used to be fatal twice over: the block is no longer at the
+    top, and the listing query never even reaches a document that doesn't start
+    with a delimiter."""
+    repaired = indexer.repair_exported_markdown(
+        '\n\\---  \nname: "Turbochargers"  \n'
+        'description: "Use when a customer reports boost loss."  \n\\---  \n\nCheck it.\n'
+    )
+
+    assert repaired.startswith("---")
+    assert skill_service.declared_skill(repaired) is not None
+
+
+def test_the_body_reads_as_the_author_wrote_it():
+    """Two different repairs meet at the closing delimiter. Emphasis the author
+    styled (`**wastegate**`) is their markdown and stays; a backslash the
+    exporter added (`part\\_number`) is noise the agent would read literally,
+    and goes. Delivery is the product: the agent gets the author's words."""
+    exported = (
+        '\\---  \nname: "Turbochargers"  \n'
+        'description: "Use when a customer reports boost loss."  \n\\---  \n\n'
+        "Check the **wastegate** and the part\\_number on the tag.\n"
+    )
+
+    body = indexer.repair_exported_markdown(exported).split("---\n")[-1]
+
+    assert "**wastegate**" in body
+    assert "part_number" in body
+    assert "\\_" not in body
+
+
+def test_an_ordinary_document_opening_with_a_divider_keeps_its_structure():
+    """The frontmatter rewrite is kept only when it produces a valid skill
+    declaration. A meeting-notes Doc that happens to open with a typed divider
+    is prose — stripping its bold or respacing its times would corrupt stored
+    text that was never frontmatter. (Backslash-unescaping still applies: that
+    noise is the exporter's in any Doc.)"""
+    exported = (
+        "---\n\nStandup 9:00 AM  \nAttendees: **Ann**, Bob  \n"
+        "Notes at https://wiki.example.com/turbo  \n\n---\n\nAction items below.\n"
+    )
+
+    assert indexer.repair_exported_markdown(exported) == exported
+
+
+def test_a_straight_quote_inside_a_curly_quoted_value_still_parses():
+    """The interior of a quoted value is the author's literal text, re-encoded
+    with json.dumps — an inner straight quote must not break the JSON, and the
+    body unescape must never strip the JSON escapes the repair just wrote."""
+    meta = _skill_from_export(
+        '\\---  \nname: "Turbochargers"  \n'
+        'description: \u201cSay "no" to boost loss.\u201d  \n\\---  \n\nCheck it.\n'
+    )
+
+    assert meta is not None
+    assert meta["description"] == 'Say "no" to boost loss.'
+
+
+def test_a_backslash_the_author_typed_survives():
+    """The author's own backslash arrives doubled from the exporter; after
+    repair the stored value must read back as the single backslash they saw."""
+    meta = _skill_from_export(
+        '\\---  \nname: "Turbochargers"  \n'
+        "description: \u201cCheck the C:\\\\temp folder.\u201d  \n\\---  \n\nCheck it.\n"
+    )
+
+    assert meta is not None
+    assert meta["description"] == "Check the C:\\temp folder."
+
+
+def test_every_exporter_escape_is_undone_in_frontmatter():
+    """The exporter escapes any CommonMark punctuation, not just the common
+    few — a surviving backslash inside a quoted value breaks json.loads and
+    silently costs the skill."""
+    meta = _skill_from_export(
+        '\\---  \nname: "Turbochargers"  \n'
+        'description: "Use when boost is \\<5 psi or the code is A\\|B\\~C."  \n'
+        "\\---  \n\nCheck it.\n"
+    )
+
+    assert meta is not None
+    assert meta["description"] == "Use when boost is <5 psi or the code is A|B~C."
+
+
+def test_single_curly_quotes_are_straightened_too():
+    """Docs curls a typed single quote exactly like a double one; both wrapping
+    pairs mean "the author quoted this"."""
+    meta = _skill_from_export(
+        "\\---  \nname: \u2018Turbochargers\u2019  \n"
+        "description: \u2018Use when a customer reports boost loss.\u2019  \n\\---  \n\nCheck it.\n"
+    )
+
+    assert meta is not None
+    assert meta["name"] == "Turbochargers"
+    assert meta["description"] == "Use when a customer reports boost loss."
+
+
+def test_an_italicized_key_is_still_the_key():
+    """Italic is the same one-click styling accident as bold and gets the same
+    treatment — `*name:*` partitions to a key nobody is looking for."""
+    meta = _skill_from_export(
+        '\\---  \n*name:* "Turbochargers"  \n'
+        '*description:* "Use when a customer reports boost loss."  \n\\---  \n\nCheck it.\n'
+    )
+
+    assert meta is not None
+    assert meta["name"] == "Turbochargers"
+
+
+def test_a_blank_first_line_with_hard_break_spaces_does_not_hide_the_block():
+    """An empty first paragraph exports with Google's hard-break trailing
+    spaces, not as a bare newline — and a BOM is the same invisible-junk shape.
+    Both must still land the block at the top of the stored text."""
+    for prefix in ("  \n", "\ufeff", "\ufeff  \n"):
+        repaired = indexer.repair_exported_markdown(
+            prefix + '\\---  \nname: "Turbochargers"  \n'
+            'description: "Use when a customer reports boost loss."  \n\\---  \n\nCheck it.\n'
+        )
+
+        assert repaired.startswith("---"), repr(prefix)
+        assert skill_service.declared_skill(repaired) is not None, repr(prefix)
+
+
+def test_four_dash_delimiters_leave_no_stray_dash_in_the_body():
+    """Delimiter lines are normalized to exactly `---` so the span the repair
+    rewrites and the span parse_frontmatter reads are the same span — a 4-dash
+    rule must not leak a dangling dash into the instructions the agent reads."""
+    repaired = indexer.repair_exported_markdown(
+        '\\----  \nname: "Turbochargers"  \n'
+        'description: "Use when a customer reports boost loss."  \n\\----  \n\nCheck it.\n'
+    )
+
+    meta, body = skill_service.parse_frontmatter(repaired)
+    assert meta["name"] == "Turbochargers"
+    assert body == "Check it.\n"

--- a/backend/tests/test_migration_repair_drive_frontmatter.py
+++ b/backend/tests/test_migration_repair_drive_frontmatter.py
@@ -1,0 +1,159 @@
+"""Data-level test for 0187, the Google-export frontmatter backfill.
+
+0187 rewrites stored `drive_documents.content`, and a backfill that rewrites
+user content is exactly where a wrong guard silently corrupts a document
+someone else authored. The chain-runs-clean tests can't catch that; this seeds
+a pre-0187 world on an isolated database, runs the migration, and asserts each
+kind of row gets exactly the treatment it should: exporter damage repaired,
+prose and hand-authored files byte-identical.
+"""
+
+import asyncio
+import os
+import subprocess
+import sys
+import uuid
+
+import asyncpg
+
+_BASE_URL = os.environ.get(
+    "TEST_DATABASE_URL",
+    "postgresql://stash:stash@localhost:5432/stash_test",
+)
+_ADMIN_URL = _BASE_URL.rsplit("/", 1)[0] + "/postgres"
+_MIG_DB = "stash_mig_frontmatter_" + uuid.uuid4().hex[:12]
+_MIG_URL = _BASE_URL.rsplit("/", 1)[0] + "/" + _MIG_DB
+
+
+def _alembic(target: str) -> None:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = _MIG_URL
+    repo_root = os.path.join(os.path.dirname(__file__), "..", "..")
+    result = subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", target],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"alembic upgrade {target} failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+
+async def _create_db() -> None:
+    conn = await asyncpg.connect(_ADMIN_URL)
+    await conn.execute(f'DROP DATABASE IF EXISTS "{_MIG_DB}"')
+    await conn.execute(f'CREATE DATABASE "{_MIG_DB}"')
+    await conn.close()
+    conn = await asyncpg.connect(_MIG_URL)
+    await conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    await conn.close()
+
+
+async def _drop_db() -> None:
+    conn = await asyncpg.connect(_ADMIN_URL)
+    await conn.execute(
+        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+        "WHERE datname = $1 AND pid <> pg_backend_pid()",
+        _MIG_DB,
+    )
+    await conn.execute(f'DROP DATABASE IF EXISTS "{_MIG_DB}"')
+    await conn.close()
+
+
+# The four kinds of stored row the backfill must treat differently.
+
+DAMAGED_DOC_EXPORT = (
+    "\\---  \n**name:** “Brake Shoes”  \n"
+    'description: "Use when a part\\_number is given."  \n\\---  \n\nCheck the drum.\n'
+)
+
+CURLY_ONLY_DOC_EXPORT = (
+    "---\nname: “Brake Shoes”\ndescription: “Use when brakes squeal.”\n---\n\nCheck the drum.\n"
+)
+
+ORDINARY_PROSE = (
+    "---\n\nStandup 9:00 AM  \nAttendees: **Ann**, Bob  \n"
+    "Notes at https://wiki.example.com/turbo  \n\n---\n\nAction items below.\n"
+)
+
+HAND_AUTHORED_SKILL_MD = (
+    '---\nname: "Fitment"\ndescription: "Use for *fitment* checks."\n---\n\nMeasure twice.\n'
+)
+
+
+async def _seed() -> dict[str, uuid.UUID]:
+    conn = await asyncpg.connect(_MIG_URL)
+    user_id = await conn.fetchval(
+        "INSERT INTO users (name, display_name) VALUES ('mig-frontmatter-user', 'u') RETURNING id",
+    )
+    source_id = await conn.fetchval(
+        "INSERT INTO user_sources (owner_user_id, source_type, external_ref, display_name, "
+        "binds_skills) VALUES ($1, 'google_drive_folder', 'folder-1', 'Shelf', TRUE) "
+        "RETURNING id",
+        user_id,
+    )
+    ids: dict[str, uuid.UUID] = {}
+    for path, content in [
+        ("damaged.gdoc", DAMAGED_DOC_EXPORT),
+        ("curly.gdoc", CURLY_ONLY_DOC_EXPORT),
+        ("notes.gdoc", ORDINARY_PROSE),
+        ("SKILL.md", HAND_AUTHORED_SKILL_MD),
+    ]:
+        ids[path] = await conn.fetchval(
+            "INSERT INTO drive_documents (owner_user_id, source_id, path, name, external_ref, "
+            "content, content_hash, extraction_status) "
+            "VALUES ($1, $2, $3, $3, $3, $4, md5($4), 'done') RETURNING id",
+            user_id,
+            source_id,
+            path,
+            content,
+        )
+    await conn.close()
+    return ids
+
+
+async def _fetch(ids: dict[str, uuid.UUID]) -> dict[str, asyncpg.Record]:
+    conn = await asyncpg.connect(_MIG_URL)
+    rows = {
+        path: await conn.fetchrow(
+            "SELECT content, content_hash, embed_stale FROM drive_documents WHERE id = $1",
+            row_id,
+        )
+        for path, row_id in ids.items()
+    }
+    await conn.close()
+    return rows
+
+
+def test_backfill_repairs_exporter_damage_and_nothing_else():
+    asyncio.run(_create_db())
+    try:
+        _alembic("0186")
+        ids = asyncio.run(_seed())
+        _alembic("head")
+        rows = asyncio.run(_fetch(ids))
+
+        damaged = rows["damaged.gdoc"]
+        assert damaged["content"] == (
+            '---\nname: "Brake Shoes"\n'
+            'description: "Use when a part_number is given."\n---\n\nCheck the drum.\n'
+        )
+        assert damaged["embed_stale"] is True
+
+        curly = rows["curly.gdoc"]
+        assert curly["content"] == (
+            '---\nname: "Brake Shoes"\ndescription: "Use when brakes squeal."\n'
+            "---\n\nCheck the drum.\n"
+        )
+        assert curly["embed_stale"] is True
+
+        # The prose row and the hand-authored SKILL.md are someone's own text:
+        # byte-identical or the backfill has corrupted a document.
+        assert rows["notes.gdoc"]["content"] == ORDINARY_PROSE
+        assert rows["notes.gdoc"]["embed_stale"] is False
+        assert rows["SKILL.md"]["content"] == HAND_AUTHORED_SKILL_MD
+        assert rows["SKILL.md"]["embed_stale"] is False
+    finally:
+        asyncio.run(_drop_db())


### PR DESCRIPTION
our google drive to skills conversion uses the google drive "export to markdown" feature to convert docs to skills, which are markdown files by default. Unfortunately, this export mangles a bunch of things about the doc in the conversion, so we need to manually fix them. This is a surgical fix, we only go ahead with this intense manual un-mangling when the result will be a valid skill (we think in this case, it's clearly a good thing for us to do this). We also include some general light unmangling fixes for all documents, skills and not-skills. We also include a migration to repair already-broken already-imported google-docs-to-markdown files from drive.

Thanks to @mholkesvik for the find


Rebuilt on main after #1040 merged, reconciled with main's general body unescape (`a933062a`). One commit.

**What it does** — the frontmatter half of undoing Google's markdown export, composed with the body half already on main:

1. `repair_exported_markdown` first repairs the frontmatter block structurally on the raw export: escaped delimiters (`\---`), curled wrapping quotes (re-encoded with json.dumps so interior quotes/backslashes survive), bolded/italicized keys (`**name:**`), a leading BOM or empty first paragraph, 4+-dash delimiters normalized to `---`. The rewrite is kept **only when the result declares a valid skill** — prose that merely opens with a divider stays untouched.
2. `unescape_exported_markdown` (already on main) then strips one level of exporter escaping from everything **outside** the block.

The order is load-bearing twice: the repair must see the raw export to tell the exporter's styling markup (bare `*`/`_`) from the author's own escaped characters, and the unescape must never cross into the repaired block or it would strip the JSON escapes json.dumps just wrote.

**Changed from the previously-approved version:** the earlier stance that body escapes are "the author writing markdown" is dropped — Heavi's real Air Disc Brake Pads sheet showed mid-sentence escapes (`\-`, `\~`, `\*\*`) the author never typed, so body backslashes are the exporter's and are removed. One test rewritten to pin the new contract.

**Migration renumbered 0186 → 0187** (main took 0186 in #1040). It backfills the frontmatter repair only; bodies are deliberately not backfilled because stored rows don't record whether their text came from a Docs export or a PDF extraction — they heal on the next edit-driven re-extraction. Blast radius in prod today: 1 damaged row out of 205.

Verified: 244 tests pass locally (drive extraction pipeline incl. 13 repair tests, the data-level migration test on an isolated DB, migration chain/placeholders, source-backed skills); ruff clean.

@-less note for the reviewer: the approval on record predates this rebuild — worth a re-look given the body-unescape stance change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)