### PR TITLE
stash revamp 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ everything before it is captured in git history (`git log`), not here.
 
 ## Unreleased
 
+- Local embeddings run on the CPU (fixes a crash on Apple Silicon).
+  sentence-transformers 5.x selects Apple's Metal (`mps`) device when it can,
+  and a Metal context cannot survive `fork()` — so every Celery prefork child
+  that embedded died on SIGABRT, crashlooping the embed-reconcile task and
+  taking down any process that had touched the model. Affects local dev and
+  self-hosters using `EMBEDDING_PROVIDER=local`; hosted prod embeds with
+  OpenAI and was never affected.
+
 - CLI onboarding redesigned (#940). `stash signin` walks a first-run wizard
   that can be re-run anytime with the new `stash setup` — no answer is final.
   Session recording is framed as private-by-default and on by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ everything before it is captured in git history (`git log`), not here.
 
 ## Unreleased
 
+- New **Hopper** tab: drop anything in and it lands in your Stash, readable by
+  your agents. Drag files onto the page, paste a link, or paste a screenshot
+  straight from the clipboard — each goes down the pipeline that can read it
+  (file extraction or webpage import) and arrives in your VFS as an ordinary
+  item.
 - Uploaded images are transcribed by vision, so agents can read them.
   `file_extraction.extract_text` has no branch for images, so every uploaded
   screenshot, photo, and diagram stored an empty knowledge-base entry and was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ everything before it is captured in git history (`git log`), not here.
 
 ## Unreleased
 
+- Uploaded images are transcribed by vision, so agents can read them.
+  `file_extraction.extract_text` has no branch for images, so every uploaded
+  screenshot, photo, and diagram stored an empty knowledge-base entry and was
+  invisible to search, ask-the-stash, and the VFS. Images now take the same
+  path scanned PDFs take: text transcribed character-for-character, and
+  everything non-textual described in place. Formats Gemini cannot read
+  inline (SVG, TIFF) still store no text rather than pretending.
 - Local embeddings run on the CPU (fixes a crash on Apple Silicon).
   sentence-transformers 5.x selects Apple's Metal (`mps`) device when it can,
   and a Metal context cannot survive `fork()` — so every Celery prefork child

--- a/backend/main.py
+++ b/backend/main.py
@@ -32,6 +32,7 @@ from .routers import (
     exports,
     files,
     files_tree,
+    hopper,
     machine,
     marketing,
     mcp_servers,
@@ -130,6 +131,7 @@ app.include_router(files.me_router)
 app.include_router(files.canonical_router)
 app.include_router(clips.router)
 app.include_router(clips.imports_router)
+app.include_router(hopper.router)
 app.include_router(curator_log.router)
 app.include_router(mini_programs.router)
 app.include_router(batch.router)

--- a/backend/routers/hopper.py
+++ b/backend/routers/hopper.py
@@ -24,11 +24,29 @@ from .files import MAX_FILE_SIZE, _strip_ext, ingest_bytes
 
 router = APIRouter(prefix="/api/v1/me/hopper", tags=["hopper"])
 
-# An image with a meaningless name (IMG_0917, CleanShot 2026-08-12) has no
-# semantic home, but it does have an obvious kind. Without this they pile up at
-# the top level, which is exactly the junk drawer a filesystem is meant to
-# prevent.
-IMAGES_FOLDER = "Images"
+# A photo, clip or recording with a meaningless name (IMG_0917, IMG_3503.MOV)
+# has no semantic home, but it does have an obvious kind. Without this they
+# pile up at the top level, which is exactly the junk drawer a filesystem is
+# meant to prevent.
+#
+# Keyed by extension as well as content type because browsers routinely hand
+# over application/octet-stream for anything they do not recognise — a .MOV
+# from an iPhone arrives untyped.
+_MEDIA_FOLDERS = (
+    ("Images", "image/", (".jpg", ".jpeg", ".png", ".gif", ".webp", ".heic", ".heif", ".bmp")),
+    ("Videos", "video/", (".mov", ".mp4", ".m4v", ".avi", ".mkv", ".webm")),
+    ("Audio", "audio/", (".mp3", ".m4a", ".wav", ".aac", ".flac", ".ogg")),
+)
+
+
+def _media_folder(filename: str, content_type: str) -> str | None:
+    """The kind-based home for a file, or None for anything that is not media."""
+    name = filename.lower()
+    for folder, prefix, extensions in _MEDIA_FOLDERS:
+        if content_type.startswith(prefix) or name.endswith(extensions):
+            return folder
+    return None
+
 
 # Dropping a directory mirrors its structure, so the depth cap is the only
 # guard against someone dragging in their home folder.
@@ -211,18 +229,20 @@ async def classify_drop(
     # Only ever files something loose: a folder drop, or filing that already
     # happened, is not for a classifier to revisit.
     if row["folder_id"] is not None:
-        return {"filed_in": None}
+        return {"filed_in": None, "folder_id": None}
 
     folder_id, path = await file_classifier.suggest_folder(
         owner_user_id, row["name"], row["content_type"]
     )
-    if folder_id is None and row["content_type"].startswith("image/"):
-        # No folder fits, but an image still has somewhere to be. This is a
-        # rule, not a guess: the kind is known, only the meaning is not.
-        folder_id = await _folder_for_path(owner_user_id, current_user["id"], IMAGES_FOLDER)
-        path = IMAGES_FOLDER
     if folder_id is None:
-        return {"filed_in": None}
+        # No folder fits, but a photo or clip still has somewhere to be. This
+        # is a rule, not a guess: the kind is known, only the meaning is not.
+        media = _media_folder(row["name"], row["content_type"])
+        if media:
+            folder_id = await _folder_for_path(owner_user_id, current_user["id"], media)
+            path = media
+    if folder_id is None:
+        return {"filed_in": None, "folder_id": None}
     await pool.execute(
         f"UPDATE {table} SET folder_id = $1 WHERE id = $2 AND owner_user_id = $3 "  # noqa: S608
         "AND folder_id IS NULL",
@@ -230,7 +250,9 @@ async def classify_drop(
         body.id,
         owner_user_id,
     )
-    return {"filed_in": path}
+    # The id as well as the path: a person told where something went will
+    # want to go there, and only the id can open the folder.
+    return {"filed_in": path, "folder_id": str(folder_id)}
 
 
 @router.post("/link", status_code=201)

--- a/backend/routers/hopper.py
+++ b/backend/routers/hopper.py
@@ -1,0 +1,79 @@
+"""Hopper router: one front door into the VFS.
+
+Two drop shapes — a file and a link — each handed to the pipeline that already
+knows how to read it: bytes through the files/pages ingest, a URL through
+url_imports. The hopper takes things that already exist; composing content is
+what pages are for. Nothing is recorded here and nothing is parked: a drop
+becomes an ordinary VFS item the moment it lands.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile
+from pydantic import BaseModel, HttpUrl
+
+from ..auth import get_current_user, get_scope
+from ..services import url_import_service, user_scope_service
+from .files import MAX_FILE_SIZE, ingest_bytes
+
+router = APIRouter(prefix="/api/v1/me/hopper", tags=["hopper"])
+
+
+class LinkDropRequest(BaseModel):
+    url: HttpUrl
+
+
+async def _writable_scope(current_user: dict, scope_user_id: UUID) -> UUID:
+    if not await user_scope_service.can_write(scope_user_id, current_user["id"]):
+        raise HTTPException(status_code=403, detail="Only the owner can add to this stash")
+    return scope_user_id
+
+
+@router.post("/file", status_code=201)
+async def drop_file(
+    file: UploadFile,
+    current_user: dict = Depends(get_current_user),
+    scope_user_id: UUID = Depends(get_scope),
+) -> dict:
+    owner_user_id = await _writable_scope(current_user, scope_user_id)
+    content = await file.read()
+    if len(content) > MAX_FILE_SIZE:
+        raise HTTPException(status_code=413, detail="File too large (max 100 MB)")
+
+    # Markdown and HTML become pages, everything else an S3-backed file whose
+    # text extraction starts on insert — the ingest path decides, not us.
+    uploaded = await ingest_bytes(
+        owner_user_id=owner_user_id,
+        user_id=current_user["id"],
+        filename=file.filename or "upload",
+        content=content,
+        content_type=file.content_type or "application/octet-stream",
+        folder_id=None,
+    )
+    return {
+        "kind": uploaded.kind,
+        "id": str(uploaded.id),
+        "name": uploaded.name,
+        "app_url": uploaded.app_url,
+    }
+
+
+@router.post("/link", status_code=201)
+async def drop_link(
+    body: LinkDropRequest,
+    current_user: dict = Depends(get_current_user),
+    scope_user_id: UUID = Depends(get_scope),
+) -> dict:
+    from ..tasks.clips import dispatch_url_imports
+
+    owner_user_id = await _writable_scope(current_user, scope_user_id)
+    url = str(body.url)
+    # The page behind the URL is fetched by a worker, so this returns as soon
+    # as the job is queued; the clip lands in the VFS when it arrives.
+    import_ids = await url_import_service.create_url_imports(
+        owner_user_id=owner_user_id,
+        created_by=current_user["id"],
+        items=[{"url": url}],
+    )
+    await dispatch_url_imports(import_ids)
+    return {"kind": "link", "id": str(import_ids[0]), "name": url, "app_url": None}

--- a/backend/routers/hopper.py
+++ b/backend/routers/hopper.py
@@ -9,14 +9,31 @@ becomes an ordinary VFS item the moment it lands.
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, UploadFile
-from pydantic import BaseModel, HttpUrl
+from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile
+from pydantic import BaseModel, Field, HttpUrl
 
 from ..auth import get_current_user, get_scope
-from ..services import url_import_service, user_scope_service
-from .files import MAX_FILE_SIZE, ingest_bytes
+from ..database import get_pool
+from ..services import (
+    file_classifier,
+    files_tree_service,
+    url_import_service,
+    user_scope_service,
+)
+from .files import MAX_FILE_SIZE, _strip_ext, ingest_bytes
 
 router = APIRouter(prefix="/api/v1/me/hopper", tags=["hopper"])
+
+# An image with a meaningless name (IMG_0917, CleanShot 2026-08-12) has no
+# semantic home, but it does have an obvious kind. Without this they pile up at
+# the top level, which is exactly the junk drawer a filesystem is meant to
+# prevent.
+IMAGES_FOLDER = "Images"
+
+# Dropping a directory mirrors its structure, so the depth cap is the only
+# guard against someone dragging in their home folder.
+MAX_PATH_DEPTH = 10
+MAX_SEGMENT_CHARS = 80
 
 
 class LinkDropRequest(BaseModel):
@@ -32,6 +49,9 @@ async def _writable_scope(current_user: dict, scope_user_id: UUID) -> UUID:
 @router.post("/file", status_code=201)
 async def drop_file(
     file: UploadFile,
+    # Relative folder path from a dropped directory ("catalogs/meritor"). The
+    # user's own filing is the one destination we never have to guess at.
+    path: str = Form(""),
     current_user: dict = Depends(get_current_user),
     scope_user_id: UUID = Depends(get_scope),
 ) -> dict:
@@ -40,22 +60,177 @@ async def drop_file(
     if len(content) > MAX_FILE_SIZE:
         raise HTTPException(status_code=413, detail="File too large (max 100 MB)")
 
+    filename = file.filename or "upload"
+    content_type = file.content_type or "application/octet-stream"
+    # Filing is a second, separate step: a model call has no business between
+    # a person dropping a file and being told it arrived.
+    folder_id = await _folder_for_path(owner_user_id, current_user["id"], path)
+
+    # Re-dropping a directory must not double its contents. Same name, same
+    # size, same folder is the same file for a person's purposes — and for a
+    # page, whose name is unique in a folder anyway.
+    existing = await _existing_item(owner_user_id, folder_id, filename, content_type, len(content))
+    if existing:
+        return {**existing, "duplicate": True}
+
     # Markdown and HTML become pages, everything else an S3-backed file whose
     # text extraction starts on insert — the ingest path decides, not us.
     uploaded = await ingest_bytes(
         owner_user_id=owner_user_id,
         user_id=current_user["id"],
-        filename=file.filename or "upload",
+        filename=filename,
         content=content,
-        content_type=file.content_type or "application/octet-stream",
-        folder_id=None,
+        content_type=content_type,
+        folder_id=folder_id,
     )
     return {
         "kind": uploaded.kind,
         "id": str(uploaded.id),
         "name": uploaded.name,
         "app_url": uploaded.app_url,
+        "duplicate": False,
+        # True when this landed loose and is worth asking /classify about.
+        "classifiable": folder_id is None,
     }
+
+
+async def _folder_for_path(owner_user_id: UUID, user_id: UUID, path: str) -> UUID | None:
+    """Mirror a dropped directory's structure, creating folders as needed.
+    An empty path means the top level, which is where single files land."""
+    segments = [s.strip() for s in path.split("/") if s.strip() not in ("", ".", "..")]
+    if not segments:
+        return None
+    if len(segments) > MAX_PATH_DEPTH:
+        raise HTTPException(
+            status_code=400, detail=f"Folder nesting deeper than {MAX_PATH_DEPTH} levels"
+        )
+
+    pool = get_pool()
+    select = (
+        "SELECT id, is_memory, is_protected FROM folders "
+        "WHERE owner_user_id = $1 AND parent_folder_id IS NOT DISTINCT FROM $2 AND name = $3"
+    )
+    parent_id: UUID | None = None
+    for segment in segments:
+        name = segment[:MAX_SEGMENT_CHARS]
+        row = await pool.fetchrow(select, owner_user_id, parent_id, name)
+        if row is None:
+            try:
+                created = await files_tree_service.create_folder(
+                    owner_user_id, name, user_id, parent_folder_id=parent_id
+                )
+                parent_id = created["id"]
+                continue
+            except files_tree_service.DuplicateFolderName:
+                # Lost a race with a sibling upload in the same batch.
+                row = await pool.fetchrow(select, owner_user_id, parent_id, name)
+        # Memory and other protected folders are the product's, not the user's:
+        # a dropped directory that happens to share a name must not pour its
+        # contents into the wiki space, where Files would never show them again.
+        if row["is_memory"] or row["is_protected"]:
+            raise HTTPException(
+                status_code=400,
+                detail=f'"{name}" is reserved in your Stash — rename that folder and drop it again',
+            )
+        parent_id = row["id"]
+    return parent_id
+
+
+async def _existing_item(
+    owner_user_id: UUID,
+    folder_id: UUID | None,
+    filename: str,
+    content_type: str,
+    size: int,
+) -> dict | None:
+    """The item this drop would duplicate, if there is one."""
+    pool = get_pool()
+    page_kind = files_tree_service.detect_page_kind(filename, content_type)
+    if page_kind is not None:
+        exts = (
+            files_tree_service.MD_EXTS if page_kind == "markdown" else files_tree_service.HTML_EXTS
+        )
+        row = await pool.fetchrow(
+            "SELECT id, name FROM pages WHERE owner_user_id = $1 "
+            "AND folder_id IS NOT DISTINCT FROM $2 AND name = $3 AND deleted_at IS NULL",
+            owner_user_id,
+            folder_id,
+            _strip_ext(filename, exts),
+        )
+        return (
+            {"kind": "page", "id": str(row["id"]), "name": row["name"], "app_url": None}
+            if row
+            else None
+        )
+    row = await pool.fetchrow(
+        "SELECT id, name FROM files WHERE owner_user_id = $1 "
+        "AND folder_id IS NOT DISTINCT FROM $2 AND name = $3 AND size_bytes = $4 "
+        "AND deleted_at IS NULL",
+        owner_user_id,
+        folder_id,
+        filename,
+        size,
+    )
+    return (
+        {"kind": "file", "id": str(row["id"]), "name": row["name"], "app_url": None}
+        if row
+        else None
+    )
+
+
+class ClassifyRequest(BaseModel):
+    kind: str = Field(..., pattern=r"^(file|page)$")
+    id: UUID
+
+
+@router.post("/classify")
+async def classify_drop(
+    body: ClassifyRequest,
+    current_user: dict = Depends(get_current_user),
+    scope_user_id: UUID = Depends(get_scope),
+) -> dict:
+    """Decide where a loose item belongs and move it there.
+
+    Deliberately its own request: the upload confirms immediately, and the
+    caller asks for this afterwards. The work is server-side, so a person who
+    navigates away still gets their file filed — they just don't watch it
+    happen.
+    """
+    owner_user_id = await _writable_scope(current_user, scope_user_id)
+    table = "files" if body.kind == "file" else "pages"
+    pool = get_pool()
+    content_type = "content_type" if body.kind == "file" else "'text/markdown' AS content_type"
+    row = await pool.fetchrow(
+        f"SELECT name, folder_id, {content_type} FROM {table} "  # noqa: S608 — pattern-checked
+        "WHERE id = $1 AND owner_user_id = $2 AND deleted_at IS NULL",
+        body.id,
+        owner_user_id,
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Not found")
+    # Only ever files something loose: a folder drop, or filing that already
+    # happened, is not for a classifier to revisit.
+    if row["folder_id"] is not None:
+        return {"filed_in": None}
+
+    folder_id, path = await file_classifier.suggest_folder(
+        owner_user_id, row["name"], row["content_type"]
+    )
+    if folder_id is None and row["content_type"].startswith("image/"):
+        # No folder fits, but an image still has somewhere to be. This is a
+        # rule, not a guess: the kind is known, only the meaning is not.
+        folder_id = await _folder_for_path(owner_user_id, current_user["id"], IMAGES_FOLDER)
+        path = IMAGES_FOLDER
+    if folder_id is None:
+        return {"filed_in": None}
+    await pool.execute(
+        f"UPDATE {table} SET folder_id = $1 WHERE id = $2 AND owner_user_id = $3 "  # noqa: S608
+        "AND folder_id IS NULL",
+        folder_id,
+        body.id,
+        owner_user_id,
+    )
+    return {"filed_in": path}
 
 
 @router.post("/link", status_code=201)
@@ -76,4 +251,11 @@ async def drop_link(
         items=[{"url": url}],
     )
     await dispatch_url_imports(import_ids)
-    return {"kind": "link", "id": str(import_ids[0]), "name": url, "app_url": None}
+    return {
+        "kind": "link",
+        "id": str(import_ids[0]),
+        "name": url,
+        "app_url": None,
+        "duplicate": False,
+        "classifiable": False,
+    }

--- a/backend/routers/user_knowledge.py
+++ b/backend/routers/user_knowledge.py
@@ -29,7 +29,7 @@ from ..services import (
 
 router = APIRouter(prefix="/api/v1/me", tags=["me"])
 
-SIDEBAR_ETAG_VERSION = "sidebar-skill-folders-v4"
+SIDEBAR_ETAG_VERSION = "sidebar-page-agent-v5"
 
 
 # ---------------------------------------------------------------------------
@@ -84,7 +84,8 @@ async def _files_tree(owner_user_id: UUID, user_id: UUID) -> dict:
             user_id,
         ),
         pool.fetch(
-            "SELECT p.id, p.name, p.content_type, p.folder_id, p.created_at, p.updated_at "
+            "SELECT p.id, p.name, p.content_type, p.folder_id, p.created_at, p.updated_at, "
+            "       p.last_edit_agent_name "
             "FROM pages p "
             f"WHERE p.owner_user_id = $1 AND p.deleted_at IS NULL AND {readable_page} "
             "ORDER BY p.name",
@@ -129,6 +130,7 @@ async def _files_tree(owner_user_id: UUID, user_id: UUID) -> dict:
                 "folder_id": str(r["folder_id"]) if r["folder_id"] else None,
                 "created_at": r["created_at"],
                 "updated_at": r["updated_at"],
+                "last_edit_agent_name": r["last_edit_agent_name"],
             }
             for r in page_rows
         ],

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -113,7 +113,7 @@ your data &mdash; and a Drive they can read and write natively.</p>
 <p><strong>Start here. Any one of these is a real first win:</strong></p>
 
 <ol>
-  <li><a href="{app_url}"><strong>Connect a source</strong></a> (Tools, in the sidebar) &mdash; GitHub, Google Drive, Gmail, Slack, Notion, Linear, Jira, Asana, Granola, PostHog, or X. Whatever you connect becomes searchable by every agent you point at Stash.</li>
+  <li><a href="{app_url}"><strong>Connect a source</strong></a> (Integrations, in the sidebar) &mdash; GitHub, Google Drive, Gmail, Slack, Notion, Linear, Jira, Asana, Granola, PostHog, or X. Whatever you connect becomes searchable by every agent you point at Stash.</li>
   <li><a href="{app_url}"><strong>Give your coding agent memory</strong></a> &mdash; run <code>uv tool install stashai</code> then <code>stash signin</code>. It finds the agents on your machine, wires them up, and from then on your sessions land in Stash automatically. Then ask one something only Stash would know.</li>
   <li><a href="{app_url}/agents"><strong>Chat with the agent in the app</strong></a> &mdash; it already has everything above, and it's a real coding agent on its own cloud box, so it can read, write, and run things rather than just answer. Connect your Claude, Codex, or OpenRouter key in settings to point it at your own account.</li>
 </ol>

--- a/backend/services/embeddings/local.py
+++ b/backend/services/embeddings/local.py
@@ -46,7 +46,13 @@ class LocalEmbedder(BaseEmbedder):
                 "Install it with: pip install sentence-transformers"
             )
         logger.info("Loading local embedding model: %s", self.model_name)
-        self._model = SentenceTransformer(self.model_name)
+        # CPU, explicitly: sentence-transformers picks Apple's Metal backend
+        # (mps) when it can, and a Metal context cannot survive fork(). Celery
+        # runs a prefork pool, so every child that embedded died on SIGABRT
+        # ("Unable to get MPS kernel ... XPC_ERROR_CONNECTION_INVALID"), taking
+        # the reconcile task — and any process that had touched the model —
+        # down with it. This model is 22M params; CPU is fast enough.
+        self._model = SentenceTransformer(self.model_name, device="cpu")
 
     async def embed_batch(self, texts: list[str]) -> list[np.ndarray] | None:
         if not texts:

--- a/backend/services/file_classifier.py
+++ b/backend/services/file_classifier.py
@@ -1,0 +1,108 @@
+"""Where a dropped file belongs, chosen from the folders that already exist.
+
+A file that always lands at the root throws away what a filesystem is for:
+progressive disclosure. So one fast-tier call reads the filename and picks a
+folder — but only ever an *existing* one. Inventing folders per file is how a
+stash ends up with forty folders holding one item each; growing the ontology
+is a decision for the user, not a side effect of an upload.
+
+The suggestion is advisory. A file that cannot be classified belongs at the
+root, which is exactly where it lands today, and a classifier that is slow,
+broken, or unconfigured must never cost someone their upload — so failures
+here are logged loudly and the drop proceeds unfiled.
+"""
+
+import logging
+from uuid import UUID
+
+from ..database import get_pool
+from . import llm
+
+logger = logging.getLogger(__name__)
+
+# Past this many folders the prompt stops being cheap and the choice stops
+# being meaningful; the deepest paths are also the least likely destinations.
+MAX_CANDIDATES = 60
+
+_SYSTEM = (
+    "You file documents into an existing folder structure. You never invent "
+    "folders and you never guess: filing something wrongly is worse than "
+    "leaving it unfiled, because a person can always find what is at the top "
+    "level but will not think to look in the wrong folder."
+)
+
+_PROMPT = """Here are the folders in this person's filesystem:
+
+{folders}
+
+A file named "{filename}" ({content_type}) has just been added.
+
+Which folder does it clearly belong in? Reply with JSON:
+{{"folder": "<exact path from the list>"}} or {{"folder": null}}
+
+Choose null unless the fit is obvious from the filename. A generic name
+(screenshot, untitled, document, image, scan) is never obvious."""
+
+
+async def _candidates(owner_user_id: UUID) -> list[dict]:
+    """Foldable folders and their paths. Reserved spaces (Memory), protected
+    folders, and skills are the product's structure, not filing destinations."""
+    rows = await get_pool().fetch(
+        """
+        WITH RECURSIVE tree AS (
+            SELECT id, name::text AS path, is_memory, is_protected, is_skill
+            FROM folders WHERE owner_user_id = $1 AND parent_folder_id IS NULL
+            UNION ALL
+            SELECT f.id, tree.path || '/' || f.name, f.is_memory, f.is_protected, f.is_skill
+            FROM folders f JOIN tree ON f.parent_folder_id = tree.id
+            WHERE f.owner_user_id = $1
+        )
+        SELECT id, path FROM tree
+        WHERE NOT is_memory AND NOT is_protected AND NOT is_skill
+        ORDER BY length(path) - length(replace(path, '/', '')), path
+        LIMIT $2
+        """,
+        owner_user_id,
+        MAX_CANDIDATES,
+    )
+    return [dict(r) for r in rows]
+
+
+async def suggest_folder(
+    owner_user_id: UUID, filename: str, content_type: str
+) -> tuple[UUID | None, str | None]:
+    """(folder_id, path) for a dropped file, or (None, None) for the top level."""
+    candidates = await _candidates(owner_user_id)
+    if not candidates:
+        # Nothing to choose from: an empty filesystem has no opinion yet.
+        return None, None
+
+    by_path = {c["path"]: c["id"] for c in candidates}
+    try:
+        answer = await llm.complete_json(
+            system=_SYSTEM,
+            prompt=_PROMPT.format(
+                folders="\n".join(f"- {path}" for path in by_path),
+                filename=filename,
+                content_type=content_type,
+            ),
+            max_tokens=200,
+        )
+    except Exception as exc:
+        # Advisory, not required: an upload must not fail because filing did.
+        logger.warning(
+            "file_classifier: suggestion failed filename=%s exception_type=%s",
+            filename,
+            type(exc).__name__,
+        )
+        return None, None
+
+    chosen = answer.get("folder")
+    if chosen is None:
+        return None, None
+    if chosen not in by_path:
+        # The model named a folder that does not exist — the one thing the
+        # prompt forbids. Loud, because it means the prompt has drifted.
+        logger.warning("file_classifier: invented folder %r for %s", chosen, filename)
+        return None, None
+    return by_path[chosen], chosen

--- a/backend/services/image_ocr.py
+++ b/backend/services/image_ocr.py
@@ -1,0 +1,81 @@
+"""Image transcription via Gemini vision.
+
+A screenshot is the most common thing a person drops into their stash and the
+one thing an agent could never read: `file_extraction.extract_text` has no
+branch for images, so every PNG landed with an empty knowledge-base entry.
+This module gives an image the same treatment `pdf_ocr` gives a scan — text
+transcribed character-for-character, and everything non-textual described in
+place so a reader who cannot see it still gets the information.
+
+Only the formats Gemini accepts inline are transcribable; anything else (SVG,
+TIFF, …) returns "" and stores no text, the same declared-support stance
+`extract_text` takes. Like `pdf_ocr`, it raises on failure so the extraction
+pipeline's retry machinery records the error rather than silently storing an
+empty entry.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import httpx
+
+from ..config import settings
+
+TRANSCRIBABLE_TYPES = ("image/png", "image/jpeg", "image/webp", "image/heic", "image/heif")
+MAX_OUTPUT_TOKENS = 8000
+REQUEST_TIMEOUT_SECONDS = 120.0
+
+_GENERATE_URL = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
+
+_PROMPT = (
+    "Describe this image so that someone who cannot see it gets everything it conveys. "
+    "Output only the description - no commentary, no surrounding code fence. "
+    "Transcribe every piece of visible text exactly as printed, in reading order, "
+    "character-for-character - names, numbers, codes, labels, UI text, handwriting. "
+    "Render any table as a markdown table. "
+    "Then state what the image shows: its subject, the setting, and every identifying "
+    "detail (people and what they are doing, objects, shapes, colors, charts and their "
+    "values, diagram structure and callouts). "
+    "If it is a screenshot, say what application or page it shows and what state it is in."
+)
+
+
+async def transcribe_image(content: bytes, content_type: str) -> str:
+    if content_type not in TRANSCRIBABLE_TYPES:
+        return ""
+    if not settings.GEMINI_API_KEY:
+        raise RuntimeError("GEMINI_API_KEY is required to transcribe images")
+
+    async with httpx.AsyncClient(
+        headers={"x-goog-api-key": settings.GEMINI_API_KEY},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    ) as client:
+        response = await client.post(
+            _GENERATE_URL.format(model=settings.GEMINI_EXTRACTION_MODEL),
+            json={
+                "contents": [
+                    {
+                        "parts": [
+                            {
+                                "inline_data": {
+                                    "mime_type": content_type,
+                                    "data": base64.standard_b64encode(content).decode("ascii"),
+                                }
+                            },
+                            {"text": _PROMPT},
+                        ]
+                    }
+                ],
+                "generationConfig": {"maxOutputTokens": MAX_OUTPUT_TOKENS, "temperature": 0},
+            },
+        )
+    response.raise_for_status()
+    candidates = response.json().get("candidates")
+    if not candidates:
+        raise RuntimeError("Gemini returned no candidates")
+    parts = candidates[0].get("content", {}).get("parts", [])
+    text = "".join(p.get("text", "") for p in parts if not p.get("thought")).strip()
+    if candidates[0].get("finishReason") == "MAX_TOKENS":
+        text += "\n\n[transcription truncated]"
+    return text

--- a/backend/tests/test_embeddings.py
+++ b/backend/tests/test_embeddings.py
@@ -1,3 +1,4 @@
+import sys
 from uuid import uuid4
 
 import numpy as np
@@ -110,3 +111,28 @@ async def test_openai_embedder_clips_inputs_before_http_request():
 
     assert vectors is not None
     assert len(client.payload["input"][0]) == embedding_service.MAX_TEXT_CHARS
+
+
+def test_local_embedder_loads_on_cpu(monkeypatch):
+    """The local model must never land on Apple's Metal (mps) device.
+
+    A Metal context cannot survive fork(), and Celery runs a prefork pool, so
+    an mps-backed model aborts (SIGABRT) in every worker child that embeds —
+    crashlooping the reconcile task. CI runs on Linux where mps does not
+    exist, so no behavioural test can catch a regression here; pinning the
+    device at construction is the only guard.
+    """
+    from backend.services.embeddings.local import LocalEmbedder
+
+    captured = {}
+
+    class FakeSentenceTransformer:
+        def __init__(self, model_name, device=None):
+            captured["device"] = device
+
+    fake_module = type("m", (), {"SentenceTransformer": FakeSentenceTransformer})
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake_module)
+
+    LocalEmbedder()._load()
+
+    assert captured["device"] == "cpu"

--- a/backend/tests/test_hopper.py
+++ b/backend/tests/test_hopper.py
@@ -1,0 +1,117 @@
+"""The hopper: an intake into the VFS, not a place things sit.
+
+A drop must become an ordinary VFS item at the top of the user's stash,
+indistinguishable from one created any other way. Nothing is parked in a
+holding folder, and no ledger records the drop: the item itself is the record.
+
+The hopper takes things that already exist — a file or a link. There is no
+compose-a-note path; that is what pages are for.
+"""
+
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+
+from backend.services import storage_service
+from backend.tasks import clips as clips_tasks
+from backend.tasks import extraction
+
+from .conftest import unique_name
+
+
+async def _register(client: AsyncClient) -> tuple[dict, str]:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name(), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    return {"Authorization": f"Bearer {body['api_key']}"}, body["id"]
+
+
+def _mock_storage(monkeypatch) -> None:
+    async def _upload(*args, **kwargs):
+        return "test/storage-key"
+
+    async def _url(key):
+        return f"https://blob.example/{key}"
+
+    monkeypatch.setattr(storage_service, "is_configured", lambda: True)
+    monkeypatch.setattr(storage_service, "upload_file", _upload)
+    monkeypatch.setattr(storage_service, "get_file_url", _url)
+    monkeypatch.setattr(extraction.extract_file_text, "delay", lambda *a, **k: None)
+
+
+@pytest.mark.asyncio
+async def test_file_lands_in_the_vfs_and_starts_extraction(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    headers, _ = await _register(client)
+    _mock_storage(monkeypatch)
+
+    resp = await client.post(
+        "/api/v1/me/hopper/file",
+        files={"file": ("contract.pdf", b"%PDF-1.4 fake body", "application/pdf")},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    drop = resp.json()
+    assert drop["kind"] == "file"
+    assert drop["name"] == "contract.pdf"
+
+    row = await pool.fetchrow(
+        "SELECT folder_id, extraction_status FROM files WHERE id = $1", UUID(drop["id"])
+    )
+    assert row["folder_id"] is None
+    # Queued for text extraction the moment it lands — that is what makes it
+    # readable by an agent.
+    assert row["extraction_status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_link_queues_an_import_that_files_itself(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    headers, owner_id = await _register(client)
+    monkeypatch.setattr(clips_tasks.process_url_imports, "delay", lambda *a, **k: None)
+
+    resp = await client.post(
+        "/api/v1/me/hopper/link",
+        json={"url": "https://example.com/post"},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    assert resp.json()["kind"] == "link"
+
+    row = await pool.fetchrow(
+        "SELECT url, folder_id, status FROM url_imports WHERE owner_user_id = $1", UUID(owner_id)
+    )
+    assert row["url"] == "https://example.com/post"
+    assert row["folder_id"] is None
+    assert row["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_hopper_creates_no_folder_of_its_own(client: AsyncClient, pool, monkeypatch) -> None:
+    """The hopper sorts things INTO the VFS. A holding folder would defeat it."""
+    headers, owner_id = await _register(client)
+    _mock_storage(monkeypatch)
+
+    await client.post(
+        "/api/v1/me/hopper/file",
+        files={"file": ("notes.txt", b"hello", "text/plain")},
+        headers=headers,
+    )
+
+    folders = await pool.fetch("SELECT name FROM folders WHERE owner_user_id = $1", UUID(owner_id))
+    assert [f["name"] for f in folders] == []
+
+
+@pytest.mark.asyncio
+async def test_there_is_no_compose_a_note_endpoint(client: AsyncClient) -> None:
+    """Typing prose into the hopper cheapens it: it is an intake for things
+    that already exist, not a scratchpad."""
+    headers, _ = await _register(client)
+    resp = await client.post("/api/v1/me/hopper/note", json={"text": "a thought"}, headers=headers)
+    assert resp.status_code == 404

--- a/backend/tests/test_hopper.py
+++ b/backend/tests/test_hopper.py
@@ -409,6 +409,34 @@ async def test_a_named_image_still_goes_where_it_belongs(
 
 
 @pytest.mark.asyncio
+async def test_an_untyped_video_still_finds_its_kind(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    """Browsers hand over application/octet-stream for anything they do not
+    recognise, so an iPhone clip arrives untyped — the extension is the only
+    thing that says what it is."""
+    headers, _ = await _register(client)
+    _mock_storage(monkeypatch)
+    landed = await _drop(client, headers, "IMG_3503.MOV", b"\x00\x00", "application/octet-stream")
+
+    async def declines(**kwargs):
+        return {"folder": None}
+
+    monkeypatch.setattr(llm, "complete_json", declines)
+    resp = await client.post(
+        "/api/v1/me/hopper/classify",
+        json={"kind": "file", "id": landed["id"]},
+        headers=headers,
+    )
+    assert resp.json()["filed_in"] == "Videos"
+    folder = await pool.fetchval(
+        "SELECT f.name FROM files fi JOIN folders f ON f.id = fi.folder_id WHERE fi.id = $1",
+        UUID(landed["id"]),
+    )
+    assert folder == "Videos"
+
+
+@pytest.mark.asyncio
 async def test_an_unfilable_document_is_left_alone(client: AsyncClient, pool, monkeypatch) -> None:
     """Only images get a kind-based home; a document with no obvious folder
     stays where the person can see it."""

--- a/backend/tests/test_hopper.py
+++ b/backend/tests/test_hopper.py
@@ -6,6 +6,10 @@ holding folder, and no ledger records the drop: the item itself is the record.
 
 The hopper takes things that already exist — a file or a link. There is no
 compose-a-note path; that is what pages are for.
+
+A dropped directory keeps its shape: the user's own filing is the one
+destination we never have to guess at, and re-dropping it must not double
+what is already there.
 """
 
 from uuid import UUID
@@ -13,7 +17,7 @@ from uuid import UUID
 import pytest
 from httpx import AsyncClient
 
-from backend.services import storage_service
+from backend.services import llm, storage_service
 from backend.tasks import clips as clips_tasks
 from backend.tasks import extraction
 
@@ -115,3 +119,313 @@ async def test_there_is_no_compose_a_note_endpoint(client: AsyncClient) -> None:
     headers, _ = await _register(client)
     resp = await client.post("/api/v1/me/hopper/note", json={"text": "a thought"}, headers=headers)
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_a_dropped_folder_keeps_its_shape(client: AsyncClient, pool, monkeypatch) -> None:
+    """Mirroring the directory is filing without guessing — it is the user's
+    own structure, not a classifier's opinion."""
+    headers, owner_id = await _register(client)
+    _mock_storage(monkeypatch)
+
+    resp = await client.post(
+        "/api/v1/me/hopper/file",
+        files={"file": ("brakes.pdf", b"%PDF-1.4 x", "application/pdf")},
+        data={"path": "catalogs/meritor"},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+
+    row = await pool.fetchrow(
+        "SELECT f.name AS folder, p.name AS parent FROM files fi "
+        "JOIN folders f ON f.id = fi.folder_id "
+        "JOIN folders p ON p.id = f.parent_folder_id "
+        "WHERE fi.id = $1",
+        UUID(resp.json()["id"]),
+    )
+    assert row["folder"] == "meritor"
+    assert row["parent"] == "catalogs"
+
+
+@pytest.mark.asyncio
+async def test_redropping_a_folder_skips_what_is_already_there(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    """A backlog gets dropped twice — once to try it, once for real. The
+    second pass must not leave two of everything."""
+    headers, owner_id = await _register(client)
+    _mock_storage(monkeypatch)
+
+    async def drop():
+        return await client.post(
+            "/api/v1/me/hopper/file",
+            files={"file": ("brakes.pdf", b"%PDF-1.4 x", "application/pdf")},
+            data={"path": "catalogs"},
+            headers=headers,
+        )
+
+    first = await drop()
+    second = await drop()
+
+    assert first.json()["duplicate"] is False
+    assert second.json()["duplicate"] is True
+    assert second.json()["id"] == first.json()["id"]
+    count = await pool.fetchval(
+        "SELECT count(*) FROM files WHERE owner_user_id = $1 AND deleted_at IS NULL",
+        UUID(owner_id),
+    )
+    assert count == 1
+    # One folder, not two: the mirror is idempotent too.
+    folders = await pool.fetchval(
+        "SELECT count(*) FROM folders WHERE owner_user_id = $1", UUID(owner_id)
+    )
+    assert folders == 1
+
+
+@pytest.mark.asyncio
+async def test_a_re_dropped_markdown_file_is_skipped_not_a_conflict(
+    client: AsyncClient, monkeypatch
+) -> None:
+    """Pages are unique by name in a folder, so the second drop of the same
+    note used to 409 and fail the whole batch."""
+    headers, _ = await _register(client)
+    _mock_storage(monkeypatch)
+
+    async def drop():
+        return await client.post(
+            "/api/v1/me/hopper/file",
+            files={"file": ("readme.md", b"# hello", "text/markdown")},
+            headers=headers,
+        )
+
+    assert (await drop()).json()["duplicate"] is False
+    second = await drop()
+    assert second.status_code == 201
+    assert second.json()["duplicate"] is True
+
+
+@pytest.mark.asyncio
+async def test_absurd_nesting_is_refused(client: AsyncClient, monkeypatch) -> None:
+    headers, _ = await _register(client)
+    _mock_storage(monkeypatch)
+
+    resp = await client.post(
+        "/api/v1/me/hopper/file",
+        files={"file": ("deep.pdf", b"%PDF-1.4 x", "application/pdf")},
+        data={"path": "/".join(f"level{i}" for i in range(12))},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_a_folder_named_memory_cannot_hijack_the_reserved_one(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    """Memory is the product's space, not a folder name to be claimed. A drop
+    that landed there would vanish: Files hides the Memory subtree."""
+    headers, owner_id = await _register(client)
+    _mock_storage(monkeypatch)
+
+    # Touching the memory tree is what creates the reserved folder.
+    assert (await client.get("/api/v1/me/memory-tree", headers=headers)).status_code == 200
+
+    resp = await client.post(
+        "/api/v1/me/hopper/file",
+        files={"file": ("notes.pdf", b"%PDF-1.4 x", "application/pdf")},
+        data={"path": "Memory"},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+    assert "reserved" in resp.json()["detail"]
+
+    landed = await pool.fetchval(
+        "SELECT count(*) FROM files WHERE owner_user_id = $1 AND deleted_at IS NULL",
+        UUID(owner_id),
+    )
+    assert landed == 0
+
+
+# --- filing a loose file, after it has already landed --------------------
+
+
+async def _drop(client: AsyncClient, headers: dict, name: str, body: bytes, ctype: str) -> dict:
+    resp = await client.post(
+        "/api/v1/me/hopper/file", files={"file": (name, body, ctype)}, headers=headers
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+@pytest.mark.asyncio
+async def test_upload_does_not_wait_on_the_classifier(client: AsyncClient, monkeypatch) -> None:
+    """A model call has no business between dropping a file and being told it
+    arrived."""
+    headers, _ = await _register(client)
+    _mock_storage(monkeypatch)
+    await client.post("/api/v1/me/folders", json={"name": "Invoices"}, headers=headers)
+
+    async def never(**kwargs):
+        raise AssertionError("the upload path must not call the model")
+
+    monkeypatch.setattr(llm, "complete_json", never)
+
+    landed = await _drop(client, headers, "acme-invoice.pdf", b"%PDF-1.4 x", "application/pdf")
+    assert landed["classifiable"] is True
+
+
+@pytest.mark.asyncio
+async def test_classify_files_a_loose_item(client: AsyncClient, pool, monkeypatch) -> None:
+    headers, _ = await _register(client)
+    _mock_storage(monkeypatch)
+    await client.post("/api/v1/me/folders", json={"name": "Invoices"}, headers=headers)
+    landed = await _drop(client, headers, "acme-invoice.pdf", b"%PDF-1.4 x", "application/pdf")
+
+    async def fake_json(**kwargs):
+        return {"folder": "Invoices"}
+
+    monkeypatch.setattr(llm, "complete_json", fake_json)
+    resp = await client.post(
+        "/api/v1/me/hopper/classify",
+        json={"kind": landed["kind"], "id": landed["id"]},
+        headers=headers,
+    )
+    assert resp.json()["filed_in"] == "Invoices"
+    folder = await pool.fetchval(
+        "SELECT f.name FROM files fi JOIN folders f ON f.id = fi.folder_id WHERE fi.id = $1",
+        UUID(landed["id"]),
+    )
+    assert folder == "Invoices"
+
+
+@pytest.mark.asyncio
+async def test_classify_never_invents_a_folder(client: AsyncClient, pool, monkeypatch) -> None:
+    """Inventing a folder per file is how a stash ends up with forty folders
+    holding one item each."""
+    headers, owner_id = await _register(client)
+    _mock_storage(monkeypatch)
+    await client.post("/api/v1/me/folders", json={"name": "Invoices"}, headers=headers)
+    landed = await _drop(client, headers, "receipt.pdf", b"%PDF-1.4 x", "application/pdf")
+
+    async def fake_json(**kwargs):
+        return {"folder": "Receipts/2026"}
+
+    monkeypatch.setattr(llm, "complete_json", fake_json)
+    resp = await client.post(
+        "/api/v1/me/hopper/classify",
+        json={"kind": "file", "id": landed["id"]},
+        headers=headers,
+    )
+    assert resp.json()["filed_in"] is None
+    assert (
+        await pool.fetchval("SELECT count(*) FROM folders WHERE owner_user_id = $1", UUID(owner_id))
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_classify_will_not_move_something_already_filed(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    """A dropped folder is the user's own filing; re-deciding it would be the
+    classifier overruling a person."""
+    headers, _ = await _register(client)
+    _mock_storage(monkeypatch)
+    resp = await client.post(
+        "/api/v1/me/hopper/file",
+        files={"file": ("brakes.pdf", b"%PDF-1.4 x", "application/pdf")},
+        data={"path": "catalogs"},
+        headers=headers,
+    )
+    landed = resp.json()
+    assert landed["classifiable"] is False
+
+    async def never(**kwargs):
+        raise AssertionError("an already-filed item must not be classified")
+
+    monkeypatch.setattr(llm, "complete_json", never)
+    filed = await client.post(
+        "/api/v1/me/hopper/classify",
+        json={"kind": "file", "id": landed["id"]},
+        headers=headers,
+    )
+    assert filed.json()["filed_in"] is None
+    folder = await pool.fetchval(
+        "SELECT f.name FROM files fi JOIN folders f ON f.id = fi.folder_id WHERE fi.id = $1",
+        UUID(landed["id"]),
+    )
+    assert folder == "catalogs"
+
+
+@pytest.mark.asyncio
+async def test_an_unfilable_image_gets_a_home_rather_than_littering_the_root(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    """IMG_0917.jpg has no semantic home, but it has an obvious kind. Leaving
+    it loose turns the top level into the junk drawer a filesystem exists to
+    prevent."""
+    headers, _ = await _register(client)
+    _mock_storage(monkeypatch)
+    landed = await _drop(client, headers, "IMG_0917.jpg", b"\xff\xd8\xff", "image/jpeg")
+
+    async def declines(**kwargs):
+        return {"folder": None}
+
+    monkeypatch.setattr(llm, "complete_json", declines)
+    resp = await client.post(
+        "/api/v1/me/hopper/classify",
+        json={"kind": "file", "id": landed["id"]},
+        headers=headers,
+    )
+    assert resp.json()["filed_in"] == "Images"
+    folder = await pool.fetchval(
+        "SELECT f.name FROM files fi JOIN folders f ON f.id = fi.folder_id WHERE fi.id = $1",
+        UUID(landed["id"]),
+    )
+    assert folder == "Images"
+
+
+@pytest.mark.asyncio
+async def test_a_named_image_still_goes_where_it_belongs(
+    client: AsyncClient, pool, monkeypatch
+) -> None:
+    """The Images folder is the last resort, not the destination for anything
+    that happens to be an image."""
+    headers, _ = await _register(client)
+    _mock_storage(monkeypatch)
+    await client.post("/api/v1/me/folders", json={"name": "Diagrams"}, headers=headers)
+    landed = await _drop(client, headers, "brake-assembly-diagram.png", b"\x89PNG", "image/png")
+
+    async def picks(**kwargs):
+        return {"folder": "Diagrams"}
+
+    monkeypatch.setattr(llm, "complete_json", picks)
+    resp = await client.post(
+        "/api/v1/me/hopper/classify",
+        json={"kind": "file", "id": landed["id"]},
+        headers=headers,
+    )
+    assert resp.json()["filed_in"] == "Diagrams"
+
+
+@pytest.mark.asyncio
+async def test_an_unfilable_document_is_left_alone(client: AsyncClient, pool, monkeypatch) -> None:
+    """Only images get a kind-based home; a document with no obvious folder
+    stays where the person can see it."""
+    headers, _ = await _register(client)
+    _mock_storage(monkeypatch)
+    landed = await _drop(client, headers, "untitled.pdf", b"%PDF-1.4 x", "application/pdf")
+
+    async def declines(**kwargs):
+        return {"folder": None}
+
+    monkeypatch.setattr(llm, "complete_json", declines)
+    resp = await client.post(
+        "/api/v1/me/hopper/classify",
+        json={"kind": "file", "id": landed["id"]},
+        headers=headers,
+    )
+    assert resp.json()["filed_in"] is None
+    assert (
+        await pool.fetchval("SELECT folder_id FROM files WHERE id = $1", UUID(landed["id"])) is None
+    )

--- a/backend/tests/test_image_ocr.py
+++ b/backend/tests/test_image_ocr.py
@@ -1,0 +1,31 @@
+"""Images reach the knowledge base via vision, or not at all.
+
+No parser reads pixels, so a stored image with no transcription is a hole in
+the stash the user can see but the agent cannot. These tests pin the two edges
+of that: a format Gemini cannot take inline stores nothing rather than
+pretending, and a missing key fails loud so the retry machinery records it
+instead of persisting an empty entry.
+"""
+
+import pytest
+
+from backend.config import settings
+from backend.services import image_ocr
+
+
+@pytest.mark.asyncio
+async def test_format_gemini_cannot_read_stores_nothing(monkeypatch) -> None:
+    async def fail(*args, **kwargs):
+        raise AssertionError("no API call for an untranscribable format")
+
+    monkeypatch.setattr(image_ocr.httpx.AsyncClient, "post", fail)
+
+    assert await image_ocr.transcribe_image(b"<svg/>", "image/svg+xml") == ""
+
+
+@pytest.mark.asyncio
+async def test_missing_api_key_fails_loud(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "GEMINI_API_KEY", "")
+
+    with pytest.raises(RuntimeError, match="GEMINI_API_KEY"):
+        await image_ocr.transcribe_image(b"\x89PNG....", "image/png")

--- a/backend/tests/test_pdf_ocr.py
+++ b/backend/tests/test_pdf_ocr.py
@@ -23,7 +23,7 @@ import pypdf
 import pytest
 
 from backend.config import settings
-from backend.services import pdf_ocr, storage_service
+from backend.services import image_ocr, pdf_ocr, storage_service
 from backend.workers import extract_one
 
 PAGE_SIZE = (612, 792)
@@ -432,32 +432,40 @@ async def test_every_uploaded_pdf_is_transcribed_and_stored(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_non_pdf_upload_never_transcribes(monkeypatch):
-    """Vision costs an API call per chunk — only PDFs take that path."""
+async def test_parsable_upload_never_transcribes(monkeypatch):
+    """Vision costs an API call — a format a parser can read never takes it."""
     conn = _FakeConnection(uuid.uuid4(), "text/plain")
     _wire_extract_one(monkeypatch, conn, b"plain text body")
 
     async def fail_transcribe(content):
         raise AssertionError("transcribe_pdf must not be called")
 
+    async def fail_image(content, content_type):
+        raise AssertionError("transcribe_image must not be called")
+
     monkeypatch.setattr(pdf_ocr, "transcribe_pdf", fail_transcribe)
+    monkeypatch.setattr(image_ocr, "transcribe_image", fail_image)
 
     assert await extract_one._run(conn.file_id) == 0
     assert conn.persisted_text == "plain text body"
 
 
 @pytest.mark.asyncio
-async def test_non_pdf_without_text_never_transcribes(monkeypatch):
+async def test_image_upload_is_transcribed_by_vision(monkeypatch):
+    """An image carries its meaning in pixels: no parser can read it, so
+    without vision a dropped screenshot stores nothing and every agent
+    surface is blind to it."""
     conn = _FakeConnection(uuid.uuid4(), "image/png")
     _wire_extract_one(monkeypatch, conn, b"\x89PNG....")
 
-    async def fail_transcribe(content):
-        raise AssertionError("transcribe_pdf must not be called")
+    async def fake_image(content, content_type):
+        assert content_type == "image/png"
+        return "a screenshot of the pricing page"
 
-    monkeypatch.setattr(pdf_ocr, "transcribe_pdf", fail_transcribe)
+    monkeypatch.setattr(image_ocr, "transcribe_image", fake_image)
 
     assert await extract_one._run(conn.file_id) == 0
-    assert conn.persisted_text is None
+    assert conn.persisted_text == "a screenshot of the pricing page"
 
 
 @pytest.mark.asyncio

--- a/backend/workers/extract_one.py
+++ b/backend/workers/extract_one.py
@@ -58,6 +58,7 @@ async def _run(file_id: UUID) -> int:
     from ..config import settings
     from ..services import storage_service
     from ..services.file_extraction import extract_text, is_pdf
+    from ..services.image_ocr import transcribe_image
     from ..services.pdf_ocr import transcribe_pdf
 
     # A document that extracts to more than this is stored truncated rather
@@ -85,6 +86,11 @@ async def _run(file_id: UUID) -> int:
             # propagate to the except below so the row records the failure and
             # the retry machinery re-runs it.
             text = await transcribe_pdf(content) or None
+        elif row["content_type"].startswith("image/"):
+            # An image carries its meaning in pixels, so vision is the only
+            # reader it has. Without this a dropped screenshot stores nothing
+            # and every agent surface is blind to it.
+            text = await transcribe_image(content, row["content_type"]) or None
         else:
             text = extract_text(content, row["content_type"])
         if text and len(text) > MAX_EXTRACTED_TEXT:

--- a/frontend/src/app/(app)/f/[fileId]/FileClient.tsx
+++ b/frontend/src/app/(app)/f/[fileId]/FileClient.tsx
@@ -246,7 +246,6 @@ function FileViewerPageInner({ fileId }: { fileId: string }) {
         <FileViewerHeader
           icon={<KindGlyph contentType={file?.content_type ?? ""} name={file?.name ?? ""} />}
           iconColor={kindIconColor(file?.content_type ?? "")}
-          breadcrumbs={ancestorCrumbs}
           title={file?.name ?? "File"}
           onRenameTitle={
             file

--- a/frontend/src/app/(app)/files/page.tsx
+++ b/frontend/src/app/(app)/files/page.tsx
@@ -4,14 +4,14 @@ import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
 import { FileBrowserSkeleton } from "@/components/SkeletonStates";
-import FilesOverview from "@/components/content/files-overview/FilesOverview";
+import FlatFilesPage from "@/components/content/flat-files/FlatFilesPage";
 import { useAuth } from "@/hooks/useAuth";
 
 export default function FilesPage() {
   const router = useRouter();
   const { user, loading } = useAuth();
 
-  useBreadcrumbs([{ label: "VFS" }], "files");
+  useBreadcrumbs([{ label: "Files" }], "files");
 
   useEffect(() => {
     if (!loading && !user) router.push("/login");
@@ -20,5 +20,5 @@ export default function FilesPage() {
   if (loading) return <FileBrowserSkeleton />;
   if (!user) return null;
 
-  return <FilesOverview />;
+  return <FlatFilesPage />;
 }

--- a/frontend/src/app/(app)/hopper/page.tsx
+++ b/frontend/src/app/(app)/hopper/page.tsx
@@ -43,6 +43,9 @@ function hrefFor(event: ActivityEvent): string {
   return event.kind.startsWith("page") ? `/p/${event.target_id}` : `/f/${event.target_id}`;
 }
 
+/** Where a drop was filed, when it was. */
+type Filing = { path: string; folderId: string } | null;
+
 type Batch = {
   total: number;
   done: number;
@@ -95,11 +98,11 @@ export default function HopperRoute() {
   // Filing runs after the uploads are confirmed, at the same concurrency.
   // Nothing here can fail the drop: an item that cannot be filed stays where
   // it already is, which is a fine place for it.
-  const fileAway = useCallback(async (landed: HopperDrop[]): Promise<Array<string | null>> => {
+  const fileAway = useCallback(async (landed: HopperDrop[]): Promise<Filing[]> => {
     const results = await runPool(landed, UPLOAD_CONCURRENCY, async (drop) => {
       if (!drop.classifiable || drop.kind === "link") return null;
-      const { filed_in } = await classifyDrop(drop.kind, drop.id);
-      return filed_in;
+      const { filed_in, folder_id } = await classifyDrop(drop.kind, drop.id);
+      return filed_in && folder_id ? { path: filed_in, folderId: folder_id } : null;
     });
     return results.map((r) => (r.ok === true ? r.value : null));
   }, []);
@@ -180,8 +183,18 @@ export default function HopperRoute() {
         void fileAway(landed).then(([filed]) => {
           toast.success(`${only.name} uploaded successfully`, {
             id,
-            // Say so either way: no second line reads as "filing never ran".
-            description: filed ? `Filed in ${filed}` : "Kept at the top level",
+            // Only when there is something to say: "kept at the top level"
+            // announces a non-event. Naming a folder without a way to open it
+            // would be a tease, so the line is a link.
+            description: filed ? (
+              <button
+                type="button"
+                onClick={() => router.push(`/folders/${filed.folderId}`)}
+                className="underline-offset-2 hover:underline"
+              >
+                Filed in {filed.path}
+              </button>
+            ) : undefined,
             action: goTo,
           });
         });
@@ -206,8 +219,7 @@ export default function HopperRoute() {
         live.filed = filed.filter(Boolean).length;
         toast.success(summarise(live), {
           id,
-          description:
-            failedNames || (live.filed ? undefined : "All kept at the top level"),
+          description: failedNames || undefined,
           action: goToVfs,
         });
       });

--- a/frontend/src/app/(app)/hopper/page.tsx
+++ b/frontend/src/app/(app)/hopper/page.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { useBreadcrumbs } from "@/components/BreadcrumbContext";
+import { dropHopperFile, dropHopperLink, type HopperDrop } from "@/lib/api";
+import { isLinkDrop } from "@/lib/hopper";
+
+// Machine-facing facts, set in mono: what the well accepts. Space does the
+// separating — middots between caps is the house style of every AI landing
+// page this year.
+const ACCEPTS = ["PDF", "DOCX", "XLSX", "PPTX", "CSV", "MD", "PNG", "JPG", "URL"];
+
+/** The hopper is an intake, not a place: a drop lands in the VFS and the
+ *  confirmation points there. Nothing accumulates on this page. */
+export default function HopperRoute() {
+  useBreadcrumbs([{ label: "Hopper" }], "hopper");
+  const router = useRouter();
+
+  const [dragging, setDragging] = useState(false);
+  const [adding, setAdding] = useState(0);
+  const [link, setLink] = useState("");
+  const fileInput = useRef<HTMLInputElement>(null);
+
+  // A drop that vanishes without saying where it went is worse than no drop
+  // at all, so every confirmation names the destination and opens it.
+  const runDrops = useCallback(
+    async (drops: Array<() => Promise<HopperDrop>>) => {
+      setAdding((n) => n + drops.length);
+      for (const drop of drops) {
+        try {
+          const landed = await drop();
+          if (landed.kind === "link") {
+            // The page is fetched by a worker and filed under Clips when it
+            // arrives, so there is nothing to go to yet.
+            toast.success("Fetching that page", { description: "It'll land in Clips" });
+          } else {
+            // One line and one way out. Naming the path as well was a third
+            // thing to read on the way to the only thing you'd click.
+            toast.success(`${landed.name} is in your Stash`, {
+              action: {
+                label: landed.kind === "page" ? "Go to page" : "Go to file",
+                onClick: () => router.push(`/${landed.kind === "page" ? "p" : "f"}/${landed.id}`),
+              },
+            });
+          }
+        } catch (e) {
+          toast.error(e instanceof Error ? e.message : "Couldn't add that to your Stash");
+        } finally {
+          setAdding((n) => n - 1);
+        }
+      }
+    },
+    [router],
+  );
+
+  const addFiles = useCallback(
+    (files: File[]) => void runDrops(files.map((f) => () => dropHopperFile(f))),
+    [runDrops],
+  );
+
+  // The hopper takes things that already exist, so text is only ever a link.
+  const addLink = useCallback(
+    (value: string) => {
+      const trimmed = value.trim();
+      if (!trimmed) return;
+      if (!isLinkDrop(trimmed)) {
+        toast.error("That isn't a link", { description: "Drop a file, or paste a URL" });
+        return;
+      }
+      void runDrops([() => dropHopperLink(trimmed)]);
+    },
+    [runDrops],
+  );
+
+  // Paste works anywhere on the page — a screenshot from the clipboard or a
+  // URL — except while typing in the link field, which submits itself.
+  useEffect(() => {
+    function onPaste(e: ClipboardEvent) {
+      const target = e.target as HTMLElement | null;
+      if (target?.tagName === "TEXTAREA" || target?.tagName === "INPUT") return;
+      const files = Array.from(e.clipboardData?.files ?? []);
+      if (files.length > 0) {
+        e.preventDefault();
+        addFiles(files);
+        return;
+      }
+      const pasted = e.clipboardData?.getData("text/plain") ?? "";
+      if (pasted.trim()) {
+        e.preventDefault();
+        addLink(pasted);
+      }
+    }
+    window.addEventListener("paste", onPaste);
+    return () => window.removeEventListener("paste", onPaste);
+  }, [addFiles, addLink]);
+
+  function onDrop(e: React.DragEvent) {
+    e.preventDefault();
+    setDragging(false);
+    const files = Array.from(e.dataTransfer.files);
+    if (files.length > 0) {
+      addFiles(files);
+      return;
+    }
+    // Dragging a link out of a browser tab hands over its URL, not a file.
+    const url = e.dataTransfer.getData("text/uri-list") || e.dataTransfer.getData("text/plain");
+    if (url) addLink(url);
+  }
+
+  const live = dragging || adding > 0;
+
+  return (
+    // min-h-full, not h-full + overflow: the shell's <main> is the scroll
+    // container. The height still spans the pane so a drop anywhere counts.
+    <div
+      className="flex min-h-full flex-col"
+      onDragOver={(e) => {
+        e.preventDefault();
+        setDragging(true);
+      }}
+      onDragLeave={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node)) setDragging(false);
+      }}
+      onDrop={onDrop}
+    >
+      <div className="mx-auto flex w-full max-w-[1100px] flex-1 flex-col px-10 py-10">
+        <header className="mb-7 shrink-0">
+          <h1 className="font-display text-[32px] font-bold leading-[1.1] tracking-[-0.02em] text-foreground">
+            Drop anything into your Stash
+          </h1>
+        </header>
+
+        <div
+          onClick={() => fileInput.current?.click()}
+          data-live={live}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") fileInput.current?.click();
+          }}
+          aria-label="Drop files here, or click to browse"
+          className="hopper-well relative isolate flex min-h-[300px] flex-1 cursor-pointer flex-col items-center justify-center overflow-hidden rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
+        >
+          <div className="relative text-center">
+            <p className="font-display text-[21px] font-medium tracking-[-0.015em] text-foreground">
+              {adding > 0
+                ? `Taking in ${adding} ${adding === 1 ? "item" : "items"}…`
+                : dragging
+                  ? "Let go"
+                  : "Drag in, paste, or click"}
+            </p>
+            <p className="mt-3 flex flex-wrap justify-center gap-x-5 gap-y-1 font-mono text-[11px] uppercase tracking-[0.05em] text-muted-foreground">
+              {ACCEPTS.map((format) => (
+                <span key={format}>{format}</span>
+              ))}
+            </p>
+          </div>
+        </div>
+
+        <input
+          ref={fileInput}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={(e) => {
+            addFiles(Array.from(e.target.files ?? []));
+            e.target.value = "";
+          }}
+        />
+
+        {/* A hairline, not a box: the link field is the well's understudy. */}
+        <form
+          className="mt-6 shrink-0 flex items-center gap-3 border-b border-[var(--divider-color)] pb-2.5 transition-colors focus-within:border-brand-400"
+          onSubmit={(e) => {
+            e.preventDefault();
+            addLink(link);
+            setLink("");
+          }}
+        >
+          <span className="font-mono text-[11px] uppercase tracking-[0.05em] text-muted-foreground">
+            URL
+          </span>
+          <input
+            value={link}
+            onChange={(e) => setLink(e.target.value)}
+            placeholder="https://"
+            className="min-w-0 flex-1 bg-transparent font-mono text-[12.5px] text-foreground caret-brand-500 outline-none placeholder:text-muted-foreground"
+          />
+          <button
+            type="submit"
+            disabled={!link.trim()}
+            className="font-mono text-[11px] uppercase tracking-[0.05em] text-brand-600 transition-opacity disabled:pointer-events-none disabled:opacity-0"
+          >
+            Take it
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(app)/hopper/page.tsx
+++ b/frontend/src/app/(app)/hopper/page.tsx
@@ -2,15 +2,63 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { toast } from "sonner";
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
-import { dropHopperFile, dropHopperLink, type HopperDrop } from "@/lib/api";
-import { isLinkDrop } from "@/lib/hopper";
+import {
+  classifyDrop,
+  dropHopperFile,
+  dropHopperLink,
+  listFileActivity,
+  type ActivityEvent,
+  type HopperDrop,
+} from "@/lib/api";
+import { firstUrlFromDrag, isLinkDrop } from "@/lib/hopper";
+import {
+  filesFromDrop,
+  filesFromPicker,
+  runPool,
+  UPLOAD_CONCURRENCY,
+  type DroppedFile,
+} from "@/lib/bulk-drop";
 
 // Machine-facing facts, set in mono: what the well accepts. Space does the
 // separating — middots between caps is the house style of every AI landing
 // page this year.
 const ACCEPTS = ["PDF", "DOCX", "XLSX", "PPTX", "CSV", "MD", "PNG", "JPG", "URL"];
+
+// Enough to answer "did that land?" without becoming a place things live.
+const RECENT_LIMIT = 6;
+
+function landedAt(iso: string): string {
+  const minutes = Math.round((Date.now() - new Date(iso).getTime()) / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+function hrefFor(event: ActivityEvent): string {
+  return event.kind.startsWith("page") ? `/p/${event.target_id}` : `/f/${event.target_id}`;
+}
+
+type Batch = {
+  total: number;
+  done: number;
+  filed: number;
+  skipped: number;
+  failed: Array<{ name: string; reason: string }>;
+  cancel: AbortController;
+};
+
+function summarise(batch: Batch): string {
+  const parts = [`${batch.done} added`];
+  if (batch.filed) parts.push(`${batch.filed} filed`);
+  if (batch.skipped) parts.push(`${batch.skipped} already there`);
+  if (batch.failed.length) parts.push(`${batch.failed.length} failed`);
+  return parts.join(" · ");
+}
 
 /** The hopper is an intake, not a place: a drop lands in the VFS and the
  *  confirmation points there. Nothing accumulates on this page. */
@@ -19,59 +67,175 @@ export default function HopperRoute() {
   const router = useRouter();
 
   const [dragging, setDragging] = useState(false);
-  const [adding, setAdding] = useState(0);
+  const [batch, setBatch] = useState<Batch | null>(null);
   const [link, setLink] = useState("");
+  const [recent, setRecent] = useState<ActivityEvent[]>([]);
   const fileInput = useRef<HTMLInputElement>(null);
+  // A ref, not the state: drop and paste handlers close over stale state, and
+  // a second batch starting mid-flight would steal the first one's Stop.
+  const batchRunning = useRef(false);
 
-  // A drop that vanishes without saying where it went is worse than no drop
-  // at all, so every confirmation names the destination and opens it.
-  const runDrops = useCallback(
-    async (drops: Array<() => Promise<HopperDrop>>) => {
-      setAdding((n) => n + drops.length);
-      for (const drop of drops) {
-        try {
-          const landed = await drop();
-          if (landed.kind === "link") {
-            // The page is fetched by a worker and filed under Clips when it
-            // arrives, so there is nothing to go to yet.
-            toast.success("Fetching that page", { description: "It'll land in Clips" });
-          } else {
-            // One line and one way out. Naming the path as well was a third
-            // thing to read on the way to the only thing you'd click.
-            toast.success(`${landed.name} is in your Stash`, {
-              action: {
-                label: landed.kind === "page" ? "Go to page" : "Go to file",
-                onClick: () => router.push(`/${landed.kind === "page" ? "p" : "f"}/${landed.id}`),
-              },
-            });
-          }
-        } catch (e) {
-          toast.error(e instanceof Error ? e.message : "Couldn't add that to your Stash");
-        } finally {
-          setAdding((n) => n - 1);
-        }
-      }
-    },
-    [router],
-  );
+  // Sourced from file activity, not from a hopper ledger: what is recently in
+  // the VFS is the truth, whether it arrived through this tab or the CLI.
+  const refreshRecent = useCallback(async () => {
+    try {
+      const feed = await listFileActivity({ limit: 30 });
+      // Markdown and HTML drops become pages, so a file-only filter would
+      // hide half of what this page just took in.
+      setRecent(feed.events.slice(0, RECENT_LIMIT));
+    } catch {
+      // A strip of recent names is not worth an error state on this page.
+    }
+  }, []);
 
+  useEffect(() => {
+    void refreshRecent();
+  }, [refreshRecent]);
+
+  // Filing runs after the uploads are confirmed, at the same concurrency.
+  // Nothing here can fail the drop: an item that cannot be filed stays where
+  // it already is, which is a fine place for it.
+  const fileAway = useCallback(async (landed: HopperDrop[]): Promise<Array<string | null>> => {
+    const results = await runPool(landed, UPLOAD_CONCURRENCY, async (drop) => {
+      if (!drop.classifiable || drop.kind === "link") return null;
+      const { filed_in } = await classifyDrop(drop.kind, drop.id);
+      return filed_in;
+    });
+    return results.map((r) => (r.ok === true ? r.value : null));
+  }, []);
+
+  // A single drop confirms itself; a batch reports once at the end. Eighty
+  // toasts for eighty files is not a confirmation, it is a denial of service.
   const addFiles = useCallback(
-    (files: File[]) => void runDrops(files.map((f) => () => dropHopperFile(f))),
-    [runDrops],
+    async (dropped: DroppedFile[]) => {
+      if (dropped.length === 0) return;
+      if (batchRunning.current) {
+        toast.info("Still taking in the last drop", { description: "One batch at a time" });
+        return;
+      }
+      batchRunning.current = true;
+      const cancel = new AbortController();
+      const live: Batch = {
+        total: dropped.length,
+        done: 0,
+        filed: 0,
+        skipped: 0,
+        failed: [],
+        cancel,
+      };
+      setBatch(live);
+
+      const results = await runPool(
+        dropped,
+        UPLOAD_CONCURRENCY,
+        async ({ file, path }) => {
+          const landed = await dropHopperFile(file, { path, signal: cancel.signal });
+          if (landed.duplicate) live.skipped += 1;
+          else live.done += 1;
+          setBatch({ ...live });
+          return landed;
+        },
+        { signal: cancel.signal },
+      );
+
+      results.forEach((result, i) => {
+        if (result.ok !== false) return;
+        const error = result.error;
+        // Stopping aborts the in-flight fetches; those rejections are the
+        // cancellation working, not files that failed to land.
+        if (error instanceof DOMException && error.name === "AbortError") return;
+        live.failed.push({
+          name: dropped[i].file.name,
+          reason: error instanceof Error ? error.message : "Upload failed",
+        });
+      });
+      batchRunning.current = false;
+      setBatch(null);
+      void refreshRecent();
+
+      if (cancel.signal.aborted) {
+        toast.info(`Stopped — ${summarise(live)}`);
+        return;
+      }
+      // One file keeps its own confirmation: naming it and offering the way to
+      // it is more useful than a count of one.
+      const landed = results
+        .map((r) => (r.ok === true ? r.value : null))
+        .filter((d): d is HopperDrop => d !== null);
+
+      const only = results.length === 1 && results[0].ok === true ? results[0].value : null;
+      if (only) {
+        const goTo = {
+          label: only.kind === "page" ? "Go to page" : "Go to file",
+          onClick: () => router.push(`/${only.kind === "page" ? "p" : "f"}/${only.id}`),
+        };
+        const id = toast.success(
+          only.duplicate
+            ? `${only.name} was already uploaded`
+            : `${only.name} uploaded successfully`,
+          { action: goTo },
+        );
+        // Filing takes a model call, so it lands after the confirmation. If
+        // the toast is still up, it grows a line saying where the file went.
+        void fileAway(landed).then(([filed]) => {
+          toast.success(`${only.name} uploaded successfully`, {
+            id,
+            // Say so either way: no second line reads as "filing never ran".
+            description: filed ? `Filed in ${filed}` : "Kept at the top level",
+            action: goTo,
+          });
+        });
+        return;
+      }
+      // "0 added · 3 failed" is not good news, and must not look like it.
+      const report = live.done + live.skipped === 0 ? toast.error : toast.success;
+      const goToVfs = { label: "Go to VFS", onClick: () => router.push("/files") };
+      const failedNames = live.failed
+        .slice(0, 3)
+        .map((f) => f.name)
+        .join(", ");
+      const id = toast.success(summarise(live), {
+        description: failedNames || "They'll be readable as your agent finishes reading them",
+        action: goToVfs,
+      });
+      if (live.done + live.skipped === 0) {
+        report(summarise(live), { id, description: failedNames, action: goToVfs });
+        return;
+      }
+      void fileAway(landed).then((filed) => {
+        live.filed = filed.filter(Boolean).length;
+        toast.success(summarise(live), {
+          id,
+          description:
+            failedNames || (live.filed ? undefined : "All kept at the top level"),
+          action: goToVfs,
+        });
+      });
+    },
+    [router, refreshRecent, fileAway],
   );
 
   // The hopper takes things that already exist, so text is only ever a link.
   const addLink = useCallback(
-    (value: string) => {
+    async (value: string): Promise<boolean> => {
       const trimmed = value.trim();
-      if (!trimmed) return;
+      if (!trimmed) return false;
       if (!isLinkDrop(trimmed)) {
         toast.error("That isn't a link", { description: "Drop a file, or paste a URL" });
-        return;
+        return false;
       }
-      void runDrops([() => dropHopperLink(trimmed)]);
+      try {
+        await dropHopperLink(trimmed);
+        // The page is fetched by a worker and filed under Clips when it
+        // arrives, so there is nothing to go to yet.
+        toast.success("Fetching that page", { description: "It'll land in Clips" });
+        return true;
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Couldn't add that to your Stash");
+        return false;
+      }
     },
-    [runDrops],
+    [],
   );
 
   // Paste works anywhere on the page — a screenshot from the clipboard or a
@@ -83,33 +247,37 @@ export default function HopperRoute() {
       const files = Array.from(e.clipboardData?.files ?? []);
       if (files.length > 0) {
         e.preventDefault();
-        addFiles(files);
+        void addFiles(files.map((file) => ({ file, path: [] })));
         return;
       }
       const pasted = e.clipboardData?.getData("text/plain") ?? "";
       if (pasted.trim()) {
         e.preventDefault();
-        addLink(pasted);
+        void addLink(pasted);
       }
     }
     window.addEventListener("paste", onPaste);
     return () => window.removeEventListener("paste", onPaste);
   }, [addFiles, addLink]);
 
-  function onDrop(e: React.DragEvent) {
+  async function onDrop(e: React.DragEvent) {
     e.preventDefault();
     setDragging(false);
-    const files = Array.from(e.dataTransfer.files);
-    if (files.length > 0) {
-      addFiles(files);
+    // Read the drop before awaiting anything: the DataTransfer is emptied by
+    // the browser as soon as the event handler yields.
+    const dropped = await filesFromDrop(e.dataTransfer);
+    if (dropped.length > 0) {
+      void addFiles(dropped);
       return;
     }
     // Dragging a link out of a browser tab hands over its URL, not a file.
-    const url = e.dataTransfer.getData("text/uri-list") || e.dataTransfer.getData("text/plain");
-    if (url) addLink(url);
+    const url =
+      firstUrlFromDrag(e.dataTransfer.getData("text/uri-list")) ||
+      e.dataTransfer.getData("text/plain");
+    if (url) void addLink(url);
   }
 
-  const live = dragging || adding > 0;
+  const live = dragging || batch !== null;
 
   return (
     // min-h-full, not h-full + overflow: the shell's <main> is the scroll
@@ -138,24 +306,43 @@ export default function HopperRoute() {
           role="button"
           tabIndex={0}
           onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") fileInput.current?.click();
+            if (e.key !== "Enter" && e.key !== " ") return;
+            // Space scrolls the page by default, which it should not do while
+            // the well has focus.
+            e.preventDefault();
+            fileInput.current?.click();
           }}
           aria-label="Drop files here, or click to browse"
           className="hopper-well relative isolate flex min-h-[300px] flex-1 cursor-pointer flex-col items-center justify-center overflow-hidden rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
         >
           <div className="relative text-center">
             <p className="font-display text-[21px] font-medium tracking-[-0.015em] text-foreground">
-              {adding > 0
-                ? `Taking in ${adding} ${adding === 1 ? "item" : "items"}…`
+              {batch
+                ? `Taking in ${batch.done + batch.skipped} of ${batch.total}…`
                 : dragging
                   ? "Let go"
                   : "Drag in, paste, or click"}
             </p>
-            <p className="mt-3 flex flex-wrap justify-center gap-x-5 gap-y-1 font-mono text-[11px] uppercase tracking-[0.05em] text-muted-foreground">
-              {ACCEPTS.map((format) => (
-                <span key={format}>{format}</span>
-              ))}
-            </p>
+            {batch ? (
+              // Progress is a live count and a way out, and it exists only
+              // while the batch does — this page keeps no history.
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  batch.cancel.abort();
+                }}
+                className="mt-3 font-mono text-[11px] uppercase tracking-[0.05em] text-brand-600 hover:underline"
+              >
+                Stop
+              </button>
+            ) : (
+              <p className="mt-3 flex flex-wrap justify-center gap-x-5 gap-y-1 font-mono text-[11px] uppercase tracking-[0.05em] text-muted-foreground">
+                {ACCEPTS.map((format) => (
+                  <span key={format}>{format}</span>
+                ))}
+              </p>
+            )}
           </div>
         </div>
 
@@ -165,18 +352,18 @@ export default function HopperRoute() {
           multiple
           className="hidden"
           onChange={(e) => {
-            addFiles(Array.from(e.target.files ?? []));
+            void addFiles(filesFromPicker(Array.from(e.target.files ?? [])));
             e.target.value = "";
           }}
         />
 
         {/* A hairline, not a box: the link field is the well's understudy. */}
         <form
-          className="mt-6 shrink-0 flex items-center gap-3 border-b border-[var(--divider-color)] pb-2.5 transition-colors focus-within:border-brand-400"
-          onSubmit={(e) => {
+          className="mt-6 flex shrink-0 items-center gap-3 border-b border-[var(--divider-color)] pb-2.5 transition-colors focus-within:border-brand-400"
+          onSubmit={async (e) => {
             e.preventDefault();
-            addLink(link);
-            setLink("");
+            // Clear only once it is accepted, so a typo stays there to fix.
+            if (await addLink(link)) setLink("");
           }}
         >
           <span className="font-mono text-[11px] uppercase tracking-[0.05em] text-muted-foreground">
@@ -196,6 +383,32 @@ export default function HopperRoute() {
             Take it
           </button>
         </form>
+
+        {/* Not the status feed we deleted — no ledger, no states, no polling.
+            Just the last few things that landed, so a drop can be seen to have
+            worked without leaving the page. */}
+        {recent.length > 0 && (
+          <section className="mt-8 shrink-0">
+            <h2 className="font-mono text-[11px] uppercase tracking-[0.05em] text-muted-foreground">
+              Recently added
+            </h2>
+            <ul className="mt-3 flex flex-col">
+              {recent.map((event) => (
+                <li key={`${event.target_id}-${event.ts}`}>
+                  <Link
+                    href={hrefFor(event)}
+                    className="flex items-baseline justify-between gap-4 rounded-md py-1.5 text-[13px] text-dim transition-colors hover:text-foreground"
+                  >
+                    <span className="truncate">{event.target_label}</span>
+                    <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
+                      {landedAt(event.ts)}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -66,7 +66,7 @@ export default function IntegrationRoute() {
 
 // The integration manager for one provider. Rendered both as the
 // /integrations/[provider] route and inside a workbench "tool" tab (clicking
-// a connector in the Tools sidebar), so the provider comes in as a prop.
+// a connector in the Integrations list), so the provider comes in as a prop.
 export function IntegrationDetail({ provider }: { provider: string }) {
   const router = useRouter();
   const pathname = usePathname();

--- a/frontend/src/app/(app)/integrations/page.test.tsx
+++ b/frontend/src/app/(app)/integrations/page.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import IntegrationsPage from "./page";
 import { createMcpServer, deleteMcpServer, listMcpServers, type McpServer } from "@/lib/api";
@@ -39,6 +39,8 @@ vi.mock("@/lib/api", () => ({
   deleteMcpServer: vi.fn(),
   // The integrations grid above the MCP registry loads these on mount.
   listSources: vi.fn().mockResolvedValue([]),
+  // The coding-agents section shows which agents are already sending sessions.
+  listAgentNames: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("@/lib/integrations", () => ({
@@ -79,14 +81,27 @@ afterEach(() => {
 });
 
 describe("IntegrationsPage", () => {
-  it("lists registered MCP servers with their targets", async () => {
+  it("lists registered MCP servers", async () => {
     render(<IntegrationsPage />);
 
     expect(await screen.findByText("linear")).toBeTruthy();
     expect(screen.getByText("notion")).toBeTruthy();
-    expect(screen.getByText(/npx -y linear-mcp/)).toBeTruthy();
+    // The card describes the server in words; the raw target belongs to the
+    // manage dialog, not the grid.
+    expect(screen.getByText(/a local npx process/)).toBeTruthy();
+    expect(screen.getByText(/mcp\.notion\.com/)).toBeTruthy();
+  });
+
+  it("shows a server's target and header names in manage, never header values", async () => {
+    render(<IntegrationsPage />);
+    await screen.findByText("notion");
+
+    // The http server is the one carrying headers.
+    fireEvent.click(screen.getAllByRole("button", { name: /^manage$/i })[1]);
+
+    expect(await screen.findByText("https://mcp.notion.com/mcp")).toBeTruthy();
     // Header values are secrets — only key names appear.
-    expect(screen.getByText(/headers: Authorization/)).toBeTruthy();
+    expect(screen.getByText("Authorization")).toBeTruthy();
     expect(screen.queryByText(/Bearer tok/)).toBeNull();
   });
 
@@ -95,14 +110,16 @@ describe("IntegrationsPage", () => {
     render(<IntegrationsPage />);
     await screen.findByText("linear");
 
-    fireEvent.change(screen.getByLabelText("Server name"), { target: { value: "notion2" } });
+    const addCard = screen.getByText("Custom MCP server").closest("div.rounded-xl")!;
+    fireEvent.click(within(addCard as HTMLElement).getByRole("button", { name: /^connect$/i }));
+    fireEvent.change(await screen.findByLabelText("Server name"), { target: { value: "notion2" } });
     fireEvent.change(screen.getByLabelText("URL"), {
       target: { value: "https://mcp.example.com/mcp" },
     });
     fireEvent.change(screen.getByLabelText("Headers"), {
       target: { value: "Authorization=Bearer abc" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /add server/i }));
+    fireEvent.click(screen.getByRole("button", { name: /connect server/i }));
 
     await waitFor(() =>
       expect(createMcpServer).toHaveBeenCalledWith({
@@ -121,12 +138,14 @@ describe("IntegrationsPage", () => {
     render(<IntegrationsPage />);
     await screen.findByText("linear");
 
-    fireEvent.change(screen.getByLabelText("Server name"), { target: { value: "fs" } });
+    const addCard = screen.getByText("Custom MCP server").closest("div.rounded-xl")!;
+    fireEvent.click(within(addCard as HTMLElement).getByRole("button", { name: /^connect$/i }));
+    fireEvent.change(await screen.findByLabelText("Server name"), { target: { value: "fs" } });
     fireEvent.click(screen.getByRole("radio", { name: /local \(stdio\)/i }));
     fireEvent.change(screen.getByLabelText("Command"), {
       target: { value: "npx -y fs-mcp" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /add server/i }));
+    fireEvent.click(screen.getByRole("button", { name: /connect server/i }));
 
     await waitFor(() =>
       expect(createMcpServer).toHaveBeenCalledWith({
@@ -146,12 +165,18 @@ describe("IntegrationsPage", () => {
     expect(await screen.findByText(/integrations are down/)).toBeTruthy();
   });
 
-  it("removes a server", async () => {
+  // Removing is deliberately behind Manage: the grid's action must never
+  // delete a server in one click, since it sits where every other box has a
+  // harmless navigation.
+  it("removes a server from its manage dialog", async () => {
     vi.mocked(deleteMcpServer).mockResolvedValue(undefined);
     render(<IntegrationsPage />);
     await screen.findByText("linear");
 
-    fireEvent.click(screen.getAllByRole("button", { name: /remove/i })[0]);
+    expect(screen.queryByRole("button", { name: /^remove/i })).toBeNull();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /^manage$/i })[0]);
+    fireEvent.click(await screen.findByRole("button", { name: /remove server/i }));
 
     await waitFor(() => expect(deleteMcpServer).toHaveBeenCalledWith("s1"));
     await waitFor(() => expect(listMcpServers).toHaveBeenCalledTimes(2));

--- a/frontend/src/app/(app)/integrations/page.test.tsx
+++ b/frontend/src/app/(app)/integrations/page.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import ToolsPage from "./page";
+import IntegrationsPage from "./page";
 import { createMcpServer, deleteMcpServer, listMcpServers, type McpServer } from "@/lib/api";
 import { listIntegrations } from "@/lib/integrations";
 
@@ -78,9 +78,9 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe("ToolsPage", () => {
+describe("IntegrationsPage", () => {
   it("lists registered MCP servers with their targets", async () => {
-    render(<ToolsPage />);
+    render(<IntegrationsPage />);
 
     expect(await screen.findByText("linear")).toBeTruthy();
     expect(screen.getByText("notion")).toBeTruthy();
@@ -92,7 +92,7 @@ describe("ToolsPage", () => {
 
   it("adds an http server with parsed headers and refreshes", async () => {
     vi.mocked(createMcpServer).mockResolvedValue(SERVERS[1]);
-    render(<ToolsPage />);
+    render(<IntegrationsPage />);
     await screen.findByText("linear");
 
     fireEvent.change(screen.getByLabelText("Server name"), { target: { value: "notion2" } });
@@ -118,7 +118,7 @@ describe("ToolsPage", () => {
 
   it("adds a stdio server with a command", async () => {
     vi.mocked(createMcpServer).mockResolvedValue(SERVERS[0]);
-    render(<ToolsPage />);
+    render(<IntegrationsPage />);
     await screen.findByText("linear");
 
     fireEvent.change(screen.getByLabelText("Server name"), { target: { value: "fs" } });
@@ -141,14 +141,14 @@ describe("ToolsPage", () => {
   // so the user could never tell that "not connected" was really "unknown".
   it("surfaces a failed integrations load instead of skeletons", async () => {
     vi.mocked(listIntegrations).mockRejectedValueOnce(new Error("integrations are down"));
-    render(<ToolsPage />);
+    render(<IntegrationsPage />);
 
     expect(await screen.findByText(/integrations are down/)).toBeTruthy();
   });
 
   it("removes a server", async () => {
     vi.mocked(deleteMcpServer).mockResolvedValue(undefined);
-    render(<ToolsPage />);
+    render(<IntegrationsPage />);
     await screen.findByText("linear");
 
     fireEvent.click(screen.getAllByRole("button", { name: /remove/i })[0]);

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -99,13 +99,13 @@ function IntegrationsGrid() {
   const [busy, setBusy] = useState<string | null>(null);
   const [paywalled, setPaywalled] = useState(false);
 
-  // Straight to the consent screen; the OAuth flow returns to /tools, where
-  // the row reads Connected. No successful-return path resets `busy` — the
-  // whole page navigates away.
+  // Straight to the consent screen; the OAuth flow returns to /integrations,
+  // where the row reads Connected. No successful-return path resets `busy` —
+  // the whole page navigates away.
   async function connectNow(connector: Connector) {
     setBusy(connector.provider);
     try {
-      await startConnect(connector.provider, "/tools");
+      await startConnect(connector.provider, "/integrations");
     } catch (e) {
       if (e instanceof ApiError && e.status === 402) setPaywalled(true);
       else toast.error(e instanceof Error ? e.message : "Could not start connection");
@@ -325,12 +325,12 @@ function ServerRow({ server, onRemoved }: { server: McpServer; onRemoved: () => 
   );
 }
 
-export default function ToolsPage() {
+export default function IntegrationsPage() {
   const router = useRouter();
   const { user, loading } = useAuth();
   const [servers, setServers] = useState<McpServer[] | null>(null);
 
-  useBreadcrumbs([{ label: "Tools" }], "tools");
+  useBreadcrumbs([{ label: "Integrations" }], "integrations");
 
   const refresh = useCallback(async () => {
     try {
@@ -355,7 +355,7 @@ export default function ToolsPage() {
       <div className="mx-auto flex max-w-5xl flex-col gap-8 px-8 py-7">
         <div>
           <h1 className="font-display text-[22px] font-semibold tracking-tight text-foreground">
-            Tools
+            Integrations
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
             Everything your agent can reach — connected sources and MCP servers.
@@ -363,7 +363,7 @@ export default function ToolsPage() {
         </div>
 
         <section>
-          <h2 className="text-[15px] font-semibold text-foreground">Integrations</h2>
+          <h2 className="text-[15px] font-semibold text-foreground">Connected sources</h2>
           <p className="mt-0.5 text-[13px] text-muted-foreground">
             Connect accounts and choose what your agent can read. Click one to connect or manage
             it.

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -1,19 +1,26 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
-import { Globe, Plus, Terminal } from "lucide-react";
+import { Globe, Server, SquareTerminal } from "lucide-react";
 import { toast } from "sonner";
+
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
 import { useAuth } from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
   ApiError,
-  createMcpServer,
   deleteMcpServer,
   listMcpServers,
   listSources,
@@ -32,90 +39,192 @@ import {
   providerForSourceType,
   type Connector,
 } from "@/components/integrations/connectors";
+import {
+  AGENT_COPY,
+  CODING_AGENTS,
+  agentDialogBody,
+} from "@/components/integrations/CodingAgents";
+import { OUTPUT_SURFACES } from "@/components/integrations/OutputSurfaces";
+import AddServerForm from "@/components/integrations/McpServers";
 import PaywallModal from "@/components/PaywallModal";
+import { ChromeIcon } from "@/components/integrations/BrandIcons";
+import { cn } from "@/lib/utils";
 
-// One row per connector — the standard integrations list. The row is a link
-// to the provider's page (manage, pick sources, disconnect). For OAuth
-// providers the Connect button skips the page and goes straight to the
-// consent screen, returning here; api-key and extension providers still
-// route through their page (credential form / extension install).
-function IntegrationRow({
-  connector,
-  connected,
-  busy,
-  onOauthConnect,
-}: {
-  connector: Connector;
-  connected: boolean;
-  busy: boolean;
-  onOauthConnect: (() => void) | null;
-}) {
+// One flat grid. Every way anything reaches Stash, or reads it back, is a box
+// with the same shape — the only structure is a direction badge and a search
+// field. Sections used to group these, but the groupings were a second
+// vocabulary to learn on top of the boxes themselves.
+type Direction = "in" | "out";
+
+// The list reads in the order a team adopts Stash: the agents they already
+// run, then the tools their work lives in, then the personal accounts they
+// save to.
+const TIER = { agents: 0, work: 1, personal: 2 };
+
+// Consumer accounts — the "save your own stuff" end of the list rather than
+// the ones a team wires up first.
+const PERSONAL_PROVIDERS = new Set(["x", "instagram"]);
+
+type Box = {
+  key: string;
+  name: string;
+  direction: Direction;
+  blurb: string;
+  icon: ReactNode;
+  /** Connected boxes sort to the front of their tier. */
+  active: boolean;
+  /** Which band of the list this belongs to; see TIER. */
+  tier: number;
+  /** Sorts to the end of its tier — for the "add one" affordance. */
+  sortLast?: boolean;
+  /** Everything the search field matches against. */
+  search: string;
+  /** What the dialog holds: setup steps, or an integration's own settings. */
+  dialog?: { title: string; description: string; body: ReactNode };
+  /** Verb on the button that opens the dialog. */
+  actionLabel?: string;
+  /** For the one box that isn't a detail view: opens the add-server form. */
+  onAction?: () => void;
+  action: ReactNode;
+};
+
+function IntegrationBox({ box, onOpen }: { box: Box; onOpen?: () => void }) {
   return (
-    <Link
-      href={`/integrations/${connector.provider}`}
-      className="group flex items-center gap-4 px-4 py-3.5 transition-colors hover:bg-raised"
-    >
-      <span className="flex h-7 w-7 shrink-0 items-center justify-center [&_img]:h-6 [&_img]:w-6 [&_svg]:h-6 [&_svg]:w-6">
-        {connectorIcon(connector.provider)}
-      </span>
-      <div className="min-w-0 flex-1">
-        <div className="text-[13.5px] font-semibold text-foreground">{connector.label}</div>
-        <p className="truncate text-[12.5px] text-dim">{connector.blurb}</p>
-      </div>
-      {connected ? (
-        <span className="flex shrink-0 items-center gap-1.5 text-[12px] font-medium text-[var(--color-success)]">
-          <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-success)]" />
-          Connected
-        </span>
-      ) : onOauthConnect ? (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onOauthConnect();
-          }}
-          disabled={busy}
-          className="shrink-0 cursor-pointer text-[12px] font-medium text-muted-foreground transition-colors hover:text-brand-700 disabled:cursor-not-allowed"
-        >
-          {busy ? "Connecting…" : "Connect"}
-        </button>
-      ) : (
-        <span className="shrink-0 text-[12px] font-medium text-muted-foreground transition-colors group-hover:text-brand-700">
-          Connect
-        </span>
+    <div
+      className={cn(
+        "flex flex-col gap-2.5 rounded-xl border p-4",
+        box.active
+          ? "border-success/30 bg-success/[0.06]"
+          : "border-border bg-surface",
       )}
-    </Link>
+    >
+      <div className="flex items-center gap-2.5">
+        <span className="flex h-7 w-7 shrink-0 items-center justify-center [&_img]:h-6 [&_img]:w-6 [&_svg]:h-6 [&_svg]:w-6">
+          {box.icon}
+        </span>
+        {onOpen ? (
+          <button
+            type="button"
+            onClick={onOpen}
+            className="min-w-0 flex-1 truncate text-left text-[14px] font-medium text-foreground hover:underline"
+          >
+            {box.name}
+          </button>
+        ) : (
+          <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-foreground">
+            {box.name}
+          </span>
+        )}
+      </div>
+
+      <p className="min-h-[34px] break-words text-[12.5px] leading-snug text-muted-foreground">
+        {box.blurb}
+      </p>
+
+      {box.action}
+    </div>
   );
 }
 
-function IntegrationsGrid() {
-  // Extension connectors have no token — source presence is their "connected".
-  // OAuth/api-key connectors use the integration status, so a provider that
-  // was disconnected with its data kept reads "Connect", not "Connected".
+/** A source connector's detail view. Also the only place `disabled_reason`
+ *  is ever shown: a server without INTEGRATIONS_ENCRYPTION_KEY offers a
+ *  Connect button that can only 503, and until now said nothing about why. */
+function ConnectorDialogBody({
+  connector,
+  status,
+  connected,
+  busy,
+  onConnect,
+}: {
+  connector: Connector;
+  status: IntegrationStatus | undefined;
+  connected: boolean;
+  busy: boolean;
+  onConnect: (() => void) | null;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-3">
+      {status?.disabled_reason && (
+        <p className="rounded-lg border border-warning/30 bg-chart-5/10 px-3 py-2 text-[12.5px] text-warning">
+          {status.disabled_reason}
+        </p>
+      )}
+      <p className="text-[12.5px] text-muted-foreground">
+        {connected
+          ? "Connected. Choose what syncs, check sync status, or disconnect on its settings page."
+          : "Connecting opens the provider's consent screen. Nothing syncs until you pick what to include."}
+      </p>
+      <div className="flex flex-wrap items-center gap-2">
+        {!connected && onConnect && (
+          <Button size="sm" disabled={busy} onClick={onConnect}>
+            {busy ? "Connecting…" : `Connect ${connector.label}`}
+          </Button>
+        )}
+        <Button asChild size="sm" variant={connected || !onConnect ? "secondary" : "ghost"}>
+          <Link href={`/integrations/${connector.provider}`}>
+            {connected ? "Manage sources" : `Open ${connector.label} settings`}
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** A lucide glyph in the same tile the brand marks sit in, so a box with no
+ *  logo still lines up with one that has. */
+function TileIcon({ icon: Icon }: { icon: typeof Globe }) {
+  return (
+    <span className="flex h-7 w-7 items-center justify-center rounded-md bg-raised">
+      <Icon className="h-4 w-4 text-dim" />
+    </span>
+  );
+}
+
+/** What a registered server points at, in words: a remote host, or a local
+ *  process named by the binary it runs. */
+function mcpServerTarget(server: McpServer): string {
+  if (server.transport === "stdio") {
+    const binary = (server.command ?? "").trim().split(/\s+/)[0];
+    return binary ? `a local ${binary} process` : "a local process";
+  }
+  try {
+    return new URL(server.url!).hostname;
+  } catch {
+    return "a remote server";
+  }
+}
+
+function mcpServerIcon(server: McpServer) {
+  if (server.url && new URL(server.url).hostname === "mcp.linear.app") {
+    return connectorIcon("linear");
+  }
+
+  return <TileIcon icon={server.transport === "stdio" ? SquareTerminal : Globe} />;
+}
+
+export default function IntegrationsPage() {
+  const router = useRouter();
+  const { user, loading } = useAuth();
   const [sourceProviders, setSourceProviders] = useState<Set<string>>(new Set());
   const [statuses, setStatuses] = useState<Record<string, IntegrationStatus> | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [servers, setServers] = useState<McpServer[]>([]);
+  const [query, setQuery] = useState("");
+  const [direction, setDirection] = useState<Direction>("in");
+  const [open, setOpen] = useState<Box | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [paywalled, setPaywalled] = useState(false);
+  const [addingServer, setAddingServer] = useState(false);
 
-  // Straight to the consent screen; the OAuth flow returns to /integrations,
-  // where the row reads Connected. No successful-return path resets `busy` —
-  // the whole page navigates away.
-  async function connectNow(connector: Connector) {
-    setBusy(connector.provider);
-    try {
-      await startConnect(connector.provider, "/integrations");
-    } catch (e) {
-      if (e instanceof ApiError && e.status === 402) setPaywalled(true);
-      else toast.error(e instanceof Error ? e.message : "Could not start connection");
-      setBusy(null);
-    }
-  }
+  useBreadcrumbs([{ label: "Integrations" }], "integrations");
 
-  // Both calls decide what a row says — statuses which rows exist, sources
-  // whether an extension row reads Connected — so either one failing makes
-  // the whole list wrong. Fail together, loudly, instead of showing a list
+  useEffect(() => {
+    if (!loading && !user) router.push("/login");
+  }, [user, loading, router]);
+
+  // Both calls decide what a box says — statuses which boxes exist, sources
+  // whether an extension box reads Connected — so either one failing makes
+  // the whole grid wrong. Fail together, loudly, instead of showing a grid
   // that lies or skeletons that never resolve.
   useEffect(() => {
     const load = () => {
@@ -128,7 +237,7 @@ function IntegrationsGrid() {
           setStatuses(byProvider);
         })
         .catch((e) =>
-          setLoadError(e instanceof Error ? e.message : "Failed to load integrations")
+          setLoadError(e instanceof Error ? e.message : "Failed to load integrations"),
         );
     };
     load();
@@ -136,203 +245,7 @@ function IntegrationsGrid() {
     return () => window.removeEventListener(INTEGRATIONS_CHANGED_EVENT, load);
   }, []);
 
-  if (loadError) {
-    return (
-      <div className="rounded-xl border border-border bg-surface px-4 py-6 text-center text-[13px] text-destructive">
-        Couldn&apos;t load integrations: {loadError}
-      </div>
-    );
-  }
-
-  if (statuses === null) {
-    return (
-      <div className="flex flex-col gap-2">
-        {Array.from({ length: 6 }, (_, i) => (
-          <Skeleton key={i} className="h-[54px] rounded-lg" />
-        ))}
-      </div>
-    );
-  }
-
-  // The server omits providers this user may not use (customer-specific
-  // integrations like Heavi) — extension connectors are always available.
-  const rows = CONNECTORS.filter((c) => c.kind === "extension" || c.provider in statuses);
-  return (
-    <div className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
-      {rows.map((c) => {
-        const status = statuses[c.provider];
-        const oauth =
-          c.kind !== "extension" && status?.auth_kind !== "api_key" && !status?.disabled_reason;
-        return (
-          <IntegrationRow
-            key={c.provider}
-            connector={c}
-            connected={c.kind === "extension" ? sourceProviders.has(c.provider) : !!status?.connected}
-            busy={busy === c.provider}
-            onOauthConnect={oauth ? () => void connectNow(c) : null}
-          />
-        );
-      })}
-      {paywalled && <PaywallModal onClose={() => setPaywalled(false)} />}
-    </div>
-  );
-}
-
-// One "KEY=VALUE" line per header, parsed at submit time.
-function parseHeaderLines(raw: string): Record<string, string> {
-  const headers: Record<string, string> = {};
-  for (const line of raw.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    const eq = trimmed.indexOf("=");
-    if (eq <= 0) throw new Error(`Headers must be KEY=VALUE lines; got "${trimmed}"`);
-    headers[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
-  }
-  return headers;
-}
-
-function AddServerForm({ onAdded }: { onAdded: () => void }) {
-  const [name, setName] = useState("");
-  const [transport, setTransport] = useState<"stdio" | "http">("http");
-  const [command, setCommand] = useState("");
-  const [url, setUrl] = useState("");
-  const [headerLines, setHeaderLines] = useState("");
-  const [saving, setSaving] = useState(false);
-
-  async function submit() {
-    setSaving(true);
-    try {
-      const headers = transport === "http" ? parseHeaderLines(headerLines) : {};
-      await createMcpServer({
-        name: name.trim(),
-        transport,
-        ...(transport === "stdio" ? { command: command.trim() } : { url: url.trim(), headers }),
-      });
-      setName("");
-      setCommand("");
-      setUrl("");
-      setHeaderLines("");
-      onAdded();
-    } catch (e) {
-      toast.error(e instanceof ApiError || e instanceof Error ? e.message : "Failed to add server");
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  const targetMissing = transport === "stdio" ? !command.trim() : !url.trim();
-
-  return (
-    <form
-      className="rounded-lg border border-border bg-surface p-4"
-      onSubmit={(e) => {
-        e.preventDefault();
-        void submit();
-      }}
-    >
-      <h2 className="text-sm font-semibold">Add an MCP server</h2>
-      <div className="mt-3 flex flex-col gap-3">
-        <Input
-          aria-label="Server name"
-          placeholder="Name (e.g. linear)"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <div className="flex gap-1 rounded-md bg-muted p-1 self-start" role="radiogroup">
-          {(["http", "stdio"] as const).map((t) => (
-            <button
-              key={t}
-              type="button"
-              role="radio"
-              aria-checked={transport === t}
-              onClick={() => setTransport(t)}
-              className={`rounded px-3 py-1 text-xs font-medium ${
-                transport === t
-                  ? "bg-surface text-foreground shadow-sm"
-                  : "text-muted-foreground"
-              }`}
-            >
-              {t === "http" ? "Remote (HTTP)" : "Local (stdio)"}
-            </button>
-          ))}
-        </div>
-        {transport === "stdio" ? (
-          <Input
-            aria-label="Command"
-            placeholder="Command (e.g. npx -y linear-mcp)"
-            value={command}
-            onChange={(e) => setCommand(e.target.value)}
-          />
-        ) : (
-          <>
-            <Input
-              aria-label="URL"
-              placeholder="URL (e.g. https://mcp.example.com/mcp)"
-              value={url}
-              onChange={(e) => setUrl(e.target.value)}
-            />
-            <Textarea
-              aria-label="Headers"
-              placeholder={"Optional headers, one per line:\nAuthorization=Bearer …"}
-              rows={2}
-              value={headerLines}
-              onChange={(e) => setHeaderLines(e.target.value)}
-            />
-          </>
-        )}
-        <Button type="submit" disabled={saving || !name.trim() || targetMissing} className="self-start">
-          <Plus className="h-4 w-4" />
-          Add server
-        </Button>
-      </div>
-    </form>
-  );
-}
-
-function ServerRow({ server, onRemoved }: { server: McpServer; onRemoved: () => void }) {
-  const [removing, setRemoving] = useState(false);
-
-  async function remove() {
-    setRemoving(true);
-    try {
-      await deleteMcpServer(server.id);
-      onRemoved();
-    } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Failed to remove server");
-      setRemoving(false);
-    }
-  }
-
-  const headerKeys = Object.keys(server.headers);
-  return (
-    <li className="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3">
-      {server.transport === "stdio" ? (
-        <Terminal className="h-4 w-4 shrink-0 text-muted-foreground" />
-      ) : (
-        <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
-      )}
-      <div className="min-w-0 flex-1">
-        <div className="text-sm font-medium">{server.name}</div>
-        <div className="truncate text-xs text-muted-foreground">
-          {server.transport === "stdio" ? server.command : server.url}
-          {headerKeys.length > 0 && `, headers: ${headerKeys.join(", ")}`}
-        </div>
-      </div>
-      <Button variant="ghost" size="sm" onClick={() => void remove()} disabled={removing}>
-        Remove
-      </Button>
-    </li>
-  );
-}
-
-export default function IntegrationsPage() {
-  const router = useRouter();
-  const { user, loading } = useAuth();
-  const [servers, setServers] = useState<McpServer[] | null>(null);
-
-  useBreadcrumbs([{ label: "Integrations" }], "integrations");
-
-  const refresh = useCallback(async () => {
+  const refreshServers = useCallback(async () => {
     try {
       setServers(await listMcpServers());
     } catch (e) {
@@ -341,59 +254,404 @@ export default function IntegrationsPage() {
   }, []);
 
   useEffect(() => {
-    if (!loading && !user) router.push("/login");
-  }, [user, loading, router]);
+    void refreshServers();
+  }, [refreshServers]);
 
-  useEffect(() => {
-    if (user) void refresh();
-  }, [user, refresh]);
+  const isConnected = useCallback(
+    (c: Connector) =>
+      c.kind === "extension"
+        ? sourceProviders.has(c.provider)
+        : !!statuses?.[c.provider]?.connected,
+    [sourceProviders, statuses],
+  );
+
+  // Straight to the consent screen; the OAuth flow returns to /integrations,
+  // where the box reads Connected. No successful-return path resets `busy` —
+  // the whole page navigates away.
+  const connectNow = useCallback(async (connector: Connector) => {
+    setBusy(connector.provider);
+    try {
+      await startConnect(connector.provider, "/integrations");
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 402) setPaywalled(true);
+      else toast.error(e instanceof Error ? e.message : "Could not start connection");
+      setBusy(null);
+    }
+  }, []);
+
+  const removeServer = useCallback(
+    async (id: string) => {
+      try {
+        await deleteMcpServer(id);
+        await refreshServers();
+      } catch (e) {
+        toast.error(e instanceof ApiError ? e.message : "Failed to remove server");
+      }
+    },
+    [refreshServers],
+  );
+
+  const boxes = useMemo<Box[]>(() => {
+    if (!statuses) return [];
+
+    // The server omits providers this user may not use (customer-specific
+    // integrations like Heavi) — extension connectors are always available.
+    const connectors = CONNECTORS.filter((c) => c.kind === "extension" || c.provider in statuses);
+
+    const sourceBoxes: Omit<Box, "action">[] = connectors.map((c) => {
+      const connected = isConnected(c);
+      const status = statuses[c.provider];
+      const oauth =
+        c.kind !== "extension" && status?.auth_kind !== "api_key" && !status?.disabled_reason;
+      return {
+        key: `source:${c.provider}`,
+        name: c.label,
+        direction: "in" as const,
+        blurb: c.blurb,
+        icon: connectorIcon(c.provider),
+        active: connected,
+        tier: PERSONAL_PROVIDERS.has(c.provider) ? TIER.personal : TIER.work,
+        search: `${c.label} ${c.blurb} ${c.provider} source`,
+        actionLabel: connected ? "Manage" : "Connect",
+        dialog: {
+          title: c.label,
+          description: c.blurb,
+          body: (
+            <ConnectorDialogBody
+              connector={c}
+              status={status}
+              connected={connected}
+              busy={busy === c.provider}
+              onConnect={oauth ? () => void connectNow(c) : null}
+            />
+          ),
+        },
+      };
+    });
+
+    const browserBox: Omit<Box, "action"> = {
+      key: "browser",
+      name: "Stash for Chrome",
+      direction: "in",
+      blurb: "Clip any page or every open tab, import your bookmarks, keep your saves in sync.",
+      icon: <ChromeIcon />,
+      active: false,
+      tier: TIER.personal,
+      search: "browser chrome extension clip bookmarks tabs",
+      actionLabel: "Connect",
+      dialog: {
+        title: "Stash for Chrome",
+        description: "Save from the browser without leaving the page.",
+        body: (
+          <div className="flex min-w-0 flex-col gap-3">
+            <ul className="flex list-disc flex-col gap-1 pl-4 text-[12.5px] text-muted-foreground">
+              <li>Clip any page, or every open tab at once.</li>
+              <li>Import your bookmarks — Stash fetches what&apos;s behind each link.</li>
+              <li>Keep your X and Instagram saves in sync.</li>
+              <li>Stream your ChatGPT and Claude chats in.</li>
+            </ul>
+            <Button asChild size="sm" className="self-start">
+              <Link href="/extension">Get the extension</Link>
+            </Button>
+          </div>
+        ),
+      },
+    };
+
+    const serverBoxes: Omit<Box, "action">[] = servers.map((s) => ({
+      key: `mcp:${s.id}`,
+      name: s.name,
+      direction: "in",
+      // Every other box describes itself in a sentence; a bare URL here read
+      // as a missing description. The exact target and header names are one
+      // click away in Manage.
+      blurb: `Tools from ${mcpServerTarget(s)}, handed to your cloud agent before every turn.`,
+      icon: mcpServerIcon(s),
+      active: true,
+      tier: TIER.work,
+      search: `${s.name} mcp server tool ${s.url ?? ""} ${s.command ?? ""}`,
+      actionLabel: "Manage",
+      dialog: {
+        title: s.name,
+        description: "An MCP server your cloud agent can call before every turn.",
+        body: (
+          <div className="flex min-w-0 flex-col gap-3">
+            <dl className="flex flex-col gap-2 text-[12.5px]">
+              <div className="flex gap-2">
+                <dt className="w-20 shrink-0 text-muted-foreground">Transport</dt>
+                <dd className="font-mono">
+                  {s.transport === "stdio" ? "Local (stdio)" : "Remote (HTTP)"}
+                </dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="w-20 shrink-0 text-muted-foreground">
+                  {s.transport === "stdio" ? "Command" : "URL"}
+                </dt>
+                <dd className="min-w-0 break-all font-mono">
+                  {s.transport === "stdio" ? s.command : s.url}
+                </dd>
+              </div>
+              {Object.keys(s.headers).length > 0 && (
+                <div className="flex gap-2">
+                  <dt className="w-20 shrink-0 text-muted-foreground">Headers</dt>
+                  {/* Values are secrets — the registry only ever shows key names. */}
+                  <dd className="min-w-0 break-all font-mono">
+                    {Object.keys(s.headers).join(", ")}
+                  </dd>
+                </div>
+              )}
+            </dl>
+            <Button
+              variant="destructive"
+              size="sm"
+              className="self-start"
+              onClick={async () => {
+                await removeServer(s.id);
+                setOpen(null);
+              }}
+            >
+              Remove server
+            </Button>
+          </div>
+        ),
+      },
+    }));
+
+    const addServerBox: Omit<Box, "action"> = {
+      key: "mcp:add",
+      name: "Custom MCP server",
+      direction: "in",
+      blurb: "Register any MCP server and your cloud agent gets it before every turn.",
+      icon: <TileIcon icon={Server} />,
+      active: false,
+      tier: TIER.work,
+      sortLast: true,
+      search: "custom mcp server add tool",
+      onAction: () => setAddingServer(true),
+    };
+
+    // A coding agent is two integrations wearing one name, so it gets a box
+    // per direction with the half that applies.
+    const agentBoxes: Omit<Box, "action">[] = (["in", "out"] as const).flatMap((d) =>
+      CODING_AGENTS.map((agent) => ({
+        key: `agent:${d}:${agent.binary}`,
+        name: AGENT_COPY[d].label(agent.name),
+        direction: d,
+        blurb: AGENT_COPY[d].blurb(agent.name),
+        icon: agent.icon,
+        active: false,
+        tier: TIER.agents,
+        search: `${agent.name} ${agent.binary} coding agent`,
+        dialog: {
+          title: AGENT_COPY[d].title(agent.name),
+          description: AGENT_COPY[d].description,
+          body: agentDialogBody(),
+        },
+      })),
+    );
+
+    const outputBoxes: Omit<Box, "action">[] = OUTPUT_SURFACES.map((s) => ({
+      key: `out:${s.key}`,
+      name: s.name,
+      direction: "out" as const,
+      blurb: s.blurb,
+      icon: <TileIcon icon={s.icon} />,
+      active: false,
+      tier: TIER.work,
+      search: `${s.name} ${s.blurb} ${s.keywords}`,
+      dialog: { title: s.name, description: s.blurb, body: s.body },
+    }));
+
+    // Every box that opens a dialog gets its button built here, so the grid
+    // can't sprout a different shape of action per box type.
+    const withDialogs: Box[] = [
+      ...sourceBoxes,
+      browserBox,
+      addServerBox,
+      ...serverBoxes,
+      ...agentBoxes,
+      ...outputBoxes,
+    ].map((b) => ({
+      ...b,
+      action: (
+        <Button
+          size="sm"
+          variant="secondary"
+          className="self-start"
+          onClick={() => (b.onAction ? b.onAction() : setOpen({ ...b, action: null }))}
+        >
+          {b.actionLabel ?? "Connect"}
+        </Button>
+      ),
+    }));
+
+    return [...withDialogs].sort(
+      (a, b) =>
+        Number(b.active) - Number(a.active) ||
+        a.tier - b.tier ||
+        Number(!!a.sortLast) - Number(!!b.sortLast) ||
+        a.name.localeCompare(b.name),
+    );
+  }, [statuses, servers, busy, isConnected, connectNow, removeServer]);
+
+  const matchesQuery = useCallback(
+    (b: Box) => {
+      const q = query.trim().toLowerCase();
+      return q === "" || b.search.toLowerCase().includes(q);
+    },
+    [query],
+  );
+
+  const visible = useMemo(
+    () => boxes.filter((b) => b.direction === direction && matchesQuery(b)),
+    [boxes, direction, matchesQuery],
+  );
+
+  // Only one direction is on screen, so a search that matches nothing here but
+  // something in the other half would otherwise read as "no results" when
+  // there are results one click away.
+  const elsewhere = useMemo(
+    () => boxes.filter((b) => b.direction !== direction && matchesQuery(b)).length,
+    [boxes, direction, matchesQuery],
+  );
 
   if (loading || !user) return null;
 
+  const connectedCount = boxes.filter((b) => b.direction === direction && b.active).length;
+
   return (
     <div className="h-full overflow-y-auto">
-      <div className="mx-auto flex max-w-5xl flex-col gap-8 px-8 py-7">
-        <div>
+      <div className="mx-auto flex max-w-5xl flex-col gap-5 px-8 py-7">
+        <header>
           <h1 className="font-display text-[22px] font-semibold tracking-tight text-foreground">
             Integrations
           </h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Everything your agent can reach — connected sources and MCP servers.
+          <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+            Choose what to add to your Stash, and what can read it.
           </p>
+        </header>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search integrations…"
+            aria-label="Search integrations"
+            className="h-9 max-w-xs"
+          />
+          {(["in", "out"] as const).map((d) => (
+            <button
+              key={d}
+              type="button"
+              aria-pressed={direction === d}
+              onClick={() => setDirection(d)}
+              className={cn(
+                "rounded-full border px-3 py-1.5 text-[12.5px] font-medium transition-colors",
+                direction === d
+                  ? d === "in"
+                    ? "border-human/40 bg-human/10 text-human"
+                    : "border-warning/40 bg-chart-5/15 text-warning"
+                  : "border-border bg-surface text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {d === "in" ? "Inputs" : "Outputs"}
+              <span className="ml-1.5 text-[11px] opacity-60">
+                {boxes.filter((b) => b.direction === d).length}
+              </span>
+            </button>
+          ))}
+          {connectedCount > 0 && (
+            <span className="ml-auto text-[12.5px] text-muted-foreground">
+              {connectedCount} connected
+            </span>
+          )}
         </div>
 
-        <section>
-          <h2 className="text-[15px] font-semibold text-foreground">Connected sources</h2>
-          <p className="mt-0.5 text-[13px] text-muted-foreground">
-            Connect accounts and choose what your agent can read. Click one to connect or manage
-            it.
-          </p>
-          <div className="mt-4">
-            <IntegrationsGrid />
+        {loadError && (
+          <div className="rounded-xl border border-border bg-surface px-4 py-6 text-center text-[13px] text-destructive">
+            Couldn&apos;t load integrations: {loadError}
           </div>
-        </section>
+        )}
 
-        <section>
-          <h2 className="text-[15px] font-semibold text-foreground">MCP servers</h2>
-          <p className="mt-0.5 text-[13px] text-muted-foreground">
-            Available to your cloud agent, and installable locally with{" "}
-            <code className="text-xs">stash tools install</code>.
-          </p>
-          <div className="mt-4 flex flex-col gap-3">
-            {servers !== null && servers.length === 0 && (
-              <p className="text-sm text-muted-foreground">No MCP servers yet — add one below.</p>
-            )}
-            {servers !== null && servers.length > 0 && (
-              <ul className="flex flex-col gap-2">
-                {servers.map((s) => (
-                  <ServerRow key={s.id} server={s} onRemoved={() => void refresh()} />
-                ))}
-              </ul>
-            )}
-            <AddServerForm onAdded={() => void refresh()} />
+        {statuses === null && !loadError ? (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 9 }, (_, i) => (
+              <Skeleton key={i} className="h-[124px] rounded-xl" />
+            ))}
           </div>
-        </section>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {visible.map((box) => (
+              <IntegrationBox
+                key={box.key}
+                box={box}
+                onOpen={box.dialog ? () => setOpen(box) : undefined}
+              />
+            ))}
+          </div>
+        )}
+
+        {statuses !== null && visible.length === 0 && (
+          <p className="py-8 text-center text-[13px] text-muted-foreground">
+            Nothing matches “{query}” here.
+            {elsewhere > 0 && (
+              <>
+                {" "}
+                <button
+                  type="button"
+                  onClick={() => setDirection(direction === "in" ? "out" : "in")}
+                  className="font-medium text-brand-600 hover:underline"
+                >
+                  {elsewhere} {elsewhere === 1 ? "match" : "matches"} in{" "}
+                  {direction === "in" ? "Outputs" : "Inputs"} →
+                </button>
+              </>
+            )}
+          </p>
+        )}
       </div>
+
+      <Dialog open={open !== null} onOpenChange={(v) => !v && setOpen(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <div className="flex items-start gap-3">
+              <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center [&_img]:h-7 [&_img]:w-7 [&_svg]:h-7 [&_svg]:w-7">
+                {open?.icon}
+              </span>
+              <div className="flex min-w-0 flex-col gap-1">
+                <DialogTitle>{open?.dialog?.title}</DialogTitle>
+                <DialogDescription>{open?.dialog?.description}</DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+          {open?.dialog?.body}
+          <DialogFooter>
+            <Button size="sm" onClick={() => setOpen(null)}>
+              Done
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={addingServer} onOpenChange={setAddingServer}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Connect an MCP server</DialogTitle>
+            <DialogDescription>
+              Your cloud agent gets it before every turn, alongside the tools Stash gives it
+              natively.
+            </DialogDescription>
+          </DialogHeader>
+          <AddServerForm
+            onAdded={() => {
+              setAddingServer(false);
+              void refreshServers();
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {paywalled && <PaywallModal onClose={() => setPaywalled(false)} />}
     </div>
   );
 }

--- a/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
@@ -622,7 +622,6 @@ export default function SkillPageView({ pageId }: { pageId: string }) {
       <FileViewerHeader
         icon={isHtml ? <HtmlGlyph /> : <PageGlyph />}
         iconColor={isHtml ? "var(--color-brand-600)" : "var(--text-muted)"}
-        breadcrumbs={ancestorCrumbs}
         title={baseName}
         onRenameTitle={
           page

--- a/frontend/src/app/(app)/sessions/page.tsx
+++ b/frontend/src/app/(app)/sessions/page.tsx
@@ -317,12 +317,11 @@ export default function SkillSessionsPage() {
           </section>
         )}
 
-        {/* Folder-first: the landing is the set of folders (Default catches
-            chat + un-targeted sessions); the chronological/filter views live
-            inside a folder once you drill in. */}
-        {openFolder ? (
-          <FolderDrill
-            folder={openFolder}
+        {/* Sessions-first: the landing is every session, flat, because the tab
+            exists to let you look at your sessions. Folders organise them and
+            sit below; the VFS view is where sessions nest into directories. */}
+        <FolderDrill
+            folder={openFolder ?? ALL_SESSIONS}
             refreshKey={drillRefresh}
             folders={folders}
             view={view}
@@ -340,15 +339,17 @@ export default function SkillSessionsPage() {
             dragActive={dragActive}
             onDropSessions={moveRowsToFolder}
           />
-        ) : (
-          <FoldersSection
-            ownFolders={folders}
-            sharedFolders={sharedFolders}
-            onOpen={setOpenFolder}
-            onNewFolder={newFolder}
-            onShare={(f) => setShareFolder(f)}
-            onDropSessions={moveRowsToFolder}
-          />
+        {!openFolder && (
+          <div className="mt-8 border-t border-border pt-5">
+            <FoldersSection
+              ownFolders={folders}
+              sharedFolders={sharedFolders}
+              onOpen={setOpenFolder}
+              onNewFolder={newFolder}
+              onShare={(f) => setShareFolder(f)}
+              onDropSessions={moveRowsToFolder}
+            />
+          </div>
         )}
       </div>
 
@@ -923,11 +924,16 @@ function formatDate(iso: string | null): string {
 // `folder` is the full record for own folders (enables Share/Delete + access
 // badge); shared-with-me folders only carry the id/name.
 type OpenFolder = {
-  id: string;
+  /** null = every session in the scope: the tab's flat landing view. Folders
+   *  are a way to organise sessions, not a wall you must click through to see
+   *  them. */
+  id: string | null;
   name: string;
   shared: boolean;
   folder?: SessionFolder;
 };
+
+const ALL_SESSIONS: OpenFolder = { id: null, name: "All sessions", shared: false };
 
 const VIS_DOT: Record<DisplayVisibility, string> = {
   public: "#22C55E",
@@ -1152,9 +1158,10 @@ function FolderDrill({
   useEffect(() => {
     setFolderSessions(null);
     setHasMore(false);
-    const request = folder.shared
-      ? listSharedSessionFolderSessions(folder.id)
-      : listMySessions(SESSIONS_PAGE_SIZE, folder.id, 0);
+    const request =
+      folder.shared && folder.id
+        ? listSharedSessionFolderSessions(folder.id)
+        : listMySessions(SESSIONS_PAGE_SIZE, folder.id ?? undefined, 0);
     request
       .then((rows) => {
         setFolderSessions(rows);
@@ -1169,7 +1176,7 @@ function FolderDrill({
     try {
       const rows = await listMySessions(
         SESSIONS_PAGE_SIZE,
-        folder.id,
+        folder.id ?? undefined,
         folderSessions.length
       );
       setFolderSessions((prev) => [...(prev ?? []), ...rows]);
@@ -1206,18 +1213,24 @@ function FolderDrill({
   // without selection (no move/delete on sessions you don't own).
   const drillSessions = sortSessions(folderSessions ?? [], sort);
 
+  const isAll = folder.id === null;
+
   return (
     <div>
-      <button
-        type="button"
-        onClick={onBack}
-        className="mb-3 inline-flex cursor-pointer items-center gap-1 text-[12.5px] text-muted-foreground hover:text-foreground"
-      >
-        ← All folders
-      </button>
+      {!isAll && (
+        <button
+          type="button"
+          onClick={onBack}
+          className="mb-3 inline-flex cursor-pointer items-center gap-1 text-[12.5px] text-muted-foreground hover:text-foreground"
+        >
+          ← All folders
+        </button>
+      )}
       <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
         <h2 className="m-0 flex items-center gap-2 font-display text-[18px] font-semibold text-foreground">
-          <span aria-hidden>{folder.shared ? "🗂️" : ownFolder?.is_default ? "🗃️" : "📁"}</span>
+          {!isAll && (
+            <span aria-hidden>{folder.shared ? "🗂️" : ownFolder?.is_default ? "🗃️" : "📁"}</span>
+          )}
           {folder.name}
           {ownFolder && <FolderAccessBadge folder={ownFolder} />}
         </h2>

--- a/frontend/src/app/(app)/sessions/page.tsx
+++ b/frontend/src/app/(app)/sessions/page.tsx
@@ -6,9 +6,10 @@ import { useCallback, useEffect, useMemo, useRef, useState, type DragEvent } fro
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
 import { useConfirm } from "@/components/ConfirmDialog";
 import CopyableCommandBlock from "@/components/CopyableCommandBlock";
+import CustomSelect from "@/components/CustomSelect";
 import SessionUpload from "@/components/SessionUpload";
 import { SessionsListSkeleton } from "@/components/SkeletonStates";
-import { PinIcon } from "@/components/SkillIcons";
+import { FolderIcon, PinIcon } from "@/components/SkillIcons";
 import { SelectBox } from "@/components/content/file-browser/ItemsList";
 import { useAuth } from "@/hooks/useAuth";
 import {
@@ -40,7 +41,17 @@ import {
 } from "@/lib/sessionGrouping";
 
 type ViewKey = "list" | "day" | "user" | "agent" | "ticket" | "folder";
-type SortKey = "recent" | "oldest" | "events" | "name";
+type SortColumn = "updated" | "events" | "name" | "agent";
+type SortKey = { column: SortColumn; dir: "asc" | "desc" };
+
+// Each column's first click picks the order you almost always want first:
+// newest, busiest, A-Z. Clicking the active column flips it.
+const FIRST_DIR: Record<SortColumn, "asc" | "desc"> = {
+  updated: "desc",
+  events: "desc",
+  name: "asc",
+  agent: "asc",
+};
 
 const VIEW_STORAGE_KEY = "stash_sessions_view";
 
@@ -55,13 +66,6 @@ const VIEWS: { key: ViewKey; label: string }[] = [
   { key: "agent", label: "By agent" },
   { key: "ticket", label: "By ticket" },
   { key: "folder", label: "By folder" },
-];
-
-const SORTS: { key: SortKey; label: string }[] = [
-  { key: "recent", label: "Recent" },
-  { key: "oldest", label: "Oldest" },
-  { key: "events", label: "Most events" },
-  { key: "name", label: "Name" },
 ];
 
 // Drag payload: the DB row ids (sessions.id) of the dragged sessions. Dragging
@@ -110,7 +114,7 @@ export default function SkillSessionsPage() {
   const [shareFolder, setShareFolder] = useState<SessionFolder | null>(null);
   const [error, setError] = useState("");
   const [view, setView] = useState<ViewKey>("list");
-  const [sort, setSort] = useState<SortKey>("recent");
+  const [sort, setSort] = useState<SortKey>({ column: "updated", dir: "desc" });
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [dragActive, setDragActive] = useState(false);
 
@@ -159,12 +163,7 @@ export default function SkillSessionsPage() {
 
   const sorted = useMemo(() => {
     if (!sessions) return null;
-    const copy = [...sessions];
-    if (sort === "recent") copy.sort((a, b) => sessionTime(b) - sessionTime(a));
-    else if (sort === "oldest") copy.sort((a, b) => sessionTime(a) - sessionTime(b));
-    else if (sort === "events") copy.sort((a, b) => b.event_count - a.event_count);
-    else copy.sort((a, b) => sessionTitle(a).localeCompare(sessionTitle(b)));
-    return copy;
+    return sortSessions(sessions, sort);
   }, [sessions, sort]);
 
   if (loading) return <SessionsListSkeleton />;
@@ -296,9 +295,6 @@ export default function SkillSessionsPage() {
           </div>
         )}
 
-        <div className="mt-5 mb-4">
-          <SessionUpload onUploaded={load} />
-        </div>
 
         {pinnedSessions.length > 0 && (
           <section className="mb-5">
@@ -308,6 +304,8 @@ export default function SkillSessionsPage() {
             </h2>
             <SessionsTable
               sessions={pinnedSessions}
+              sort={sort}
+              onSort={setSort}
               isPinned={pins.isPinned}
               onTogglePin={pins.toggle}
               selectedIds={selectedIds}
@@ -338,6 +336,7 @@ export default function SkillSessionsPage() {
             drag={drag}
             dragActive={dragActive}
             onDropSessions={moveRowsToFolder}
+            onUploaded={load}
           />
         {!openFolder && (
           <div className="mt-8 border-t border-border pt-5">
@@ -439,10 +438,14 @@ function SessionsView({
   onToggleSelect,
   drag,
   withInstallCta,
+  sort,
+  onSort,
 }: {
   view: ViewKey;
   sessions: SessionSummary[];
   folders: SessionFolder[];
+  sort: SortKey;
+  onSort: (s: SortKey) => void;
   isPinned: (sessionId: string) => boolean;
   onTogglePin: (sessionId: string) => void;
   selectedIds: Set<string>;
@@ -458,6 +461,8 @@ function SessionsView({
     return (
       <SessionsTable
         sessions={sessions}
+        sort={sort}
+        onSort={onSort}
         isPinned={isPinned}
         onTogglePin={onTogglePin}
         selectedIds={selectedIds}
@@ -475,6 +480,8 @@ function SessionsView({
           <DayGroup
             key={group.key}
             group={group}
+            sort={sort}
+            onSort={onSort}
             initialOpen={i === 0}
             isPinned={isPinned}
             onTogglePin={onTogglePin}
@@ -501,6 +508,9 @@ function SessionsView({
         <FlatGroup
           key={group.key}
           group={group}
+          sort={sort}
+          onSort={onSort}
+          soleGroup={groups.length === 1}
           initialOpen={i === 0}
           isPinned={isPinned}
           onTogglePin={onTogglePin}
@@ -515,6 +525,8 @@ function SessionsView({
 
 function DayGroup({
   group,
+  sort,
+  onSort,
   initialOpen,
   isPinned,
   onTogglePin,
@@ -523,6 +535,8 @@ function DayGroup({
   drag,
 }: {
   group: SessionDayGroup;
+  sort: SortKey;
+  onSort: (s: SortKey) => void;
   initialOpen: boolean;
   isPinned: (sessionId: string) => boolean;
   onTogglePin: (sessionId: string) => void;
@@ -534,16 +548,16 @@ function DayGroup({
   return (
     <section>
       <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="flex w-full cursor-pointer items-center gap-2 rounded-md px-1 py-1 text-left hover:bg-raised"
-      >
-        <Chev open={open} />
-        <h2 className="m-0 font-display text-[15px] font-semibold">{group.label}</h2>
-        <span className="sys-label" style={{ fontSize: 10.5 }}>
-          {group.count}
-        </span>
-      </button>
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="flex w-full cursor-pointer items-center gap-2 rounded-md px-1 py-1 text-left hover:bg-raised"
+        >
+          <Chev open={open} />
+          <h2 className="m-0 font-display text-[15px] font-semibold">{group.label}</h2>
+          <span className="sys-label" style={{ fontSize: 10.5 }}>
+            {group.count}
+          </span>
+        </button>
       {open && (
         <div className="mt-1.5 flex flex-col gap-4">
           {group.users.map((bucket) => (
@@ -551,6 +565,8 @@ function DayGroup({
               <div className="mb-1 px-2 text-[11px] font-medium text-muted-foreground">{bucket.user}</div>
               <SessionsTable
                 sessions={bucket.sessions}
+                sort={sort}
+                onSort={onSort}
                 isPinned={isPinned}
                 onTogglePin={onTogglePin}
                 selectedIds={selectedIds}
@@ -567,6 +583,9 @@ function DayGroup({
 
 function FlatGroup({
   group,
+  sort,
+  onSort,
+  soleGroup,
   initialOpen,
   isPinned,
   onTogglePin,
@@ -575,6 +594,9 @@ function FlatGroup({
   drag,
 }: {
   group: SessionFlatGroup;
+  sort: SortKey;
+  onSort: (s: SortKey) => void;
+  soleGroup: boolean;
   initialOpen: boolean;
   isPinned: (sessionId: string) => boolean;
   onTogglePin: (sessionId: string) => void;
@@ -585,21 +607,27 @@ function FlatGroup({
   const [open, setOpen] = useState(initialOpen);
   return (
     <section>
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="flex w-full cursor-pointer items-center gap-2 rounded-md px-1 py-1 text-left hover:bg-raised"
-      >
-        <Chev open={open} />
-        <h2 className="m-0 font-display text-[15px] font-semibold">{group.label}</h2>
-        <span className="sys-label" style={{ fontSize: 10.5 }}>
-          {group.count}
-        </span>
-      </button>
-      {open && (
+      {/* Grouping that yields one group is not grouping — drawing "Unlabeled 7"
+          over the whole list only adds a lid to it. */}
+      {!soleGroup && (
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="flex w-full cursor-pointer items-center gap-2 rounded-md px-1 py-1 text-left hover:bg-raised"
+        >
+          <Chev open={open} />
+          <h2 className="m-0 font-display text-[15px] font-semibold">{group.label}</h2>
+          <span className="sys-label" style={{ fontSize: 10.5 }}>
+            {group.count}
+          </span>
+        </button>
+      )}
+      {(open || soleGroup) && (
         <div className="mt-1.5">
           <SessionsTable
             sessions={group.sessions}
+            sort={sort}
+            onSort={onSort}
             isPinned={isPinned}
             onTogglePin={onTogglePin}
             selectedIds={selectedIds}
@@ -612,43 +640,28 @@ function FlatGroup({
   );
 }
 
-function SegmentedControl<T extends string>({
-  label,
+function GroupBySelect({
   value,
-  options,
   onChange,
 }: {
-  label: string;
-  value: T;
-  options: { key: T; label: string }[];
-  onChange: (next: T) => void;
+  value: ViewKey;
+  onChange: (v: ViewKey) => void;
 }) {
   return (
-    <div className="inline-flex items-center gap-1.5 text-[12px]">
-      <span className="sys-label" style={{ fontSize: 10 }}>
-        {label}
-      </span>
-      <div className="inline-flex gap-1 rounded-full border border-border bg-surface/60 p-1 shadow-sm">
-        {options.map((opt) => {
-          const active = value === opt.key;
-          return (
-            <button
-              key={opt.key}
-              type="button"
-              onClick={() => onChange(opt.key)}
-              className={
-                "cursor-pointer rounded-full px-2.5 py-1 text-[12px] leading-none transition-colors " +
-                (active
-                  ? "bg-base font-semibold text-foreground shadow-sm"
-                  : "text-muted-foreground hover:bg-raised/70 hover:text-foreground")
-              }
-            >
-              {opt.label}
-            </button>
-          );
-        })}
-      </div>
-    </div>
+    <span className="flex items-center gap-1.5 text-[12px] text-muted-foreground">
+      Group
+      <CustomSelect
+        value={value}
+        onChange={(v) => onChange(v as ViewKey)}
+        ariaLabel="Group sessions by"
+        align="right"
+        options={VIEWS.map((v) => ({
+          value: v.key,
+          label: v.key === "list" ? "None" : v.label.slice(3, 4).toUpperCase() + v.label.slice(4),
+        }))}
+        className="cursor-pointer rounded-md border border-border bg-transparent px-2 py-1 text-[12.5px] text-foreground hover:bg-raised"
+      />
+    </span>
   );
 }
 
@@ -670,6 +683,8 @@ function Chev({ open }: { open: boolean }) {
 
 function SessionsTable({
   sessions,
+  sort,
+  onSort,
   isPinned,
   onTogglePin,
   selectedIds,
@@ -677,6 +692,8 @@ function SessionsTable({
   drag = NO_DRAG,
 }: {
   sessions: SessionSummary[];
+  sort: SortKey;
+  onSort: (s: SortKey) => void;
   isPinned: (sessionId: string) => boolean;
   onTogglePin: (sessionId: string) => void;
   selectedIds: Set<string>;
@@ -687,22 +704,34 @@ function SessionsTable({
     return <SessionsEmptyState withInstallCta />;
   }
 
+  // A column that never varies is not a column, it is a watermark: User is the
+  // same name on every row in a personal stash, and Ticket is empty until
+  // something links one. Both earn their place per listing, not globally.
+  const showUser = new Set(sessions.map((s) => s.user_name)).size > 1;
+  const showTicket = sessions.some((s) => primaryTicket(s) !== null);
+  const cols = gridColumns(showUser, showTicket);
+
   return (
-    <div className="overflow-hidden rounded-lg border border-border bg-surface">
-      <div className="hidden grid-cols-[minmax(128px,0.68fr)_minmax(240px,1.7fr)_86px_58px_minmax(104px,0.62fr)_94px_88px_28px] gap-3 border-b border-border bg-base/70 px-3 py-2 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground md:grid">
-        <span>User</span>
-        <span>Session</span>
-        <span>Ticket</span>
-        <span>Events</span>
-        <span>Agent</span>
-        <span>Date</span>
-        <span>Updated</span>
+    <div>
+      <div
+        className="hidden gap-3 border-b border-border px-3 pb-1.5 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground md:grid"
+        style={{ gridTemplateColumns: cols }}
+      >
+        {showUser && <span>User</span>}
+        <SessionSortHeader label="Session" column="name" sort={sort} onSort={onSort} />
+        {showTicket && <span>Ticket</span>}
+        <SessionSortHeader label="Events" column="events" sort={sort} onSort={onSort} />
+        <SessionSortHeader label="Agent" column="agent" sort={sort} onSort={onSort} />
+        <SessionSortHeader label="Updated" column="updated" sort={sort} onSort={onSort} />
         <span />
       </div>
       {sessions.map((session) => (
         <SessionTableRow
           key={session.session_id}
           session={session}
+          cols={cols}
+          showUser={showUser}
+          showTicket={showTicket}
           pinned={isPinned(session.session_id)}
           onTogglePin={onTogglePin}
           selected={selectedIds.has(session.session_id)}
@@ -714,8 +743,61 @@ function SessionsTable({
   );
 }
 
+/** Columns collapse out of the template entirely when they carry nothing, so
+ *  the remaining ones take the space instead of leaving a gap. */
+function gridColumns(showUser: boolean, showTicket: boolean): string {
+  return [
+    showUser ? "minmax(120px,0.6fr)" : null,
+    "minmax(240px,2fr)",
+    showTicket ? "86px" : null,
+    "58px",
+    "minmax(96px,0.55fr)",
+    "88px",
+    "28px",
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+// Sorting lives in the column headers, where a table keeps it. Updated toggles
+// between newest and oldest; the others are one-way orders.
+function SessionSortHeader({
+  label,
+  column,
+  sort,
+  onSort,
+}: {
+  label: string;
+  column: SortColumn;
+  sort: SortKey;
+  onSort: (s: SortKey) => void;
+}) {
+  const active = sort.column === column;
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        onSort({
+          column,
+          dir: active ? (sort.dir === "asc" ? "desc" : "asc") : FIRST_DIR[column],
+        })
+      }
+      className={
+        "flex cursor-pointer items-center gap-1 text-left text-[11px] font-medium uppercase tracking-[0.08em] hover:text-foreground " +
+        (active ? "text-foreground" : "text-muted-foreground")
+      }
+    >
+      {label}
+      {active && <span aria-hidden>{sort.dir === "asc" ? "\u25B2" : "\u25BC"}</span>}
+    </button>
+  );
+}
+
 function SessionTableRow({
   session,
+  cols,
+  showUser,
+  showTicket,
   pinned,
   onTogglePin,
   selected,
@@ -723,6 +805,9 @@ function SessionTableRow({
   drag,
 }: {
   session: SessionSummary;
+  cols: string;
+  showUser: boolean;
+  showTicket: boolean;
   pinned: boolean;
   onTogglePin: (sessionId: string) => void;
   selected: boolean;
@@ -750,15 +835,12 @@ function SessionTableRow({
       }}
       onDragEnd={() => drag.onActiveChange(false)}
       className={
-        "group/srow grid min-h-12 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-b border-border px-3 py-2 text-[13px] last:border-b-0 md:grid-cols-[minmax(128px,0.68fr)_minmax(240px,1.7fr)_86px_58px_minmax(104px,0.62fr)_94px_88px_28px] " +
-        (selected ? "bg-[var(--color-brand-50)]" : "hover:bg-[var(--color-brand-50)]")
+        "group/srow grid min-h-10 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-b border-border-subtle px-3 py-1.5 text-[13px] last:border-b-0 md:grid " +
+        (selected ? "bg-[var(--color-brand-50)]" : "hover:bg-[var(--color-brand-50)]/60")
       }
+      style={{ gridTemplateColumns: cols }}
     >
-      <div className="hidden min-w-0 items-center gap-2 md:flex">
-        <SelectBox
-          selected={selected}
-          onToggle={() => onToggleSelect(session.session_id)}
-        />
+      <div className={"min-w-0 items-center gap-2 " + (showUser ? "hidden md:flex" : "hidden")}>
         <span
           className={
             "inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[9px] font-semibold " +
@@ -773,7 +855,11 @@ function SessionTableRow({
       </div>
       <div className="min-w-0">
         <div className="flex min-w-0 items-center gap-2">
-          <div className="min-w-0 flex-1 truncate font-medium text-foreground">{sessionTitle(session)}</div>
+          <SelectBox
+            selected={selected}
+            onToggle={() => onToggleSelect(session.session_id)}
+          />
+          <div className="min-w-0 flex-1 truncate text-[13.5px] font-medium text-foreground">{sessionTitle(session)}</div>
           {ticket && (
             <span className="md:hidden">
               <LinearTicketPill ticket={ticket} compact />
@@ -786,18 +872,24 @@ function SessionTableRow({
             .join(", ")}
         </div>
       </div>
-      <span className="hidden min-w-0 md:block">
-        {ticket ? <LinearTicketPill ticket={ticket} /> : <span className="text-[11px] text-muted-foreground">None</span>}
-      </span>
+      {showTicket && (
+        <span className="hidden min-w-0 md:block">
+          {ticket ? (
+            <LinearTicketPill ticket={ticket} />
+          ) : (
+            <span className="text-[12px] text-muted-foreground/40">—</span>
+          )}
+        </span>
+      )}
       <span className="hidden items-center gap-1 text-[12px] text-muted-foreground md:flex">
         <MessageIcon />
         {session.event_count}
       </span>
-      <span className="hidden truncate text-muted-foreground md:block">{agent}</span>
-      <span className="hidden whitespace-nowrap text-[12px] text-muted-foreground md:block">
-        {formatDate(session.last_event_at || session.started_at)}
-      </span>
-      <span className="justify-self-end whitespace-nowrap text-[12px] text-muted-foreground">
+      <span className="hidden truncate text-[12px] text-muted-foreground md:block">{agent}</span>
+      <span
+        className="justify-self-end whitespace-nowrap text-[12px] text-muted-foreground"
+        title={formatDate(session.last_event_at || session.started_at)}
+      >
         {formatRelative(session.last_event_at)}
       </span>
       <span
@@ -906,7 +998,9 @@ function formatRelative(iso: string | null): string {
   if (diffH < 24) return `${diffH}h ago`;
   const diffD = Math.round(diffH / 24);
   if (diffD < 7) return `${diffD}d ago`;
-  return new Date(iso).toLocaleDateString();
+  // "Aug 4", not "8/4/2026": one column should not switch numbering systems
+  // partway down. The exact timestamp is on the row's title attribute.
+  return formatDate(iso);
 }
 
 function formatDate(iso: string | null): string {
@@ -1043,8 +1137,8 @@ function FolderCard({
         (over ? "border-[var(--color-brand-300)] ring-1 ring-inset ring-[var(--color-brand-300)]" : "border-border")
       }
     >
-      <span aria-hidden className="mt-0.5 text-[18px]">
-        {folder.is_default ? "🗃️" : "📁"}
+      <span aria-hidden className="mt-0.5 text-muted-foreground">
+        <FolderIcon />
       </span>
       <span className="min-w-0 flex-1">
         <span className="flex items-center gap-1.5">
@@ -1097,8 +1191,8 @@ function SharedFolderCard({
       onClick={onClick}
       className="flex cursor-pointer items-start gap-2.5 rounded-lg border border-border bg-surface/50 px-3 py-3 text-left transition hover:border-[var(--color-brand-300)] hover:bg-raised/50"
     >
-      <span aria-hidden className="mt-0.5 text-[18px]">
-        🗂️
+      <span aria-hidden className="mt-0.5 text-muted-foreground">
+        <FolderIcon />
       </span>
       <span className="min-w-0">
         <span className="block truncate text-[13.5px] font-semibold text-foreground">{name}</span>
@@ -1126,6 +1220,7 @@ function FolderDrill({
   drag,
   dragActive,
   onDropSessions,
+  onUploaded,
 }: {
   folder: OpenFolder;
   refreshKey: number;
@@ -1144,6 +1239,7 @@ function FolderDrill({
   drag: SessionDrag;
   dragActive: boolean;
   onDropSessions: (rowIds: string[], folderId: string) => void;
+  onUploaded: () => void;
 }) {
   const [folderSessions, setFolderSessions] = useState<SessionSummary[] | null>(null);
   const [hasMore, setHasMore] = useState(false);
@@ -1197,7 +1293,10 @@ function FolderDrill({
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     const el = sentinelRef.current;
-    if (!el || !hasMore || sort !== "recent") return;
+    // Newest-first is the server's own paging order, so appended pages land
+    // below the sentinel. Any other order would place them above it and
+    // cascade-load the whole folder.
+    if (!el || !hasMore || sort.column !== "updated" || sort.dir !== "desc") return;
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0]?.isIntersecting) loadMore();
@@ -1227,11 +1326,18 @@ function FolderDrill({
         </button>
       )}
       <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
-        <h2 className="m-0 flex items-center gap-2 font-display text-[18px] font-semibold text-foreground">
+        <h2 className="m-0 flex items-baseline gap-2 font-display text-[18px] font-semibold text-foreground">
           {!isAll && (
-            <span aria-hidden>{folder.shared ? "🗂️" : ownFolder?.is_default ? "🗃️" : "📁"}</span>
+            <span aria-hidden className="text-muted-foreground">
+              <FolderIcon />
+            </span>
           )}
-          {folder.name}
+          {isAll ? "Sessions" : folder.name}
+          {folderSessions !== null && (
+            <span className="text-[13px] font-normal text-muted-foreground">
+              {folderSessions.length}
+            </span>
+          )}
           {ownFolder && <FolderAccessBadge folder={ownFolder} />}
         </h2>
         {ownFolder && (
@@ -1274,19 +1380,12 @@ function FolderDrill({
             ))}
         </div>
       )}
-      <div className="mb-3 flex flex-wrap items-center gap-3 border-b border-border pb-2.5">
-        <SegmentedControl
-          label="View"
-          value={view}
-          options={VIEWS}
-          onChange={(v) => onChangeView(v as ViewKey)}
-        />
-        <SegmentedControl
-          label="Sort"
-          value={sort}
-          options={SORTS}
-          onChange={(v) => onChangeSort(v as SortKey)}
-        />
+      {/* Sorting moved into the column headers, where a table keeps it. What
+          is left is a group-by, and one quiet control says that better than
+          ten pills that outweighed the rows beneath them. */}
+      <div className="mb-2 flex flex-wrap items-center justify-end gap-2">
+        <GroupBySelect value={view} onChange={onChangeView} />
+        {!folder.shared && <SessionUpload onUploaded={onUploaded} bare />}
       </div>
       {folderSessions === null ? (
         <p className="text-[12.5px] text-muted-foreground">Loading…</p>
@@ -1296,6 +1395,8 @@ function FolderDrill({
             view={view}
             sessions={drillSessions}
             folders={folders}
+            sort={sort}
+            onSort={onChangeSort}
             isPinned={isPinned}
             onTogglePin={onTogglePin}
             selectedIds={folder.shared ? EMPTY_SELECTION : selectedIds}
@@ -1353,7 +1454,9 @@ function FolderDropChip({
           : "border-border bg-base text-dim")
       }
     >
-      <span aria-hidden>{folder.is_default ? "🗃️" : "📁"}</span>
+      <span aria-hidden>
+        <FolderIcon />
+      </span>
       {folder.name}
     </span>
   );
@@ -1362,11 +1465,19 @@ function FolderDropChip({
 const EMPTY_SELECTION: Set<string> = new Set();
 function noop() {}
 
+// Ascending comparators; descending reverses. Ties fall back to the title so
+// equal values keep a stable, readable order instead of shuffling per render.
 function sortSessions(list: SessionSummary[], sort: SortKey): SessionSummary[] {
-  const copy = [...list];
-  if (sort === "recent") copy.sort((a, b) => sessionTime(b) - sessionTime(a));
-  else if (sort === "oldest") copy.sort((a, b) => sessionTime(a) - sessionTime(b));
-  else if (sort === "events") copy.sort((a, b) => b.event_count - a.event_count);
-  else copy.sort((a, b) => sessionTitle(a).localeCompare(sessionTitle(b)));
-  return copy;
+  const byColumn = {
+    updated: (a: SessionSummary, b: SessionSummary) => sessionTime(a) - sessionTime(b),
+    events: (a: SessionSummary, b: SessionSummary) => a.event_count - b.event_count,
+    name: (a: SessionSummary, b: SessionSummary) =>
+      sessionTitle(a).localeCompare(sessionTitle(b)),
+    agent: (a: SessionSummary, b: SessionSummary) =>
+      (a.agent_name || "").localeCompare(b.agent_name || ""),
+  }[sort.column];
+  const copy = [...list].sort(
+    (a, b) => byColumn(a, b) || sessionTitle(a).localeCompare(sessionTitle(b)),
+  );
+  return sort.dir === "desc" ? copy.reverse() : copy;
 }

--- a/frontend/src/app/(app)/vfs/[[...path]]/page.tsx
+++ b/frontend/src/app/(app)/vfs/[[...path]]/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { useBreadcrumbs } from "@/components/BreadcrumbContext";
+import { FileBrowserSkeleton } from "@/components/SkeletonStates";
+import VfsBrowser from "@/components/content/vfs-browser/VfsBrowser";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function VfsPage() {
+  const router = useRouter();
+  const { user, loading } = useAuth();
+
+  useBreadcrumbs([{ label: "VFS", href: "/files" }], "files");
+
+  useEffect(() => {
+    if (!loading && !user) router.push("/login");
+  }, [user, loading, router]);
+
+  if (loading) return <FileBrowserSkeleton />;
+  if (!user) return null;
+
+  return <VfsBrowser />;
+}

--- a/frontend/src/app/(app)/viz/page.tsx
+++ b/frontend/src/app/(app)/viz/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import VisualizationsPage from "@/components/viz/VisualizationsPage";
+
+export default function VizRoute() {
+  return <VisualizationsPage />;
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -882,3 +882,33 @@ details > summary::-webkit-details-marker {
 .proseish code { font-family: var(--font-mono), monospace; color: #C2410C; background: var(--bg-raised); padding: 1px 5px; border-radius: 4px; font-size: 0.88em; }
 .proseish a { color: #F97316; text-decoration: underline; text-underline-offset: 2px; }
 .proseish blockquote { border-left: 3px solid var(--border-color); padding-left: 12px; color: var(--text-muted); margin: 10px 0; }
+
+/* === Hopper: the intake well ===
+   Per docs/design-system.md the app is industrial/utilitarian: typography and
+   colour do the work, no gradients or glow, and motion is minimal-functional.
+   So the well is a flat surface with a border, brand orange marks the active
+   state, and the only animation runs while a drop is actually in flight.
+   The texture is the landing page's warm dot-field (www/DESIGN.md), the
+   reusable brand motif — sparse and faded, not a grain overlay. */
+
+.hopper-well {
+  background-color: var(--bg-surface);
+  background-image: radial-gradient(rgb(50 47 41 / 0.05) 1px, transparent 1.4px);
+  background-size: 22px 22px;
+  /* A hairline plus the faintest top shading — just enough that the surface
+     sits below the page rather than floating on it. Anything heavier reads as
+     the gradient the kit rules out. */
+  box-shadow:
+    inset 0 0 0 1px var(--border-color),
+    inset 0 2px 4px -3px rgb(50 47 41 / 0.10);
+  transition: box-shadow 150ms ease-out, background-color 150ms ease-out;
+}
+
+.hopper-well[data-live="true"] {
+  background-color: color-mix(in oklab, var(--color-brand-500) 6%, var(--bg-surface));
+  box-shadow: inset 0 0 0 1px var(--color-brand-500);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hopper-well { transition: none; }
+}

--- a/frontend/src/components/CommandPalette.test.tsx
+++ b/frontend/src/components/CommandPalette.test.tsx
@@ -57,6 +57,8 @@ const sidebar = {
         name: "Launch Roadmap.md",
         content_type: "markdown" as const,
         folder_id: null,
+        updated_at: "2026-01-01T00:00:00Z",
+        last_edit_agent_name: null,
       },
     ],
     files: [],

--- a/frontend/src/components/CopyableCommandBlock.tsx
+++ b/frontend/src/components/CopyableCommandBlock.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+import { toast } from "sonner";
 
 const COPIED_RESET_MS = 1500;
 
@@ -9,23 +11,38 @@ const COPIED_RESET_MS = 1500;
 export default function CopyableCommandBlock({ commands }: { commands: string }) {
   const [copied, setCopied] = useState(false);
 
+  // The Clipboard API rejects for reasons the page can't prevent — a denied
+  // permission, an unfocused document, an embedded context. Unhandled, the
+  // button just does nothing and the user has no idea the copy failed.
   async function copy() {
-    await navigator.clipboard.writeText(commands);
+    try {
+      await navigator.clipboard.writeText(commands);
+    } catch {
+      toast.error("Couldn't copy — select the command and copy it manually.");
+      return;
+    }
     setCopied(true);
     setTimeout(() => setCopied(false), COPIED_RESET_MS);
   }
 
   return (
-    <div className="relative inline-block text-left">
-      <pre className="overflow-x-auto rounded-md border border-border bg-surface px-3 py-2 pr-16 font-mono text-[11.5px] leading-relaxed text-foreground">
+    <div className="relative inline-block max-w-full text-left">
+      {/* Wrap rather than scroll: a scrolling line slides underneath the
+          absolutely-positioned copy button, which reads as broken in a narrow
+          container like a dialog. */}
+      <pre className="whitespace-pre-wrap break-all rounded-md border border-border bg-surface px-3 py-2.5 pr-10 font-mono text-[11.5px] leading-relaxed text-foreground">
         {commands}
       </pre>
+      {/* Icon-only, so a long command keeps as much width as possible and the
+          block reads as code rather than as a form control. */}
       <button
         type="button"
         onClick={() => void copy()}
-        className="absolute right-1.5 top-1.5 cursor-pointer rounded border border-border bg-base px-1.5 py-0.5 text-[10.5px] font-medium text-muted-foreground hover:text-foreground"
+        aria-label={copied ? "Copied" : "Copy to clipboard"}
+        title={copied ? "Copied" : "Copy"}
+        className="absolute right-1.5 top-1.5 cursor-pointer rounded p-1.5 text-muted-foreground transition-colors hover:bg-raised hover:text-foreground"
       >
-        {copied ? "Copied" : "Copy"}
+        {copied ? <Check className="h-3.5 w-3.5 text-success" /> : <Copy className="h-3.5 w-3.5" />}
       </button>
     </div>
   );

--- a/frontend/src/components/HopperIcon.tsx
+++ b/frontend/src/components/HopperIcon.tsx
@@ -1,0 +1,25 @@
+/** The Minecraft hopper the feature is named after: a wide open mouth, walls
+ *  tapering in, and a spout underneath. Drawn to lucide's conventions (24-unit
+ *  grid, 1.5 stroke, currentColor) so it sits correctly beside the rail's
+ *  other icons. */
+export default function HopperIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      {/* One continuous silhouette — wide mouth, shoulders angling in, square
+          spout. Drawn as a single outline rather than stacked boxes: at 18px
+          the internal edges of separate shapes merge into mush. */}
+      <path d="M3 4h18v6h-3l-3.5 4v4h-5v-4L6 10H3z" />
+      {/* the lip, which makes the top read as an open container */}
+      <path d="M3 10h18" />
+    </svg>
+  );
+}

--- a/frontend/src/components/SessionUpload.tsx
+++ b/frontend/src/components/SessionUpload.tsx
@@ -1,12 +1,20 @@
 "use client";
 
-import { useRef, useState, type DragEvent } from "react";
+import { useEffect, useRef, useState, type DragEvent } from "react";
+
+// The window listeners see the DOM event, not React's synthetic one.
+type DragEvent_ = globalThis.DragEvent;
 import { uploadTranscript } from "../lib/api";
 
 type Status = "idle" | "uploading" | "done" | "error";
 
 interface SessionUploadProps {
   onUploaded?: () => void;
+  /** Bare renders just the button and watches the window for a file drag,
+   *  showing the drop target only once one is in flight. A permanent dashed
+   *  box spends the top of the page on an action almost nobody takes —
+   *  transcripts arrive from the plugin, not by hand. */
+  bare?: boolean;
 }
 
 function isJsonl(file: File): boolean {
@@ -17,7 +25,7 @@ function defaultSessionId(file: File): string {
   return file.name.replace(/\.jsonl$/i, "").trim();
 }
 
-export default function SessionUpload({ onUploaded }: SessionUploadProps) {
+export default function SessionUpload({ onUploaded, bare = false }: SessionUploadProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [dragActive, setDragActive] = useState(false);
   const [status, setStatus] = useState<Status>("idle");
@@ -73,12 +81,87 @@ export default function SessionUpload({ onUploaded }: SessionUploadProps) {
     if (file) handleFile(file);
   }
 
+  // In bare mode the window is the drop target, so a transcript can be dropped
+  // anywhere on the page and the invitation only appears while one is in the
+  // air. A counter keeps the overlay steady across child dragleave events.
+  const dragDepth = useRef(0);
+  useEffect(() => {
+    if (!bare) return;
+    function isFileDrag(e: DragEvent_) {
+      return Array.from(e.dataTransfer?.types ?? []).includes("Files");
+    }
+    function onEnter(e: DragEvent_) {
+      if (!isFileDrag(e)) return;
+      dragDepth.current += 1;
+      setDragActive(true);
+    }
+    function onLeave(e: DragEvent_) {
+      if (!isFileDrag(e)) return;
+      dragDepth.current = Math.max(0, dragDepth.current - 1);
+      if (dragDepth.current === 0) setDragActive(false);
+    }
+    function onOver(e: DragEvent_) {
+      if (!isFileDrag(e)) return;
+      e.preventDefault();
+    }
+    function onDrop(e: DragEvent_) {
+      if (!isFileDrag(e)) return;
+      e.preventDefault();
+      dragDepth.current = 0;
+      setDragActive(false);
+      const file = e.dataTransfer?.files?.[0];
+      if (file) handleFile(file);
+    }
+    window.addEventListener("dragenter", onEnter);
+    window.addEventListener("dragleave", onLeave);
+    window.addEventListener("dragover", onOver);
+    window.addEventListener("drop", onDrop);
+    return () => {
+      window.removeEventListener("dragenter", onEnter);
+      window.removeEventListener("dragleave", onLeave);
+      window.removeEventListener("dragover", onOver);
+      window.removeEventListener("drop", onDrop);
+    };
+  });
+
   const tone =
     status === "error"
       ? "text-red-600"
       : status === "done"
         ? "text-[var(--color-brand-700)]"
         : "text-muted-foreground";
+
+  if (bare) {
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          disabled={status === "uploading"}
+          className="cursor-pointer rounded-md border border-border bg-base px-2.5 py-1 text-[12.5px] font-medium text-foreground hover:bg-raised disabled:opacity-50"
+        >
+          {status === "uploading" ? "Uploading…" : "Add session"}
+        </button>
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".jsonl"
+          className="hidden"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            if (file) handleFile(file);
+            event.target.value = "";
+          }}
+        />
+        {message && <span className={"text-[12px] " + tone}>{message}</span>}
+        {dragActive && (
+          <div className="pointer-events-none fixed inset-4 z-50 flex items-center justify-center rounded-2xl border-2 border-dashed border-[var(--color-brand-400)] bg-[var(--color-brand-50)]/80 text-[14px] font-medium text-[var(--color-brand-700)]">
+            Drop a .jsonl transcript
+          </div>
+        )}
+      </>
+    );
+  }
 
   return (
     <div

--- a/frontend/src/components/content/FileViewerHeader.tsx
+++ b/frontend/src/components/content/FileViewerHeader.tsx
@@ -13,11 +13,6 @@ interface BackLink {
   href: string;
 }
 
-interface Breadcrumb {
-  label: string;
-  href: string;
-}
-
 interface Tag {
   label: string;
   tone?: "brand" | "muted";
@@ -38,9 +33,6 @@ interface FileViewerHeaderProps {
   readOnlyLabel?: string;
   /** Back link rendered above the title (e.g. "← Demo Skill"). */
   backLink?: BackLink;
-  /** Ancestor trail rendered before the title in the compact bar
-   *  (e.g. Files / Research / — the title itself is the last crumb). */
-  breadcrumbs?: Breadcrumb[];
   /** Small label chips before the meta items. */
   tags?: Tag[];
   /**
@@ -74,7 +66,6 @@ export default function FileViewerHeader({
   readOnly,
   readOnlyLabel = "read-only",
   backLink,
-  breadcrumbs,
   tags,
   meta,
   saveStatus,
@@ -96,12 +87,6 @@ export default function FileViewerHeader({
           <span className="text-muted-foreground/50">/</span>
         </span>
       )}
-      {breadcrumbs?.map((crumb) => (
-        <span key={crumb.href} className="hidden shrink-0 items-center gap-2.5 text-[12.5px] text-muted-foreground sm:inline-flex">
-          <Link href={crumb.href} className="max-w-[160px] truncate hover:text-foreground">{crumb.label}</Link>
-          <span className="text-muted-foreground/50">/</span>
-        </span>
-      ))}
       <span className="min-w-0 shrink truncate text-[13.5px] font-semibold text-foreground">
         {readOnly || !onRenameTitle ? title : <EditableTitle value={title} onSave={onRenameTitle} />}
       </span>

--- a/frontend/src/components/content/file-browser/ItemsList.test.tsx
+++ b/frontend/src/components/content/file-browser/ItemsList.test.tsx
@@ -68,35 +68,36 @@ describe("ItemsList type filter", () => {
     );
   }
 
-  it("hides non-document types by default so uploads don't clutter the view", () => {
+  it("shows every type by default, uploads included", () => {
     renderMixedList();
 
-    // HTML/Markdown/folders are the default doc set; the PNG stays hidden until
-    // it's explicitly chosen from the Type menu.
-    expect(screen.getByText(item.name)).toBeDefined();
-    expect(screen.queryByText(png.name)).toBeNull();
-  });
-
-  it("reveals every type via All types", () => {
-    renderMixedList();
-
-    fireEvent.click(screen.getByRole("button", { name: /^Type$/i }));
-    fireEvent.click(screen.getByRole("button", { name: "All types" }));
-
+    // This used to open on documents only, which meant a folder of
+    // screenshots read as "Empty folder" while the tree beside it counted
+    // six. A file browser that hides files is the wrong kind of tidy.
     expect(screen.getByText(item.name)).toBeDefined();
     expect(screen.getByText(png.name)).toBeDefined();
   });
 
-  it("returns to the document set via Documents only", () => {
+  it("narrows to the document set via Documents only", () => {
     renderMixedList();
 
     fireEvent.click(screen.getByRole("button", { name: /^Type$/i }));
-    fireEvent.click(screen.getByRole("button", { name: "All types" }));
-    fireEvent.click(screen.getByRole("button", { name: /^Type: All$/i }));
     fireEvent.click(screen.getByRole("button", { name: "Documents only" }));
 
     expect(screen.getByText(item.name)).toBeDefined();
     expect(screen.queryByText(png.name)).toBeNull();
+  });
+
+  it("returns to everything via All types", () => {
+    renderMixedList();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Type$/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Documents only" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Type: Documents$/i }));
+    fireEvent.click(screen.getByRole("button", { name: "All types" }));
+
+    expect(screen.getByText(item.name)).toBeDefined();
+    expect(screen.getByText(png.name)).toBeDefined();
   });
 
   it("narrows the list to the chosen type", () => {

--- a/frontend/src/components/content/file-browser/ItemsList.tsx
+++ b/frontend/src/components/content/file-browser/ItemsList.tsx
@@ -94,14 +94,16 @@ const SORT_STORAGE_KEY = "stash_files_sort";
 
 const DEFAULT_SORT: Sort = { key: "modified", dir: "desc" };
 
-// The List view opens on documents only — folders plus the page types people
-// author (HTML, Markdown). Other file types (PDFs, images, tables) stay hidden
-// until chosen from the Type menu, so uploads don't clutter the default view.
-// `typeFilter === null` means this doc set; ALL_TYPES means show everything.
-// Tables are first-class residents of the folder tree, so they show by
-// default like documents do.
-const DEFAULT_TYPES = new Set(["Folder", "HTML", "Markdown", "Table"]);
-const ALL_TYPES = "__all__";
+// The List view shows everything a folder holds. It used to open on documents
+// only — folders, HTML, Markdown, Table — so uploads would not "clutter" it,
+// but that predates a product whose front door is uploads: a folder of
+// screenshots read as "Empty folder" while the tree beside it counted six.
+// A file browser that hides files is the wrong kind of tidy.
+//
+// `typeFilter === null` now means everything; DOC_TYPES stays as the explicit
+// "Documents only" choice in the Type menu.
+const DOC_TYPES = new Set(["Folder", "HTML", "Markdown", "Table"]);
+const DOCS_ONLY = "__docs__";
 
 function readSort(): Sort {
   if (typeof window === "undefined") return null;
@@ -165,20 +167,16 @@ export default function ItemsList({
     applySort(next);
   }
 
-  // Only the non-default types are pickable here; folders/HTML/Markdown already
-  // show by default, so the menu is purely for revealing the other types.
+  // Every type present, so the menu can narrow to any one of them.
   const typeOptions = useMemo(
-    () =>
-      Array.from(new Set(items.map(typeFor)))
-        .filter((type) => !DEFAULT_TYPES.has(type))
-        .sort(),
+    () => Array.from(new Set(items.map(typeFor))).sort(),
     [items],
   );
 
   const sortedItems = useMemo(() => {
     const visible = items.filter((item) => {
-      if (typeFilter === null) return DEFAULT_TYPES.has(typeFor(item));
-      if (typeFilter === ALL_TYPES) return true;
+      if (typeFilter === null) return true;
+      if (typeFilter === DOCS_ONLY) return DOC_TYPES.has(typeFor(item));
       return typeFor(item) === typeFilter;
     });
     if (!sort) return visible;
@@ -224,7 +222,7 @@ export default function ItemsList({
         ))}
         {sortedItems.length === 0 && (
           <div className="px-4 py-10 text-center text-[12.5px] text-muted-foreground">
-            {typeFilter && typeFilter !== ALL_TYPES
+            {typeFilter && typeFilter !== DOCS_ONLY
               ? `No ${typeFilter} items here.`
               : "Empty folder."}
           </div>
@@ -314,8 +312,8 @@ function TypeHeader({
       >
         {filter === null
           ? "Type"
-          : filter === ALL_TYPES
-            ? "Type: All"
+          : filter === DOCS_ONLY
+            ? "Type: Documents"
             : `Type: ${filter}`}
         {sortActive && <span className="text-[9px]">{sort?.dir === "desc" ? "▼" : "▲"}</span>}
         <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
@@ -327,8 +325,8 @@ function TypeHeader({
           <MenuItem label="Sort A → Z" checked={sortActive && sort?.dir === "asc"} onSelect={() => choose(() => onSort("asc"))} />
           <MenuItem label="Sort Z → A" checked={sortActive && sort?.dir === "desc"} onSelect={() => choose(() => onSort("desc"))} />
           <div className="my-1 border-t border-border" />
-          <MenuItem label="Documents only" checked={filter === null} onSelect={() => choose(() => onFilter(null))} />
-          <MenuItem label="All types" checked={filter === ALL_TYPES} onSelect={() => choose(() => onFilter(ALL_TYPES))} />
+          <MenuItem label="All types" checked={filter === null} onSelect={() => choose(() => onFilter(null))} />
+          <MenuItem label="Documents only" checked={filter === DOCS_ONLY} onSelect={() => choose(() => onFilter(DOCS_ONLY))} />
           {options.map((type) => (
             <MenuItem key={type} label={type} checked={filter === type} onSelect={() => choose(() => onFilter(type))} />
           ))}

--- a/frontend/src/components/content/file-browser/ItemsList.tsx
+++ b/frontend/src/components/content/file-browser/ItemsList.tsx
@@ -73,21 +73,32 @@ export function isFbDrag(e: DragEvent<HTMLElement>): boolean {
 // inline style. Keeps the four-column Drive-style layout: name takes 2fr,
 // modified + type each take 1fr, action button is fixed 36px.
 const LIST_GRID_COLS = "minmax(0,2fr) minmax(0,1fr) minmax(0,1fr) 64px";
+// With a detail column ("Agent" on /sessions), Name yields the width for it.
+const LIST_GRID_COLS_DETAIL =
+  "minmax(0,2fr) minmax(0,1fr) minmax(0,1fr) minmax(0,1fr) 64px";
 
 interface Props {
   items: GridItem[];
   onNavigate: (item: GridItem, options?: NavigateOptions) => void;
-  onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
-  onReparentMany: (payloads: FBDragPayload[], targetFolderId: string | null) => Promise<void>;
-  onDelete: (item: GridItem) => Promise<void>;
-  isPinned: (item: GridItem) => boolean;
-  onTogglePin: (item: GridItem) => void;
-  selectedIds: Set<string>;
-  onToggleSelect: (item: GridItem) => void;
-  selectedDragPayloads: FBDragPayload[];
+  /** Header for the optional secondary column. A listing where every row has
+   *  the same Type ("Session") wastes that column; the mount says what the
+   *  useful fact is instead — the agent that ran it, the skill's contents. */
+  detailColumn?: string;
+  // Everything below is a capability, not a callback the caller may stub: the
+  // VFS mounts that are not files (sessions, skills, source documents) have no
+  // reparent, pin, or delete, so they pass nothing and the row renders without
+  // those controls rather than offering one that does nothing.
+  onReparent?: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
+  onReparentMany?: (payloads: FBDragPayload[], targetFolderId: string | null) => Promise<void>;
+  onDelete?: (item: GridItem) => Promise<void>;
+  isPinned?: (item: GridItem) => boolean;
+  onTogglePin?: (item: GridItem) => void;
+  selectedIds?: Set<string>;
+  onToggleSelect?: (item: GridItem) => void;
+  selectedDragPayloads?: FBDragPayload[];
 }
 
-type SortKey = "name" | "modified" | "type";
+type SortKey = "name" | "modified" | "type" | "detail";
 type Sort = { key: SortKey; dir: "asc" | "desc" } | null;
 
 const SORT_STORAGE_KEY = "stash_files_sort";
@@ -127,6 +138,9 @@ function timeOf(item: GridItem): number {
 function compareItems(a: GridItem, b: GridItem, key: SortKey): number {
   if (key === "modified") return timeOf(a) - timeOf(b) || a.name.localeCompare(b.name);
   if (key === "type") return typeFor(a).localeCompare(typeFor(b)) || a.name.localeCompare(b.name);
+  if (key === "detail") {
+    return (a.detail ?? "").localeCompare(b.detail ?? "") || a.name.localeCompare(b.name);
+  }
   return a.name.localeCompare(b.name);
 }
 
@@ -137,6 +151,7 @@ function compareItems(a: GridItem, b: GridItem, key: SortKey): number {
 export default function ItemsList({
   items,
   onNavigate,
+  detailColumn,
   onReparent,
   onReparentMany,
   onDelete,
@@ -150,10 +165,15 @@ export default function ItemsList({
   const [typeFilter, setTypeFilter] = useState<string | null>(null);
 
   function applySort(next: NonNullable<Sort>) {
-    try {
-      window.localStorage.setItem(SORT_STORAGE_KEY, `${next.key}:${next.dir}`);
-    } catch {
-      /* ignore */
+    // The detail column belongs to one listing, but the sort preference is
+    // shared across every file browser — persisting "detail" would silently
+    // reset the user's Files sort to the default on the next load.
+    if (next.key !== "detail") {
+      try {
+        window.localStorage.setItem(SORT_STORAGE_KEY, `${next.key}:${next.dir}`);
+      } catch {
+        /* ignore */
+      }
     }
     setSort(next);
   }
@@ -191,9 +211,12 @@ export default function ItemsList({
     <div className="rounded-xl border border-border bg-surface">
       <div
         className="grid items-center gap-3 rounded-t-xl border-b border-border bg-base/60 px-4 py-2.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground"
-        style={{ gridTemplateColumns: LIST_GRID_COLS }}
+        style={{ gridTemplateColumns: detailColumn ? LIST_GRID_COLS_DETAIL : LIST_GRID_COLS }}
       >
         <SortHeader label="Name" sortKey="name" sort={sort} onSort={toggleSort} />
+        {detailColumn && (
+          <SortHeader label={detailColumn} sortKey="detail" sort={sort} onSort={toggleSort} />
+        )}
         <SortHeader label="Modified" sortKey="modified" sort={sort} onSort={toggleSort} />
         <TypeHeader
           sort={sort}
@@ -210,12 +233,13 @@ export default function ItemsList({
             key={`${item.kind}-${item.id}`}
             item={item}
             onNavigate={onNavigate}
+            hasDetail={detailColumn !== undefined}
             onReparent={onReparent}
             onReparentMany={onReparentMany}
             onDelete={onDelete}
-            pinned={isPinned(item)}
+            pinned={isPinned ? isPinned(item) : false}
             onTogglePin={onTogglePin}
-            selected={selectedIds.has(item.id)}
+            selected={selectedIds ? selectedIds.has(item.id) : false}
             onToggleSelect={onToggleSelect}
             selectedDragPayloads={selectedDragPayloads}
           />
@@ -364,6 +388,7 @@ function MenuItem({
 function Row({
   item,
   onNavigate,
+  hasDetail,
   onReparent,
   onReparentMany,
   onDelete,
@@ -375,14 +400,15 @@ function Row({
 }: {
   item: GridItem;
   onNavigate: (item: GridItem, options?: NavigateOptions) => void;
-  onReparent: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
-  onReparentMany: (payloads: FBDragPayload[], targetFolderId: string | null) => Promise<void>;
-  onDelete: (item: GridItem) => Promise<void>;
+  hasDetail: boolean;
+  onReparent?: (payload: FBDragPayload, targetFolderId: string | null) => Promise<void>;
+  onReparentMany?: (payloads: FBDragPayload[], targetFolderId: string | null) => Promise<void>;
+  onDelete?: (item: GridItem) => Promise<void>;
   pinned: boolean;
-  onTogglePin: (item: GridItem) => void;
+  onTogglePin?: (item: GridItem) => void;
   selected: boolean;
-  onToggleSelect: (item: GridItem) => void;
-  selectedDragPayloads: FBDragPayload[];
+  onToggleSelect?: (item: GridItem) => void;
+  selectedDragPayloads?: FBDragPayload[];
 }) {
   const [over, setOver] = useState(false);
   const isFolder = item.kind === "folder";
@@ -398,12 +424,12 @@ function Row({
       onKeyDown={(e) => {
         if (e.key === "Enter") onNavigate(item);
       }}
-      draggable={item.movable !== false}
+      draggable={onReparent !== undefined && item.movable !== false}
       onDragStart={(e: DragEvent<HTMLDivElement>) =>
-        startItemDrag(e, item, selected, selectedDragPayloads)
+        startItemDrag(e, item, selected, selectedDragPayloads ?? [])
       }
       onDragOver={(e) => {
-        if (!isFolder) return;
+        if (!isFolder || !onReparent) return;
         if (!isFbDrag(e)) return;
         e.preventDefault();
         e.dataTransfer.dropEffect = "move";
@@ -411,7 +437,7 @@ function Row({
       }}
       onDragLeave={() => setOver(false)}
       onDrop={(e) => {
-        if (!isFolder) return;
+        if (!isFolder || !onReparent || !onReparentMany) return;
         setOver(false);
         e.preventDefault();
         handleFolderDrop(e, item.id, onReparent, onReparentMany);
@@ -423,21 +449,32 @@ function Row({
           : "hover:bg-[var(--color-brand-50)]/50 ") +
         (over ? "ring-1 ring-inset ring-[var(--color-brand-300)]" : "")
       }
-      style={{ gridTemplateColumns: LIST_GRID_COLS }}
+      style={{ gridTemplateColumns: hasDetail ? LIST_GRID_COLS_DETAIL : LIST_GRID_COLS }}
     >
       <div className="flex min-w-0 items-center gap-2.5">
-        <SelectBox
-          selected={selected}
-          onToggle={() => onToggleSelect(item)}
-        />
-        <span className={"flex h-4 w-4 flex-shrink-0 items-center justify-center " + tintFor(item)}>
-          <KindIcon kind={item.kind} />
+        {onToggleSelect && (
+          <SelectBox
+            selected={selected}
+            onToggle={() => onToggleSelect(item)}
+          />
+        )}
+        <span
+          className={
+            "flex h-4 w-4 flex-shrink-0 items-center justify-center [&_svg]:h-[15px] [&_svg]:w-[15px] [&_img]:h-[15px] [&_img]:w-[15px] " +
+            tintFor(item)
+          }
+        >
+          {item.icon ?? <KindIcon kind={item.kind} />}
         </span>
         <span className="min-w-0 truncate font-medium text-foreground">{item.name}</span>
       </div>
+      {hasDetail && (
+        <span className="truncate text-[12px] text-muted-foreground">{item.detail ?? "—"}</span>
+      )}
       <span className="truncate text-[12px] text-muted-foreground">{formatRelative(item.updatedAt)}</span>
       <span className="truncate text-[12px] text-muted-foreground">{typeFor(item)}</span>
       <div className="flex items-center justify-end gap-0.5">
+        {onTogglePin && (
         <button
           type="button"
           onClick={(e) => {
@@ -456,6 +493,8 @@ function Row({
         >
           <PinIcon className="text-[15px]" />
         </button>
+        )}
+        {onDelete && (
         <button
           type="button"
           onClick={(e) => {
@@ -474,6 +513,7 @@ function Row({
             <path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2" />
           </svg>
         </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/content/file-browser/kind.tsx
+++ b/frontend/src/components/content/file-browser/kind.tsx
@@ -1,9 +1,24 @@
+import type { ReactNode } from "react";
+import { GraduationCap, MessagesSquare } from "lucide-react";
 import { FileIcon, FolderIcon, PageIcon, TableIcon } from "../../SkillIcons";
 
 // "table" = a CSV/spreadsheet *file* linked to a table; "datatable" = a
 // standalone structured-data table (the `tables` entity). Both render with the
 // table icon, but they have different backing rows so move/delete/nav differ.
-export type ItemKind = "folder" | "page" | "html" | "table" | "datatable" | "file";
+// The last three are VFS mounts that are not files: /sessions, /skills, and
+// the documents inside /sources. They list in the same browser as files
+// because that is what the VFS shows an agent, but they are not stored as
+// files and carry none of the file operations.
+export type ItemKind =
+  | "folder"
+  | "page"
+  | "html"
+  | "table"
+  | "datatable"
+  | "file"
+  | "session"
+  | "skill"
+  | "source-doc";
 
 export interface GridItem {
   kind: ItemKind;
@@ -19,17 +34,29 @@ export interface GridItem {
   /** ISO timestamp. Renders as "Modified" in the Drive-style List view.
    *  Not all rows have one — FolderContents.pages currently omits it. */
   updatedAt?: string;
+  /** The one secondary fact worth a column in this listing — the agent that
+   *  ran a session, what a skill contains. Rendered only when the caller asks
+   *  for a detail column. */
+  detail?: string;
+  /** Row icon that overrides the kind icon — connected sources wear their
+   *  own brand mark, which is how you tell gmail from slack at a glance. */
+  icon?: ReactNode;
 }
 
 export function KindIcon({ kind }: { kind: ItemKind }) {
   if (kind === "folder") return <FolderIcon />;
   if (kind === "page" || kind === "html") return <PageIcon />;
   if (kind === "table" || kind === "datatable") return <TableIcon />;
+  if (kind === "session") return <MessagesSquare className="h-[15px] w-[15px]" />;
+  if (kind === "skill") return <GraduationCap className="h-[15px] w-[15px]" />;
   return <FileIcon />;
 }
 
 export function tintFor(item: GridItem): string {
   if (item.kind === "folder") return "text-muted-foreground";
+  if (item.kind === "session") return "text-chart-1";
+  if (item.kind === "skill") return "text-chart-3";
+  if (item.kind === "source-doc") return "text-muted-foreground";
   if (item.kind === "html") return "text-[#D97706]";
   if (item.kind === "table" || item.kind === "datatable") return "text-emerald-600";
   if (item.contentType?.includes("pdf")) return "text-rose-500";
@@ -40,6 +67,9 @@ export function tintFor(item: GridItem): string {
 
 export function typeFor(item: GridItem): string {
   if (item.kind === "folder") return "Folder";
+  if (item.kind === "session") return "Session";
+  if (item.kind === "skill") return "Skill";
+  if (item.kind === "source-doc") return "Document";
   if (item.kind === "table" || item.kind === "datatable") return "Table";
   if (item.kind === "html") return "HTML";
   if (item.kind === "page") return "Markdown";

--- a/frontend/src/components/content/files-overview/FilesOverview.test.tsx
+++ b/frontend/src/components/content/files-overview/FilesOverview.test.tsx
@@ -42,7 +42,7 @@ function sidebar() {
       // 12 pages inside Research: enough to trip the per-directory cap.
       pages: Array.from({ length: 12 }, (_, i) => ({
         id: `p${i}`, name: `Page ${String(i).padStart(2, "0")}`,
-        content_type: "markdown" as const, folder_id: "root-1",
+        content_type: "markdown" as const, folder_id: "root-1", updated_at: "2026-01-01T00:00:00Z", last_edit_agent_name: null,
       })),
       files: [],
     },

--- a/frontend/src/components/content/files-overview/build.test.ts
+++ b/frontend/src/components/content/files-overview/build.test.ts
@@ -25,8 +25,8 @@ const tree: FilesTree = {
     { id: "m1", name: "People", parent_folder_id: MEMORY_ID, page_count: 2, file_count: 0 },
   ],
   pages: [
-    { id: "p1", name: "Notes", content_type: "markdown", folder_id: "a" },
-    { id: "p2", name: "Root page", content_type: "markdown", folder_id: null },
+    { id: "p1", name: "Notes", content_type: "markdown", folder_id: "a", updated_at: "2026-01-01T00:00:00Z", last_edit_agent_name: null },
+    { id: "p2", name: "Root page", content_type: "markdown", folder_id: null, updated_at: "2026-01-01T00:00:00Z", last_edit_agent_name: null },
   ],
   files: [
     {

--- a/frontend/src/components/content/files-overview/build.ts
+++ b/frontend/src/components/content/files-overview/build.ts
@@ -36,6 +36,10 @@ export interface VNode {
   icon?: ReactNode;
   /** Where this subtree's "+N more" rows should take the user. */
   moreHref?: string;
+  /** ISO timestamp, when the entry has one — the browse view sorts on it. */
+  updatedAt?: string;
+  /** The one secondary fact the browse view gives a column to. */
+  detail?: string;
 }
 
 function byName<T extends { name: string }>(a: T, b: T): number {
@@ -129,14 +133,36 @@ export function buildFilesNodes(
 // Session and skill hrefs carry ?section=files: these nodes are only rendered
 // by VFS surfaces (the /files lens and the docked tree), and the stamp keeps
 // the VFS docked when one opens instead of teleporting to another section.
+// The four files stashvfs materializes inside every session directory
+// (stashvfs/model.py::_add_sessions). They all open the session itself: the
+// point of the drill-down is seeing what an agent can read, not four
+// destinations.
+const SESSION_FILES = ["metadata.json", "events.json", "transcript.jsonl", "transcript.md"];
+
 export function buildSessionNodes(sessions: SidebarSession[]): VNode[] {
-  return sessions.map((s) => ({
-    key: s.session_id,
-    kind: "session",
-    name: s.title || s.agent_name || "session",
-    href: `/sessions/${s.session_id}?section=files`,
-    annotation: [s.agent_name, timeAgo(s.last_at)].filter(Boolean).join(", "),
-  }));
+  return sessions.map((s) => {
+    const href = `/sessions/${s.session_id}?section=files`;
+    return {
+      key: s.session_id,
+      kind: "session",
+      name: s.title || s.agent_name || "session",
+      href,
+      annotation: [s.agent_name, timeAgo(s.last_at)].filter(Boolean).join(", "),
+      updatedAt: s.last_at,
+      // "Henry's codex", not "codex": in a shared scope the same agent runs for
+      // several people, and whose run it was is the thing you scan for.
+      detail: s.user_name ? `${s.user_name}’s ${s.agent_name}` : s.agent_name,
+      // A session is a directory in the VFS, so it is one here too — that
+      // nesting is what the browse view has that a flat list does not.
+      children: SESSION_FILES.map((name) => ({
+        key: `${s.session_id}/${name}`,
+        kind: "file" as const,
+        name,
+        href,
+        updatedAt: s.last_at,
+      })),
+    };
+  });
 }
 
 export function buildSkillNodes(skills: Skill[]): VNode[] {
@@ -145,6 +171,13 @@ export function buildSkillNodes(skills: Skill[]): VNode[] {
     kind: "skill",
     name: s.name,
     href: `/skills/folder/${s.folder_id}?section=files`,
+    updatedAt: s.updated_at,
+    detail: [
+      `${s.file_count} file${s.file_count === 1 ? "" : "s"}`,
+      s.published ? "published" : null,
+    ]
+      .filter(Boolean)
+      .join(", "),
     annotation: [
       `${s.file_count} file${s.file_count === 1 ? "" : "s"}`,
       s.published ? "published" : null,

--- a/frontend/src/components/content/files-overview/useVfsMounts.tsx
+++ b/frontend/src/components/content/files-overview/useVfsMounts.tsx
@@ -34,6 +34,10 @@ export interface Mount {
   icon: ReactNode;
   nodes: VNode[];
   href?: string;
+  /** Header for the browse view's secondary column, when this mount has one
+   *  fact worth scanning down. Type earns nothing there — every row in
+   *  /sessions is a Session. */
+  detailLabel?: string;
   /** Rows the API cut off before we ever saw them (sources per-dir cap). */
   apiHidden?: number;
   /** Where "+N more" rows we can't expand locally should take the user. */
@@ -115,13 +119,15 @@ export function useVfsMounts(): {
         path: "/files",
         icon: <FolderTree className="h-4 w-4 text-chart-4" />,
         nodes: core.filesNodes,
+        href: "/vfs/files",
         emptyLabel: "empty",
       },
       {
         path: "/sessions",
         icon: <MessagesSquare className="h-4 w-4 text-chart-1" />,
         nodes: core.sessionNodes,
-        href: "/sessions",
+        href: "/vfs/sessions",
+        detailLabel: "Agent",
         footer:
           core.vitals.sessions > core.sessionNodes.length
             ? { label: `all ${core.vitals.sessions} sessions`, href: "/sessions" }
@@ -139,7 +145,8 @@ export function useVfsMounts(): {
         path: "/skills",
         icon: <GraduationCap className="h-4 w-4 text-chart-3" />,
         nodes: core.skillNodes,
-        href: "/skills",
+        href: "/vfs/skills",
+        detailLabel: "Contents",
         emptyLabel: "no skills yet",
       },
     ];
@@ -177,6 +184,7 @@ export function useVfsMounts(): {
         path: "/sources",
         icon: <Cable className="h-4 w-4 text-chart-1" />,
         nodes: providerNodes,
+        href: "/vfs/sources",
         footer:
           providerNodes.length === 0
             ? { label: "connect a source", href: "/settings/integrations" }

--- a/frontend/src/components/content/files-overview/useVfsMounts.tsx
+++ b/frontend/src/components/content/files-overview/useVfsMounts.tsx
@@ -152,7 +152,7 @@ export function useVfsMounts(): {
           name: provider,
           icon: connectorIcon(provider),
           // ?section=files keeps the VFS docked when a provider opens from
-          // either VFS surface, instead of teleporting to the Tools section.
+          // either VFS surface, instead of teleporting to the Integrations section.
           href: `/integrations/${provider}?section=files`,
           children: nodes,
           hiddenCount: hiddenCount || undefined,

--- a/frontend/src/components/content/files-overview/useVfsMounts.tsx
+++ b/frontend/src/components/content/files-overview/useVfsMounts.tsx
@@ -74,11 +74,15 @@ export function useVfsMounts(): {
   coreError: string | null;
   sourcesPending: boolean;
   sourcesError: string | null;
+  /** Re-read the tree — after creating a folder, the sidebar is stale. */
+  reload: () => void;
 } {
   const [core, setCore] = useState<CoreData | null>(null);
   const [coreError, setCoreError] = useState<string | null>(null);
   const [sources, setSources] = useState<SourceTreeRoot[] | null>(null);
   const [sourcesError, setSourcesError] = useState<string | null>(null);
+
+  const [reloadNonce, setReloadNonce] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -102,7 +106,7 @@ export function useVfsMounts(): {
       .then((s) => { if (!cancelled) setSources(s); })
       .catch((e) => { if (!cancelled) setSourcesError(e instanceof Error ? e.message : String(e)); });
     return () => { cancelled = true; };
-  }, []);
+  }, [reloadNonce]);
 
   const mounts = useMemo<Mount[]>(() => {
     if (!core) return [];
@@ -188,5 +192,6 @@ export function useVfsMounts(): {
     coreError,
     sourcesPending: sources === null && !sourcesError,
     sourcesError,
+    reload: () => setReloadNonce((n) => n + 1),
   };
 }

--- a/frontend/src/components/content/flat-files/FlatFilesPage.tsx
+++ b/frontend/src/components/content/flat-files/FlatFilesPage.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+// Experimental full-screen VFS: no tree, no folders — one reverse-chron table
+// of everything in the stash. The search input is the topbar's search bar
+// (topbar.tsx renders it on /files and writes to the shared store); this page
+// renders the filtered results. Arrows move, Enter opens.
+
+import Link from "next/link";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowUpRight } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { timeAgo } from "@/components/content/files-overview/build";
+import { useFilesSearch } from "./search-store";
+import { FlatItemIcon, filterItems, useFlatItems, type FlatItem, type FlatKind } from "./useFlatItems";
+
+const PAGE_SIZE = 100;
+
+const KINDS: { kind: FlatKind; label: string }[] = [
+  { kind: "page", label: "Pages" },
+  { kind: "file", label: "Files" },
+  { kind: "table", label: "Tables" },
+  { kind: "session", label: "Sessions" },
+  { kind: "skill", label: "Skills" },
+];
+
+// One shared grid so the header and every row line up as table columns.
+const COLUMNS =
+  "grid grid-cols-[minmax(0,3fr)_80px_minmax(0,1.2fr)_minmax(0,1fr)_80px] items-center gap-x-4";
+
+const KIND_NAME: Record<FlatKind, string> = {
+  page: "Page",
+  file: "File",
+  table: "Table",
+  session: "Session",
+  skill: "Skill",
+};
+
+type SortKey = "name" | "type" | "folder" | "agent" | "modified";
+type Sort = { key: SortKey; dir: "asc" | "desc" };
+
+// Modified-desc is what the list already arrives in, and doubles as "default":
+// while searching under the default sort, relevance ranking wins instead.
+const DEFAULT_SORT: Sort = { key: "modified", dir: "desc" };
+
+function compareBy(key: SortKey, a: FlatItem, b: FlatItem): number {
+  if (key === "modified") return +new Date(a.updatedAt) - +new Date(b.updatedAt);
+  if (key === "name") return a.name.localeCompare(b.name);
+  if (key === "type") return KIND_NAME[a.kind].localeCompare(KIND_NAME[b.kind]);
+  if (key === "folder") return (a.context ?? "").localeCompare(b.context ?? "");
+  return (a.agent ?? "").localeCompare(b.agent ?? "");
+}
+
+function HeaderCell({
+  label,
+  sortKey,
+  sort,
+  onSort,
+  right,
+}: {
+  label: string;
+  sortKey: SortKey;
+  sort: Sort;
+  onSort: (key: SortKey) => void;
+  right?: boolean;
+}) {
+  const active = sort.key === sortKey;
+  return (
+    <button
+      type="button"
+      onClick={() => onSort(sortKey)}
+      className={cn(
+        "flex items-center gap-1 font-mono text-[10.5px] uppercase tracking-wide",
+        right && "justify-end",
+        active ? "text-foreground" : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {label}
+      <span className={cn("w-2", !active && "invisible")}>{sort.dir === "asc" ? "↑" : "↓"}</span>
+    </button>
+  );
+}
+
+function Chip({ active, label, onClick }: { active: boolean; label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-full border px-2.5 py-0.5 text-[12px]",
+        active
+          ? "border-brand-500/40 bg-brand-500/10 text-brand-700"
+          : "border-border text-muted-foreground hover:bg-raised",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+export default function FlatFilesPage() {
+  const router = useRouter();
+  const { items, loaded, error } = useFlatItems();
+  const query = useFilesSearch((s) => s.query);
+  const [kind, setKind] = useState<FlatKind | "all">("all");
+  const [sort, setSort] = useState<Sort>(DEFAULT_SORT);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const [limit, setLimit] = useState(PAGE_SIZE);
+  // Only keyboard moves scroll the active row into view; mouse and initial
+  // renders must not yank the page around.
+  const keyed = useRef(false);
+
+  const ofKind = useMemo(
+    () => (kind === "all" ? items : items.filter((i) => i.kind === kind)),
+    [items, kind],
+  );
+  const searching = query.trim().length > 0;
+  const matches = useMemo(() => {
+    const filtered = filterItems(ofKind, query);
+    const isDefault = sort.key === DEFAULT_SORT.key && sort.dir === DEFAULT_SORT.dir;
+    // Relevance order survives only under the default sort; an explicit sort
+    // is a stronger statement than the ranker.
+    if (searching && isDefault) return filtered;
+    const sign = sort.dir === "asc" ? 1 : -1;
+    return [...filtered].sort((a, b) => sign * compareBy(sort.key, a, b));
+  }, [ofKind, query, searching, sort]);
+  const visible = matches.slice(0, limit);
+
+  function onSort(key: SortKey) {
+    setActiveIdx(0);
+    setSort((s) =>
+      s.key === key
+        ? { key, dir: s.dir === "asc" ? "desc" : "asc" }
+        : { key, dir: key === "modified" ? "desc" : "asc" },
+    );
+  }
+
+  // The topbar owns the input; leaving the page clears the shared query so a
+  // return visit starts with the full list.
+  useEffect(() => () => useFilesSearch.getState().setQuery(""), []);
+
+  useEffect(() => {
+    setActiveIdx(0);
+    setLimit(PAGE_SIZE);
+  }, [query]);
+
+  // Keyboard driving happens at window level: focus sits in the topbar input
+  // while the results live here.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (!searching || e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        keyed.current = true;
+        setActiveIdx((i) => Math.min(i + 1, visible.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        keyed.current = true;
+        setActiveIdx((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter" && visible[activeIdx]) {
+        router.push(visible[activeIdx].href);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [searching, visible, activeIdx, router]);
+
+  if (error) {
+    return <div className="p-6 font-mono text-[12px] text-error">✗ couldn&apos;t read the stash: {error}</div>;
+  }
+
+  return (
+    <div className="h-full overflow-y-auto bg-base">
+      <div className="mx-auto w-full max-w-5xl px-6 py-8">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Chip
+            active={kind === "all"}
+            label={`All ${items.length}`}
+            onClick={() => { setKind("all"); setActiveIdx(0); }}
+          />
+          {KINDS.map(({ kind: k, label }) => {
+            const count = items.filter((i) => i.kind === k).length;
+            if (count === 0) return null;
+            return (
+              <Chip
+                key={k}
+                active={kind === k}
+                label={`${label} ${count}`}
+                onClick={() => { setKind(k); setActiveIdx(0); }}
+              />
+            );
+          })}
+        </div>
+
+        <div className="mt-4">
+          {!loaded && (
+            <div className="space-y-3 py-2">
+              {Array.from({ length: 10 }, (_, i) => (
+                <Skeleton key={i} className="h-5" style={{ width: `${55 + (i % 4) * 12}%` }} />
+              ))}
+            </div>
+          )}
+
+          {loaded && matches.length === 0 && (
+            <div className="py-8 text-center font-mono text-[12px] text-muted-foreground">
+              {searching ? <>no matches for &ldquo;{query.trim()}&rdquo;</> : "nothing here yet"}
+            </div>
+          )}
+
+          {loaded && matches.length > 0 && (
+            <div className={cn("border-b border-border px-3 pb-1.5", COLUMNS)}>
+              <HeaderCell label="Name" sortKey="name" sort={sort} onSort={onSort} />
+              <HeaderCell label="Type" sortKey="type" sort={sort} onSort={onSort} />
+              <HeaderCell label="Folder" sortKey="folder" sort={sort} onSort={onSort} />
+              <HeaderCell label="Agent" sortKey="agent" sort={sort} onSort={onSort} />
+              <HeaderCell label="Modified" sortKey="modified" sort={sort} onSort={onSort} right />
+            </div>
+          )}
+
+          {visible.map((item, idx) => (
+            <Link
+              key={item.key}
+              href={item.href}
+              ref={
+                searching && idx === activeIdx
+                  ? (el) => {
+                      if (el && keyed.current) {
+                        keyed.current = false;
+                        el.scrollIntoView({ block: "nearest" });
+                      }
+                    }
+                  : undefined
+              }
+              onMouseMove={() => { if (searching) setActiveIdx(idx); }}
+              className={cn(
+                "rounded-md px-3 py-2",
+                COLUMNS,
+                searching && idx === activeIdx ? "bg-brand-500/10" : "hover:bg-raised",
+              )}
+            >
+              <span className="flex min-w-0 items-center gap-2">
+                <FlatItemIcon kind={item.kind} />
+                <span className="min-w-0 truncate text-[13.5px] text-foreground">{item.name}</span>
+                {item.annotation && (
+                  <span className="shrink-0 font-mono text-[10.5px] text-muted-foreground">{item.annotation}</span>
+                )}
+              </span>
+              <span className="truncate text-[12px] text-muted-foreground">{KIND_NAME[item.kind]}</span>
+              <span className="truncate text-[12px] text-muted-foreground">{item.context ?? "—"}</span>
+              <span className="truncate font-mono text-[11px] text-muted-foreground">{item.agent ?? "—"}</span>
+              <span className="text-right font-mono text-[11px] text-muted-foreground">{timeAgo(item.updatedAt)}</span>
+            </Link>
+          ))}
+
+          {matches.length > visible.length && (
+            <button
+              type="button"
+              onClick={() => setLimit((l) => l + 500)}
+              className="mt-1 flex w-full items-center gap-1 rounded-md px-3 py-1.5 text-left font-mono text-[11.5px] text-dim hover:bg-raised hover:text-brand-700"
+            >
+              … +{matches.length - visible.length} more
+            </button>
+          )}
+
+          {searching && (
+            <Link
+              href={`/search?q=${encodeURIComponent(query.trim())}`}
+              className="mt-2 flex items-center gap-1 rounded-md px-3 py-1.5 font-mono text-[11.5px] text-dim hover:bg-raised hover:text-brand-700"
+            >
+              search connected sources too <ArrowUpRight className="h-3 w-3" />
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/content/flat-files/search-store.ts
+++ b/frontend/src/components/content/flat-files/search-store.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+// The /files search query lives here because the input is the topbar's search
+// bar while the results render in the page below — one search, two components.
+interface FilesSearchState {
+  query: string;
+  setQuery: (query: string) => void;
+}
+
+export const useFilesSearch = create<FilesSearchState>((set) => ({
+  query: "",
+  setQuery: (query) => set({ query }),
+}));

--- a/frontend/src/components/content/flat-files/useFlatItems.tsx
+++ b/frontend/src/components/content/flat-files/useFlatItems.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+// The flat-list VFS experiment: the whole stash as one searchable,
+// reverse-chronological list — no hierarchy. Folder location survives only as
+// a dim context label on each row. Agents still get the real filesystem
+// through the CLI VFS; this is the human lens.
+
+import { useEffect, useState } from "react";
+import { GraduationCap, MessagesSquare } from "lucide-react";
+import {
+  getMemoryFolder,
+  getSidebar,
+  listSkills,
+  listTables,
+  type Sidebar,
+  type Skill,
+  type TreeFolder,
+} from "@/lib/api";
+import type { Table } from "@/lib/types";
+import { FileIcon, PageIcon, TableIcon } from "@/components/SkillIcons";
+import { humanSize } from "@/components/content/files-overview/build";
+
+export type FlatKind = "page" | "file" | "table" | "session" | "skill";
+
+export interface FlatItem {
+  key: string;
+  kind: FlatKind;
+  name: string;
+  href: string;
+  /** Where it lives, in words: the folder path. */
+  context?: string;
+  /** Agent it came from — the session's agent, or a page's last agent editor. */
+  agent?: string;
+  /** Dim mono note — "12 KB", "8 rows", "4 files". */
+  annotation?: string;
+  updatedAt: string;
+}
+
+export function FlatItemIcon({ kind }: { kind: FlatKind }) {
+  if (kind === "page") return <span className="shrink-0 text-muted-foreground"><PageIcon /></span>;
+  if (kind === "table") return <span className="shrink-0 text-muted-foreground"><TableIcon /></span>;
+  if (kind === "session") return <MessagesSquare className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />;
+  if (kind === "skill") return <GraduationCap className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />;
+  return <span className="shrink-0 text-muted-foreground"><FileIcon /></span>;
+}
+
+/** Full "A / B / C" location for every folder, in one pass. */
+function folderPaths(folders: TreeFolder[]): Map<string, string> {
+  const byId = new Map(folders.map((f) => [f.id, f]));
+  const paths = new Map<string, string>();
+  function pathOf(id: string): string {
+    const cached = paths.get(id);
+    if (cached) return cached;
+    const folder = byId.get(id);
+    // Parents can be invisible (skill subtrees, unreadable folders); the
+    // path then starts at the first visible ancestor.
+    if (!folder) return "";
+    const parent = folder.parent_folder_id ? pathOf(folder.parent_folder_id) : "";
+    const path = parent ? `${parent} / ${folder.name}` : folder.name;
+    paths.set(id, path);
+    return path;
+  }
+  folders.forEach((f) => pathOf(f.id));
+  return paths;
+}
+
+/** The memory folder and every folder under it. */
+function memorySubtree(folders: TreeFolder[], memoryFolderId: string): Set<string> {
+  const ids = new Set([memoryFolderId]);
+  let grew = true;
+  while (grew) {
+    grew = false;
+    for (const f of folders) {
+      if (f.parent_folder_id && ids.has(f.parent_folder_id) && !ids.has(f.id)) {
+        ids.add(f.id);
+        grew = true;
+      }
+    }
+  }
+  return ids;
+}
+
+function buildFlatItems(
+  sidebar: Sidebar,
+  tables: Table[],
+  skills: Skill[],
+  memoryFolderId: string,
+): FlatItem[] {
+  // Memory is a derived layer over the stash, not ground truth — the whole
+  // subtree is invisible here (part of the never-show-memory experiment).
+  const memoryIds = memorySubtree(sidebar.files.folders, memoryFolderId);
+  const inMemory = (folderId: string | null) => folderId !== null && memoryIds.has(folderId);
+
+  const paths = folderPaths(sidebar.files.folders);
+  const context = (folderId: string | null) => (folderId ? paths.get(folderId) : undefined);
+
+  const pages = sidebar.files.pages.filter((p) => !inMemory(p.folder_id)).map<FlatItem>((p) => ({
+    key: `page:${p.id}`,
+    kind: "page",
+    name: p.name,
+    href: `/p/${p.id}`,
+    context: context(p.folder_id),
+    agent: p.last_edit_agent_name ?? undefined,
+    updatedAt: p.updated_at,
+  }));
+  const files = sidebar.files.files.filter((f) => !inMemory(f.folder_id)).map<FlatItem>((f) => ({
+    key: `file:${f.id}`,
+    kind: "file",
+    name: f.name,
+    href: `/f/${f.id}`,
+    context: context(f.folder_id),
+    annotation: humanSize(f.size_bytes),
+    updatedAt: f.created_at,
+  }));
+  const tableItems = tables.filter((t) => !inMemory(t.folder_id)).map<FlatItem>((t) => ({
+    key: `table:${t.id}`,
+    kind: "table",
+    name: t.name,
+    href: `/tables/${t.id}`,
+    context: context(t.folder_id),
+    annotation: `${t.row_count ?? 0} row${t.row_count === 1 ? "" : "s"}`,
+    updatedAt: t.updated_at,
+  }));
+  const sessions = sidebar.sessions.map<FlatItem>((s) => ({
+    key: `session:${s.session_id}`,
+    kind: "session",
+    name: s.title || s.agent_name || "session",
+    href: `/sessions/${s.session_id}`,
+    agent: s.agent_name || undefined,
+    updatedAt: s.last_at,
+  }));
+  const skillItems = skills.map<FlatItem>((s) => ({
+    key: `skill:${s.folder_id}`,
+    kind: "skill",
+    name: s.name,
+    href: `/skills/folder/${s.folder_id}`,
+    annotation: `${s.file_count} file${s.file_count === 1 ? "" : "s"}`,
+    updatedAt: s.updated_at,
+  }));
+
+  return [...pages, ...files, ...tableItems, ...sessions, ...skillItems].sort(
+    (a, b) => +new Date(b.updatedAt) - +new Date(a.updatedAt),
+  );
+}
+
+/** Rank matches: name prefix, then name substring, then location/agent
+ *  substring. Within a rank the list keeps its recency order (Array.sort is
+ *  stable). */
+export function filterItems(items: FlatItem[], query: string): FlatItem[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return items;
+  const scored: { item: FlatItem; score: number }[] = [];
+  for (const item of items) {
+    const name = item.name.toLowerCase();
+    const rest = `${item.context ?? ""} ${item.agent ?? ""}`.toLowerCase();
+    if (name.startsWith(q)) scored.push({ item, score: 0 });
+    else if (name.includes(q)) scored.push({ item, score: 1 });
+    else if (rest.includes(q)) scored.push({ item, score: 2 });
+  }
+  return scored.sort((a, b) => a.score - b.score).map((s) => s.item);
+}
+
+export function useFlatItems(): { items: FlatItem[]; loaded: boolean; error: string | null } {
+  const [items, setItems] = useState<FlatItem[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([getSidebar(), listTables(), listSkills(), getMemoryFolder()])
+      .then(([sidebar, tables, skills, memoryFolder]) => {
+        if (cancelled) return;
+        setItems(buildFlatItems(sidebar, tables.tables, skills, memoryFolder.id));
+      })
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : String(e)); });
+    return () => { cancelled = true; };
+  }, []);
+
+  return { items: items ?? [], loaded: items !== null, error };
+}

--- a/frontend/src/components/content/vfs-browser/VfsBrowser.tsx
+++ b/frontend/src/components/content/vfs-browser/VfsBrowser.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+// The third VFS surface: one mount, full-page, in the same browser every
+// folder uses. The lens (/files) answers "what is in my stash"; this answers
+// "what does /sessions actually look like as a filesystem".
+//
+// /files renders the real FileBrowser, because it is a real filesystem and
+// gets the whole toolkit — views, sort, upload, preview. The other mounts are
+// not files (sessions, skills, source documents), so they render the same
+// rows through ItemsList but pass no reparent/pin/delete capability: the list
+// looks identical and offers only what actually exists for them.
+
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { Skeleton } from "@/components/ui/skeleton";
+import FileBrowser from "@/components/content/file-browser/FileBrowser";
+import ItemsList from "@/components/content/file-browser/ItemsList";
+import type { GridItem, ItemKind } from "@/components/content/file-browser/kind";
+import type { VNode, VNodeKind } from "@/components/content/files-overview/build";
+import { useVfsMounts, type Mount } from "@/components/content/files-overview/useVfsMounts";
+
+const KIND: Record<VNodeKind, ItemKind> = {
+  folder: "folder",
+  page: "page",
+  file: "file",
+  table: "datatable",
+  session: "session",
+  skill: "skill",
+  "source-doc": "source-doc",
+};
+
+function vfsHref(segments: string[]): string {
+  return `/vfs/${segments.map(encodeURIComponent).join("/")}`;
+}
+
+type Resolved =
+  | { ok: true; nodes: VNode[]; emptyLabel: string; mount: Mount }
+  | { ok: false; missing: string };
+
+/** Walk `segments` from the mount roots. Names are the path, which is what
+ *  makes the URL read like the filesystem it is describing. */
+function resolve(mounts: Mount[], segments: string[]): Resolved {
+  const mount = mounts.find((m) => m.path === `/${segments[0]}`);
+  if (!mount) return { ok: false, missing: `/${segments[0]}` };
+
+  let nodes = mount.nodes;
+  for (const segment of segments.slice(1)) {
+    const next = nodes.find((n) => n.name === segment);
+    if (!next || !next.children) return { ok: false, missing: segment };
+    nodes = next.children;
+  }
+  // The mount's empty label speaks for the mount ("no sources connected"); a
+  // directory inside it is just empty, and saying otherwise misreports why.
+  const emptyLabel = segments.length === 1 ? mount.emptyLabel : "empty";
+  return { ok: true, nodes, emptyLabel, mount };
+}
+
+function Breadcrumbs({ segments }: { segments: string[] }) {
+  return (
+    <div className="flex flex-wrap items-center font-mono text-[15px]">
+      {segments.map((segment, i) => {
+        const last = i === segments.length - 1;
+        return (
+          <span key={segment} className="flex items-center">
+            <span className="text-muted-foreground/40">/</span>
+            {last ? (
+              <span className="font-semibold text-foreground">{segment}</span>
+            ) : (
+              <Link
+                href={vfsHref(segments.slice(0, i + 1))}
+                className="rounded px-0.5 text-dim hover:bg-raised hover:text-brand-700"
+              >
+                {segment}
+              </Link>
+            )}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function VfsBrowser() {
+  const params = useParams();
+  const router = useRouter();
+  const raw = params.path;
+  const segments = (Array.isArray(raw) ? raw : raw ? [raw] : []).map((s) => decodeURIComponent(s));
+
+  const { mounts, coreLoaded, coreError, sourcesPending } = useVfsMounts();
+
+  if (segments.length === 1 && segments[0] === "files") {
+    return (
+      <div className="h-full overflow-y-auto px-8 py-6">
+        <Breadcrumbs segments={segments} />
+        <FileBrowser folderId={null} />
+      </div>
+    );
+  }
+
+  if (coreError) {
+    return <div className="px-8 py-6 font-mono text-[13px] text-error">✗ {coreError}</div>;
+  }
+  // /sources arrives on its own clock, so a bare /vfs/sources is still loading
+  // while the native mounts are ready.
+  if (!coreLoaded || (segments[0] === "sources" && sourcesPending)) {
+    return (
+      <div className="space-y-2 px-8 py-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-6 w-64" />
+        ))}
+      </div>
+    );
+  }
+
+  const resolved = resolve(mounts, segments);
+
+  // A directory drills deeper into this view; a leaf opens its own page. That
+  // split is what keeps /sources/gmail browsing the filesystem instead of
+  // jumping to the Gmail integration screen.
+  const destinations = new Map<string, string>();
+  const items: GridItem[] = !resolved.ok
+    ? []
+    : resolved.nodes.map((node) => {
+        const dir = node.children !== undefined;
+        const destination = dir ? vfsHref([...segments, node.name]) : node.href;
+        if (destination) destinations.set(node.key, destination);
+        return {
+          kind: dir ? "folder" : KIND[node.kind],
+          id: node.key,
+          name: node.name,
+          subtitle: node.annotation ?? "",
+          updatedAt: node.updatedAt,
+          detail: node.detail,
+          icon: node.icon,
+          movable: false,
+        };
+      });
+
+  function navigate(item: GridItem, options?: { newTab?: boolean }) {
+    // Source documents live in the provider, not in Stash: they are real VFS
+    // entries with no page of ours to open, so their rows do not navigate.
+    const destination = destinations.get(item.id);
+    if (!destination) return;
+    if (options?.newTab) window.open(destination, "_blank");
+    else router.push(destination);
+  }
+
+  return (
+    <div className="h-full overflow-y-auto px-8 py-6">
+      <Breadcrumbs segments={segments} />
+      <div className="mt-5">
+        {!resolved.ok ? (
+          <div className="font-mono text-[13px] text-muted-foreground">
+            no such path: {resolved.missing}
+          </div>
+        ) : resolved.nodes.length === 0 ? (
+          <div className="font-mono text-[13px] italic text-muted-foreground">
+            {resolved.emptyLabel}
+          </div>
+        ) : (
+          <ItemsList
+            items={items}
+            onNavigate={navigate}
+            detailColumn={resolved.mount.detailLabel}
+          />
+        )}
+      </div>
+      {resolved.ok && resolved.mount.footer && (
+        <Link
+          href={resolved.mount.footer.href}
+          className="mt-4 inline-flex items-center gap-1 font-mono text-[12.5px] text-dim hover:text-brand-700"
+        >
+          {resolved.mount.footer.label} →
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/integrations/BrandIcons.tsx
+++ b/frontend/src/components/integrations/BrandIcons.tsx
@@ -2,6 +2,133 @@ type Props = { className?: string; size?: number };
 
 const defaultSize = 18;
 
+export function ClaudeCodeIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" aria-hidden>
+      <path
+        fill="#D97757"
+        fillRule="evenodd"
+        d="M21 10.95h3v3.1h-3v3.03h-1.49V20H18v-2.92h-1.49V20H15v-2.92H9V20H7.49v-2.92H6V20H4.49v-2.92H3v-3.03H0v-3.1h3V5h18v5.95ZM6 10.95h1.49V8.1H6v2.85Zm10.51 0H18V8.1h-1.49v2.85Z"
+      />
+    </svg>
+  );
+}
+
+export function CodexIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" aria-hidden>
+      <defs>
+        <linearGradient id="codex-gradient" x1="12" x2="12" y1="3" y2="21" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#B1A7FF" />
+          <stop offset=".5" stopColor="#7A9DFF" />
+          <stop offset="1" stopColor="#3941FF" />
+        </linearGradient>
+      </defs>
+      <rect width="24" height="24" rx="4.5" fill="white" />
+      <path
+        fill="url(#codex-gradient)"
+        d="M9.06 3.34a4.58 4.58 0 0 1 4.96.97.1.1 0 0 0 .08.02 4.55 4.55 0 0 1 3.05.27 4.58 4.58 0 0 1 2.35 2.48c.21.51.31 1.04.31 1.6 0 .41-.04.82-.13 1.22a.12.12 0 0 0 .03.11 4.48 4.48 0 0 1 1.18 2.17 4.46 4.46 0 0 1-.89 3.86 4.55 4.55 0 0 1-2.33 1.55.12.12 0 0 0-.08.08 4.58 4.58 0 0 1-4.48 3.33 4.55 4.55 0 0 1-3.16-1.3.11.11 0 0 0-.1-.03 4.43 4.43 0 0 1-3.15-.33 4.54 4.54 0 0 1-1.61-1.34 4.69 4.69 0 0 1-.79-1.58 4.58 4.58 0 0 1-.01-2.3.12.12 0 0 0-.02-.1 4.47 4.47 0 0 1-1.04-1.65 4.56 4.56 0 0 1 1.82-5.41c.42-.28.91-.49 1.54-.68a.1.1 0 0 0 .07-.06 4.52 4.52 0 0 1 2.66-2.9Zm3.49 10.57a.64.64 0 0 0 0 1.27h3.63a.64.64 0 1 0 0-1.27h-3.63ZM8.46 9.23a.64.64 0 0 0-1.1.63l1.27 2.23-1.27 2.13a.64.64 0 1 0 1.1.65l1.45-2.46a.64.64 0 0 0 .01-.64L8.46 9.23Z"
+      />
+    </svg>
+  );
+}
+
+export function CursorIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M22.11 5.68 12.5.14a1 1 0 0 0-1 0L1.89 5.68a.84.84 0 0 0-.42.73v11.18c0 .3.16.58.42.73l9.61 5.55a1 1 0 0 0 1 0l9.61-5.55a.84.84 0 0 0 .42-.73V6.41a.84.84 0 0 0-.42-.73Zm-.61 1.18-9.27 16.06c-.06.11-.23.06-.23-.06V12.34a.59.59 0 0 0-.3-.51L2.6 6.57c-.11-.06-.06-.23.06-.23h18.55c.26 0 .43.29.3.52Z" />
+    </svg>
+  );
+}
+
+export function OpenCodeIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M16 6H8v12h8V6Zm4 16H4V2h16v20Z" />
+    </svg>
+  );
+}
+
+export function GeminiCliIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" aria-hidden>
+      <defs>
+        <linearGradient id="gemini-cli-gradient" x1="24" x2="0" y1="6.59" y2="16.49" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#EE4D5D" />
+          <stop offset=".33" stopColor="#B381DD" />
+          <stop offset=".48" stopColor="#207CFE" />
+        </linearGradient>
+      </defs>
+      <rect width="24" height="24" rx="4.39" fill="url(#gemini-cli-gradient)" />
+      <path fill="#1E1E2E" d="m7.24 8.56 7.75 3.73-7.75 3.73v2.8l9.55-4.6v-3.86l-9.55-4.6v2.8Z" />
+    </svg>
+  );
+}
+
+export function OpenClawIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" aria-hidden>
+      <defs>
+        <linearGradient id="openclaw-gradient" x1="0" x2="24" y1="2" y2="22" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#FF4D4D" />
+          <stop offset="1" stopColor="#991B1B" />
+        </linearGradient>
+      </defs>
+      <path fill="url(#openclaw-gradient)" d="M12 2.57c-6.33 0-9.5 5.27-9.5 9.49s3.17 8.44 6.33 9.5v2.1h2.11v-2.1s1.06.42 2.11 0v2.1h2.11v-2.1c3.17-1.06 6.33-5.28 6.33-9.5S18.33 2.57 12 2.57Z" />
+      <path fill="url(#openclaw-gradient)" d="M3.56 9.95C.4 8.9-.66 11.01.4 13.12c1.05 2.11 3.16 1.05 4.22-1.06.63-1.47 0-2.1-1.06-2.1Zm16.88 0c3.16-1.05 4.22 1.06 3.16 3.17-1.05 2.11-3.16 1.05-4.22-1.06-.63-1.47 0-2.1 1.06-2.1Z" />
+      <path fill="#FF4D4D" d="M5.51 1.88c.47-.29 1.03-.24 1.61.03.58.27 1.22.78 1.94 1.49a.32.32 0 0 1-.45.45 7.14 7.14 0 0 0-1.76-1.36c-.47-.23-.79-.21-1.02-.07a.32.32 0 0 1-.32-.54Zm11.37.03c.58-.27 1.14-.32 1.61-.03a.32.32 0 0 1-.32.54c-.23-.14-.55-.16-1.03.07-.47.22-1.06.67-1.75 1.36a.32.32 0 1 1-.45-.45c.72-.71 1.36-1.22 1.94-1.49Z" />
+      <circle cx="8.84" cy="7.84" r="1.27" fill="#050810" />
+      <circle cx="15.16" cy="7.84" r="1.27" fill="#050810" />
+      <circle cx="9.05" cy="7.63" r=".53" fill="#00E5CC" />
+      <circle cx="15.38" cy="7.63" r=".53" fill="#00E5CC" />
+    </svg>
+  );
+}
+
+export function HermesIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 64 64" aria-hidden>
+      <defs>
+        <linearGradient id="hermes-gold" x1="0" y1="0" x2="0" y2="1">
+          <stop stopColor="#F5C542" />
+          <stop offset="1" stopColor="#D4961C" />
+        </linearGradient>
+      </defs>
+      <rect x="30" y="10" width="4" height="46" rx="2" fill="url(#hermes-gold)" />
+      <path d="M30 18c-6-4-16-4-20 0 4-2 12-2 18 2m2 2c-4-3-12-3-16 0 4-2 10-2 14 2" fill="none" stroke="#F5C542" strokeWidth="3" />
+      <path d="M34 18c6-4 16-4 20 0-4-2-12-2-18 2m-2 2c4-3 12-3 16 0-4-2-10-2-14 2" fill="none" stroke="#D4961C" strokeWidth="3" />
+      <path d="M32 48c-10-4-12-10-6-14-6 2-8 8-2 12-6-6-2-16 6-18M32 48c10-4 12-10 6-14 6 2 8 8 2 12 6-6 2-16-6-18" fill="none" stroke="url(#hermes-gold)" strokeWidth="2.5" strokeLinecap="round" />
+      <circle cx="32" cy="10" r="4" fill="#F5C542" />
+    </svg>
+  );
+}
+
+export function ChromeIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 48 48" aria-hidden>
+      <defs>
+        <linearGradient id="chrome-red" x1="3.22" y1="15" x2="44.78" y2="15" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#D93025" />
+          <stop offset="1" stopColor="#EA4335" />
+        </linearGradient>
+        <linearGradient id="chrome-yellow" x1="20.72" y1="47.68" x2="41.5" y2="11.68" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#FCC934" />
+          <stop offset="1" stopColor="#FBBC04" />
+        </linearGradient>
+        <linearGradient id="chrome-green" x1="26.6" y1="46.5" x2="5.82" y2="10.51" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#1E8E3E" />
+          <stop offset="1" stopColor="#34A853" />
+        </linearGradient>
+      </defs>
+      <path fill="url(#chrome-red)" d="M24 12h20.78A24 24 0 0 0 3.22 12L13.61 30a12 12 0 0 1 10.4-18Z" />
+      <path fill="url(#chrome-yellow)" d="M34.39 30 24 48a24 24 0 0 0 20.78-36H24a12 12 0 0 1 10.39 18Z" />
+      <path fill="url(#chrome-green)" d="M13.61 30 3.22 12A24 24 0 0 0 24 48l10.39-18a12 12 0 0 1-20.78 0Z" />
+      <circle cx="24" cy="24" r="10.5" fill="white" />
+      <circle cx="24" cy="24" r="9.5" fill="#1A73E8" />
+    </svg>
+  );
+}
+
 export function GitHubIcon({ className, size = defaultSize }: Props) {
   return (
     <svg
@@ -229,16 +356,10 @@ export function InstagramIcon({ className, size = defaultSize }: Props) {
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
+      fill="#FF0069"
       aria-hidden
     >
-      <rect x="2" y="2" width="20" height="20" rx="5" />
-      <circle cx="12" cy="12" r="4" />
-      <circle cx="17.5" cy="6.5" r="0.6" fill="currentColor" />
+      <path d="M7.0301.084c-1.2768.0602-2.1487.264-2.911.5634-.7888.3075-1.4575.72-2.1228 1.3877-.6652.6677-1.075 1.3368-1.3802 2.127-.2954.7638-.4956 1.6365-.552 2.914-.0564 1.2775-.0689 1.6882-.0626 4.947.0062 3.2586.0206 3.6671.0825 4.9473.061 1.2765.264 2.1482.5635 2.9107.308.7889.72 1.4573 1.388 2.1228.6679.6655 1.3365 1.0743 2.1285 1.38.7632.295 1.6361.4961 2.9134.552 1.2773.056 1.6884.069 4.9462.0627 3.2578-.0062 3.668-.0207 4.9478-.0814 1.28-.0607 2.147-.2652 2.9098-.5633.7889-.3086 1.4578-.72 2.1228-1.3881.665-.6682 1.0745-1.3378 1.3795-2.1284.2957-.7632.4966-1.636.552-2.9124.056-1.2809.0692-1.6898.063-4.948-.0063-3.2583-.021-3.6668-.0817-4.9465-.0607-1.2797-.264-2.1487-.5633-2.9117-.3084-.7889-.72-1.4568-1.3876-2.1228C21.2982 1.33 20.628.9208 19.8378.6165 19.074.321 18.2017.1197 16.9244.0645 15.6471.0093 15.236-.005 11.977.0014 8.718.0076 8.31.0215 7.0301.0839m.1402 21.6932c-1.17-.0509-1.8053-.2453-2.2287-.408-.5606-.216-.96-.4771-1.3819-.895-.422-.4178-.6811-.8186-.9-1.378-.1644-.4234-.3624-1.058-.4171-2.228-.0595-1.2645-.072-1.6442-.079-4.848-.007-3.2037.0053-3.583.0607-4.848.05-1.169.2456-1.805.408-2.2282.216-.5613.4762-.96.895-1.3816.4188-.4217.8184-.6814 1.3783-.9003.423-.1651 1.0575-.3614 2.227-.4171 1.2655-.06 1.6447-.072 4.848-.079 3.2033-.007 3.5835.005 4.8495.0608 1.169.0508 1.8053.2445 2.228.408.5608.216.96.4754 1.3816.895.4217.4194.6816.8176.9005 1.3787.1653.4217.3617 1.056.4169 2.2263.0602 1.2655.0739 1.645.0796 4.848.0058 3.203-.0055 3.5834-.061 4.848-.051 1.17-.245 1.8055-.408 2.2294-.216.5604-.4763.96-.8954 1.3814-.419.4215-.8181.6811-1.3783.9-.4224.1649-1.0577.3617-2.2262.4174-1.2656.0595-1.6448.072-4.8493.079-3.2045.007-3.5825-.006-4.848-.0608M16.953 5.5864A1.44 1.44 0 1 0 18.39 4.144a1.44 1.44 0 0 0-1.437 1.4424M5.8385 12.012c.0067 3.4032 2.7706 6.1557 6.173 6.1493 3.4026-.0065 6.157-2.7701 6.1506-6.1733-.0065-3.4032-2.771-6.1565-6.174-6.1498-3.403.0067-6.156 2.771-6.1496 6.1738M8 12.0077a4 4 0 1 1 4.008 3.9921A3.9996 3.9996 0 0 1 8 12.0077" />
     </svg>
   );
 }

--- a/frontend/src/components/integrations/CodingAgents.tsx
+++ b/frontend/src/components/integrations/CodingAgents.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import CopyableCommandBlock from "@/components/CopyableCommandBlock";
+import {
+  ClaudeCodeIcon,
+  CodexIcon,
+  CursorIcon,
+  GeminiCliIcon,
+  HermesIcon,
+  OpenClawIcon,
+  OpenCodeIcon,
+} from "@/components/integrations/BrandIcons";
+
+// The agents `stash install` wires up — the same list the CLI walks
+// (_SUPPORTED_AGENTS in cli/main.py). Keep the two in step: an agent listed
+// here that the CLI can't wire is a promise the product doesn't keep.
+export const CODING_AGENTS = [
+  { name: "Claude Code", binary: "claude", icon: <ClaudeCodeIcon /> },
+  { name: "Codex", binary: "codex", icon: <CodexIcon /> },
+  { name: "Cursor", binary: "cursor-agent", icon: <CursorIcon /> },
+  { name: "OpenCode", binary: "opencode", icon: <OpenCodeIcon /> },
+  { name: "Gemini CLI", binary: "gemini", icon: <GeminiCliIcon /> },
+  { name: "OpenClaw", binary: "openclaw", icon: <OpenClawIcon /> },
+  { name: "Hermes", binary: "hermes", icon: <HermesIcon /> },
+];
+
+export type CodingAgent = (typeof CODING_AGENTS)[number];
+
+const INSTALL_COMMAND = `bash -c "$(curl -fsSL https://joinstash.ai/install)"`;
+
+// A coding agent is two integrations wearing one name — it writes transcripts
+// in and reads the stash back out — so it gets a box per direction with the
+// half that applies. One install command serves both, which is why the two
+// dialogs differ in what they explain rather than what they run. There is
+// deliberately no per-agent connected state: the uploaded `agent_name` is
+// whatever the user named their agent, not which harness produced it, so
+// "Claude Code: connected" would be a guess dressed as a fact.
+export const AGENT_COPY = {
+  in: {
+    label: (name: string) => `${name} transcripts`,
+    blurb: (name: string) => `Add ${name} transcripts to your Stash.`,
+    title: (name: string) => `Record ${name} sessions`,
+    description:
+      "One command turns on session recording for every coding agent on your machine, this one included.",
+  },
+  out: {
+    label: (name: string) => `${name} access`,
+    blurb: (name: string) => `Give ${name} read access to your Stash.`,
+    title: (name: string) => `Give ${name} access`,
+    description:
+      "One command gives every coding agent on your machine read access, this one included.",
+  },
+} as const;
+
+/** One command, both directions. The MCP route to a stash is its own box
+ *  under Outputs — repeating it inside every agent dialog turned one answer
+ *  into a choice the user has no basis to make. */
+export function agentDialogBody() {
+  return (
+    <div className="flex min-w-0 flex-col gap-3">
+      <CopyableCommandBlock commands={INSTALL_COMMAND} />
+    </div>
+  );
+}

--- a/frontend/src/components/integrations/McpServers.tsx
+++ b/frontend/src/components/integrations/McpServers.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { ApiError, createMcpServer } from "@/lib/api";
+
+// One "KEY=VALUE" line per header, parsed at submit time.
+function parseHeaderLines(raw: string): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) throw new Error(`Headers must be KEY=VALUE lines; got "${trimmed}"`);
+    headers[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+  }
+  return headers;
+}
+
+/** The add-a-server form, shown in the dialog behind the "Custom MCP server"
+ *  box. Registering one hands it to your cloud agent before every turn. */
+export default function AddServerForm({ onAdded }: { onAdded: () => void }) {
+  const [name, setName] = useState("");
+  const [transport, setTransport] = useState<"stdio" | "http">("http");
+  const [command, setCommand] = useState("");
+  const [url, setUrl] = useState("");
+  const [headerLines, setHeaderLines] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  async function submit() {
+    setSaving(true);
+    try {
+      const headers = transport === "http" ? parseHeaderLines(headerLines) : {};
+      await createMcpServer({
+        name: name.trim(),
+        transport,
+        ...(transport === "stdio" ? { command: command.trim() } : { url: url.trim(), headers }),
+      });
+      onAdded();
+    } catch (e) {
+      toast.error(e instanceof ApiError || e instanceof Error ? e.message : "Failed to connect the server");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const targetMissing = transport === "stdio" ? !command.trim() : !url.trim();
+
+  return (
+    <form
+      className="flex min-w-0 flex-col gap-3"
+      onSubmit={(e) => {
+        e.preventDefault();
+        void submit();
+      }}
+    >
+      <Input
+        aria-label="Server name"
+        placeholder="Name (e.g. linear)"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <div className="flex gap-1 self-start rounded-md bg-muted p-1" role="radiogroup">
+        {(["http", "stdio"] as const).map((t) => (
+          <button
+            key={t}
+            type="button"
+            role="radio"
+            aria-checked={transport === t}
+            onClick={() => setTransport(t)}
+            className={`rounded px-3 py-1 text-xs font-medium ${
+              transport === t ? "bg-surface text-foreground shadow-sm" : "text-muted-foreground"
+            }`}
+          >
+            {t === "http" ? "Remote (HTTP)" : "Local (stdio)"}
+          </button>
+        ))}
+      </div>
+      {transport === "stdio" ? (
+        <Input
+          aria-label="Command"
+          placeholder="Command (e.g. npx -y linear-mcp)"
+          value={command}
+          onChange={(e) => setCommand(e.target.value)}
+        />
+      ) : (
+        <>
+          <Input
+            aria-label="URL"
+            placeholder="URL (e.g. https://mcp.example.com/mcp)"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+          />
+          <Textarea
+            aria-label="Headers"
+            placeholder={"Optional headers, one per line:\nAuthorization=Bearer …"}
+            rows={2}
+            value={headerLines}
+            onChange={(e) => setHeaderLines(e.target.value)}
+          />
+        </>
+      )}
+      <Button type="submit" disabled={saving || !name.trim() || targetMissing} className="self-start">
+        <Plus className="h-4 w-4" />
+        Connect server
+      </Button>
+    </form>
+  );
+}

--- a/frontend/src/components/integrations/OutputSurfaces.tsx
+++ b/frontend/src/components/integrations/OutputSurfaces.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState, type ReactNode } from "react";
+import { Braces, SquareTerminal, Waypoints } from "lucide-react";
+
+import CopyableCommandBlock from "@/components/CopyableCommandBlock";
+
+// `stash-mcp` is a console script (pyproject.toml: stash-mcp =
+// "cli.mcp_server:main"), speaking stdio and reading the CLI's stored config —
+// so a client needs no key of its own, only a machine where `stash signin` has
+// run. Deliberately no tool count anywhere here: it drifts every time
+// cli/mcp_server.py gains a tool, and a stale number is worse than no number.
+export const MCP_CLIENT_CONFIG = `{
+  "mcpServers": {
+    "stash": { "command": "stash-mcp" }
+  }
+}`;
+
+export const CLI_SETUP = `uv tool install stashai\nstash signin`;
+
+const CLI_USAGE = `stash search "org isolation"\nstash vfs "ls /"\nstash vfs "cat '/files/spec.md'"`;
+
+export function Step({ n, children }: { n: number; children: ReactNode }) {
+  return <div className="text-[12px] font-medium text-dim">{n}. {children}</div>;
+}
+
+/** The API steps depend on where the app is served from, so they're a
+ *  component rather than a constant. */
+function ApiSteps() {
+  // The app proxies /api/v1 to the backend, so its own origin is the correct
+  // base for every deployment — hardcoding api.joinstash.ai would hand
+  // self-hosters a URL that isn't theirs.
+  const [origin, setOrigin] = useState("");
+  useEffect(() => setOrigin(window.location.origin), []);
+
+  return (
+    <div className="flex min-w-0 flex-col gap-3">
+      <Step n={1}>Mint a key</Step>
+      <Link href="/settings" className="text-[12.5px] font-medium text-brand-600 hover:underline">
+        Settings → API keys &amp; sessions →
+      </Link>
+      <Step n={2}>Call it</Step>
+      <CopyableCommandBlock
+        commands={`curl -H "Authorization: Bearer <your-key>" \\\n  ${origin || "https://your-stash"}/api/v1/me/vitals`}
+      />
+    </div>
+  );
+}
+
+export type OutputSurface = {
+  key: string;
+  name: string;
+  icon: typeof Waypoints;
+  blurb: string;
+  keywords: string;
+  body: ReactNode;
+};
+
+/** The ways an agent or a script reads a stash. Each is one box on the
+ *  Integrations grid; the setup lives in its dialog. */
+export const OUTPUT_SURFACES: OutputSurface[] = [
+  {
+    key: "mcp",
+    name: "MCP server",
+    icon: Waypoints,
+    blurb: "Point any MCP client at your stash — Claude Desktop, Cursor, anything that speaks MCP.",
+    keywords: "mcp model context protocol claude desktop cursor stash-mcp",
+    body: (
+      <div className="flex min-w-0 flex-col gap-3">
+        <Step n={1}>Install the CLI and sign in</Step>
+        <CopyableCommandBlock commands={CLI_SETUP} />
+        <Step n={2}>Add it to your client&apos;s MCP config</Step>
+        <CopyableCommandBlock commands={MCP_CLIENT_CONFIG} />
+        <p className="text-[12.5px] text-muted-foreground">
+          The server reads the CLI&apos;s stored credentials, so the client needs no key of its own.
+          It exposes search, the VFS, your sources, sessions, and the Memory wiki as tools.
+        </p>
+      </div>
+    ),
+  },
+  {
+    key: "cli",
+    name: "CLI",
+    icon: SquareTerminal,
+    blurb: "Read and write your stash from any terminal or script — the same commands your agents use.",
+    keywords: "cli terminal shell command line stash search vfs",
+    body: (
+      <div className="flex min-w-0 flex-col gap-3">
+        <Step n={1}>Install and sign in</Step>
+        <CopyableCommandBlock commands={CLI_SETUP} />
+        <Step n={2}>Read anything</Step>
+        <CopyableCommandBlock commands={CLI_USAGE} />
+        <p className="text-[12.5px] text-muted-foreground">
+          <code className="font-mono">stash --help</code> lists the rest.
+        </p>
+      </div>
+    ),
+  },
+  {
+    key: "api",
+    name: "HTTP API",
+    icon: Braces,
+    blurb: "Everything the app can do, over HTTP, authenticated with an API key.",
+    keywords: "api http rest curl key token",
+    body: <ApiSteps />,
+  },
+];

--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -1,31 +1,19 @@
 "use client";
 
 import Link from "next/link";
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
-import { ActivitySkeleton, SkeletonBlock } from "@/components/SkeletonStates";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ActivitySkeleton } from "@/components/SkeletonStates";
 import { FileIcon, PageIcon } from "@/components/SkillIcons";
-import EmbeddingSpaceExplorer from "@/components/viz/EmbeddingSpaceExplorer";
 import CuratorLog from "@/components/memory/CuratorLog";
-import WikiGraph from "@/components/memory/WikiGraph";
 import CopyableCommandBlock from "@/components/CopyableCommandBlock";
 import { StashIcon } from "@/components/SkillIcons";
 import {
-  getEmbeddingProjection,
   getMe,
   getMeOverview,
-  getMemoryGraph,
   listFileActivity,
   type ActivityEvent,
   type MeOverview,
-  type WikiGraph as WikiGraphData,
 } from "@/lib/api";
-import type { EmbeddingProjection } from "@/lib/types";
 
 const PAGE_SIZE = 50;
 
@@ -43,20 +31,17 @@ function editTimestamp(iso: string): string {
   });
 }
 
-/** The home dashboard — the wiki graph, the curator log, the knowledge map,
- *  and the file-activity feed. Renders full-page as the app's home route; the
- *  shell guarantees a signed-in user. Scrolls itself (h-full). Browsing the
- *  Memory folder itself happens in Files. */
+/** The home dashboard — your stash's vitals, the curator log, and the
+ *  file-activity feed. Renders full-page as the app's home route; the shell
+ *  guarantees a signed-in user. Scrolls itself (h-full). The graphs of the
+ *  same content live in Visualizations; browsing the Memory folder itself
+ *  happens in the VFS. */
 export default function BrainDashboard() {
   const [events, setEvents] = useState<ActivityEvent[]>([]);
   const [fetching, setFetching] = useState(true);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const sentinelRef = useRef<HTMLDivElement>(null);
-  const [projection, setProjection] = useState<EmbeddingProjection | null>(null);
-  const [graph, setGraph] = useState<WikiGraphData | null>(null);
-  const [projectionLoaded, setProjectionLoaded] = useState(false);
-  const [graphLoaded, setGraphLoaded] = useState(false);
   const [firstName, setFirstName] = useState<string | null>(null);
   const [vitals, setVitals] = useState<MeOverview | null>(null);
   const [vitalsError, setVitalsError] = useState<string | null>(null);
@@ -127,34 +112,6 @@ export default function BrainDashboard() {
     return () => obs.disconnect();
   }, [loadMore, ready]);
 
-  // The brain's vitals + visualizations. All span the user's own content plus
-  // everything shared with them (the /me/* aggregates, called without a
-  // scope, include readable shared rows). Each card renders as soon as its
-  // own fetch settles — gating them together let one slow or failing
-  // endpoint hold the whole dashboard in skeletons.
-  useEffect(() => {
-    let cancelled = false;
-    getEmbeddingProjection(2000)
-      .then((p) => {
-        if (!cancelled) setProjection(p);
-      })
-      .catch(() => {})
-      .finally(() => {
-        if (!cancelled) setProjectionLoaded(true);
-      });
-    getMemoryGraph()
-      .then((g) => {
-        if (!cancelled) setGraph(g);
-      })
-      .catch(() => {})
-      .finally(() => {
-        if (!cancelled) setGraphLoaded(true);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
   if (vitalsError) {
     return (
       <div className="flex h-full min-h-0 items-center justify-center px-8">
@@ -186,78 +143,51 @@ export default function BrainDashboard() {
           Welcome back{firstName ? `, ${firstName}` : ""}
         </h1>
 
-        {/* Dashboard grid: wiki graph with the curator log beneath it on
-            the left, knowledge map + file activity on the right. */}
-        <div className="mt-5 grid grid-cols-1 gap-4 lg:grid-cols-3">
-          <div className="flex min-w-0 flex-col gap-4 lg:col-span-2">
-            {/* Wiki graph — the curated context graph of linked pages, obsidian
-                style. The centerpiece: click a node to open its page. */}
-            <VizCard label="Memory wiki">
-              {!graphLoaded ? (
-                <SkeletonBlock className="h-[560px] w-full" />
-              ) : graph && graph.nodes.length > 0 ? (
-                <WikiGraph data={graph} />
-              ) : (
-                <div className="flex h-[560px] items-center justify-center px-2 text-center text-[12.5px] text-muted-foreground">
-                  No wiki pages yet. The Memory curator&apos;s nightly run compiles
-                  your history into a context graph of linked pages.
-                </div>
-              )}
-            </VizCard>
-
-            {/* The curator log — the curator's own account of each run,
-                beneath the structure it maintains. */}
-            <CuratorLog />
+        {vitals && (
+          <div className="mt-4 grid max-w-lg grid-cols-3 gap-3">
+            <Vital count={vitals.pages} label="pages" />
+            <Vital count={vitals.files} label="files" />
+            <Vital count={vitals.sessions} label="sessions" />
           </div>
+        )}
 
-          <div className="flex min-h-0 min-w-0 flex-col gap-4">
-            {/* Brain map — the knowledge the brain holds, laid out in space. (Decorative.) */}
-            <VizCard label="Knowledge map">
-              {!projectionLoaded ? (
-                <SkeletonBlock className="h-[240px] w-full" />
-              ) : projection && projection.points.length > 0 ? (
-                <div className="h-[240px]">
-                  <EmbeddingSpaceExplorer data={projection} />
-                </div>
-              ) : (
-                <div className="flex h-[240px] items-center justify-center px-2 text-center text-[12.5px] text-muted-foreground">
-                  No embeddings indexed yet. Pages, table rows, and session events
-                  get embedded as they&apos;re added.
-                </div>
-              )}
-            </VizCard>
-
-            {/* File activity — what's landing in the filesystem, live. The
-                Memory subtree is excluded server-side, so the curator's own
-                writes never echo here. Scrolls in place (hard cap — inside a
-                grid, flex-1 can't bound it) so the panel stays a dashboard,
-                not a page. */}
-            <section className="flex flex-col">
-              <div className="sys-label mb-1.5">File activity</div>
-              <div className="card-soft max-h-[480px] overflow-y-auto p-3">
-                <div className="flex flex-col gap-2.5">
-                  {events.length === 0 ? (
-                    <div className="rounded-[10px] border border-border bg-base px-4 py-6 text-center text-[13px] text-muted-foreground">
-                      Nothing here yet. Upload a file or edit a page and it
-                      shows up here.
-                    </div>
-                  ) : (
-                    events.map((event, i) => (
-                      <FeedCard
-                        key={`${event.kind}-${event.target_id}-${i}`}
-                        event={event}
-                      />
-                    ))
-                  )}
-                  {loadingMore && (
-                    <div className="py-2 text-center text-[12.5px] text-muted-foreground">
-                      Loading more…
-                    </div>
-                  )}
-                  {hasMore && <div ref={sentinelRef} />}
-                </div>
+        {/* Dashboard grid: the file-activity feed on the left, the curator log
+            beside it. The graphs of this same content live in Visualizations. */}
+        <div className="mt-5 grid grid-cols-1 gap-4 lg:grid-cols-3">
+          {/* File activity — what's landing in the filesystem, live. The
+              Memory subtree is excluded server-side, so the curator's own
+              writes never echo here. Flows with the page: it's the feed you
+              come to Home to read, so it pages instead of scrolling in a box. */}
+          <section className="flex min-w-0 flex-col lg:col-span-2">
+            <div className="sys-label mb-1.5">File activity</div>
+            <div className="card-soft p-3">
+              <div className="flex flex-col gap-2.5">
+                {events.length === 0 ? (
+                  <div className="rounded-[10px] border border-border bg-base px-4 py-6 text-center text-[13px] text-muted-foreground">
+                    Nothing here yet. Upload a file or edit a page and it
+                    shows up here.
+                  </div>
+                ) : (
+                  events.map((event, i) => (
+                    <FeedCard
+                      key={`${event.kind}-${event.target_id}-${i}`}
+                      event={event}
+                    />
+                  ))
+                )}
+                {loadingMore && (
+                  <div className="py-2 text-center text-[12.5px] text-muted-foreground">
+                    Loading more…
+                  </div>
+                )}
+                {hasMore && <div ref={sentinelRef} />}
               </div>
-            </section>
+            </div>
+          </section>
+
+          {/* The curator log — the curator's own account of each nightly run. */}
+          <div className="min-w-0">
+            <CuratorLog />
           </div>
         </div>
       </div>
@@ -265,24 +195,15 @@ export default function BrainDashboard() {
   );
 }
 
-// A labeled visualization card — the repeated sys-label + card-soft shell used
-// by the map, topics, and timeline sections.
-function VizCard({
-  label,
-  className,
-  scroll,
-  children,
-}: {
-  label: string;
-  className?: string;
-  scroll?: boolean;
-  children: ReactNode;
-}) {
+// One vitals counter — how much of a given thing the stash holds.
+function Vital({ count, label }: { count: number; label: string }) {
   return (
-    <section className={className}>
-      <div className="sys-label mb-1.5">{label}</div>
-      <div className={`card-soft p-3${scroll ? " overflow-x-auto" : ""}`}>{children}</div>
-    </section>
+    <div className="card-soft px-3.5 py-2.5">
+      <div className="font-display text-[20px] font-semibold tabular-nums tracking-tight text-foreground">
+        {count.toLocaleString()}
+      </div>
+      <div className="text-[12px] text-muted-foreground">{label}</div>
+    </div>
   );
 }
 

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -107,7 +107,9 @@ function DialogFooter({
     <div
       data-slot="dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        // `border-t` alone resolves to currentColor under Tailwind v4, which
+        // painted this divider near-black instead of a hairline.
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t border-border bg-muted/50 p-4 sm:flex-row sm:justify-end",
         className
       )}
       {...props}

--- a/frontend/src/components/viz/VisualizationsPage.tsx
+++ b/frontend/src/components/viz/VisualizationsPage.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { SkeletonBlock } from "@/components/SkeletonStates";
+import EmbeddingSpaceExplorer from "@/components/viz/EmbeddingSpaceExplorer";
+import KnowledgeDensityMap from "@/components/viz/KnowledgeDensityMap";
+import WikiGraph from "@/components/memory/WikiGraph";
+import {
+  getEmbeddingProjection,
+  getKnowledgeDensity,
+  getMemoryGraph,
+  type WikiGraph as WikiGraphData,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+import type { EmbeddingProjection, KnowledgeDensity } from "@/lib/types";
+
+type View = "wiki" | "embeddings" | "topics";
+
+const VIEWS: { key: View; label: string; blurb: string }[] = [
+  { key: "wiki", label: "Memory wiki", blurb: "Curated pages and the links between them. Click a node to open its page." },
+  { key: "embeddings", label: "Embedding space", blurb: "Every embedded page, table row, and session event, projected to 3D. Drag to rotate." },
+  { key: "topics", label: "Knowledge map", blurb: "What your stash holds the most of. Area is volume, shade is recency." },
+];
+
+// Module-level so each panel's loader keeps its identity across renders and
+// the fetch runs once per mounted view.
+const loadWiki = () => getMemoryGraph();
+const loadEmbeddings = () => getEmbeddingProjection(2000);
+const loadTopics = () => getKnowledgeDensity();
+
+function Centered({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-[320px] items-center justify-center px-6 text-center text-[13px] text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+/** One visualization: fetches its data on mount, then hands it to `render`.
+ *  Each view mounts only while its tab is selected. */
+function VizPanel<T>({
+  load,
+  isEmpty,
+  emptyMessage,
+  render,
+}: {
+  load: () => Promise<T>;
+  isEmpty: (data: T) => boolean;
+  emptyMessage: string;
+  render: (data: T) => ReactNode;
+}) {
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    load()
+      .then((loaded) => {
+        if (!cancelled) setData(loaded);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [load]);
+
+  if (error) return <Centered>Couldn&apos;t load this view: {error}</Centered>;
+  if (!data) return <SkeletonBlock className="h-[420px] w-full" />;
+  if (isEmpty(data)) return <Centered>{emptyMessage}</Centered>;
+  return <>{render(data)}</>;
+}
+
+/** The Visualizations section — the three views of the stash's shape, which
+ *  used to be cards on Home. One at a time, each with the full canvas. */
+export default function VisualizationsPage() {
+  const [view, setView] = useState<View>("wiki");
+  const active = VIEWS.find((v) => v.key === view)!;
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto max-w-[1360px] px-8 pb-10 pt-7">
+        <h1 className="font-display text-[22px] font-semibold tracking-tight text-foreground">
+          Visualizations
+        </h1>
+
+        <div role="tablist" aria-label="Visualizations" className="mt-4 flex gap-1 border-b border-border">
+          {VIEWS.map((v) => (
+            <button
+              key={v.key}
+              role="tab"
+              aria-selected={v.key === view}
+              onClick={() => setView(v.key)}
+              className={cn(
+                "-mb-px border-b-2 px-3 pb-2 pt-1 text-[13px] font-medium transition-colors",
+                v.key === view
+                  ? "border-brand-500 text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {v.label}
+            </button>
+          ))}
+        </div>
+
+        <p className="mt-2.5 text-[13px] text-muted-foreground">{active.blurb}</p>
+
+        <div className="card-soft mt-3 p-3">
+          {view === "wiki" && (
+            <VizPanel<WikiGraphData>
+              load={loadWiki}
+              isEmpty={(d) => d.nodes.length === 0}
+              emptyMessage="No wiki pages yet. The Memory curator's nightly run compiles your history into a context graph of linked pages."
+              render={(d) => <WikiGraph data={d} />}
+            />
+          )}
+
+          {view === "embeddings" && (
+            <VizPanel<EmbeddingProjection>
+              load={loadEmbeddings}
+              isEmpty={(d) => d.points.length === 0}
+              emptyMessage="No embeddings indexed yet. Pages, table rows, and session events get embedded as they're added."
+              render={(d) => (
+                <div className="h-[560px]">
+                  <EmbeddingSpaceExplorer data={d} />
+                </div>
+              )}
+            />
+          )}
+
+          {view === "topics" && (
+            <VizPanel<KnowledgeDensity>
+              load={loadTopics}
+              isEmpty={(d) => d.clusters.length === 0}
+              emptyMessage="Nothing to cluster yet. Topics appear once your stash has enough embedded content."
+              render={(d) => <KnowledgeDensityMap data={d} />}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -14,16 +14,16 @@ import { opensNewTab } from "@/lib/tab-nav";
 import FilesExplorer, { type Item } from "./files-explorer";
 import VfsTree from "./vfs-tree";
 
-export type ExplorerSection = "files" | "sessions" | "skills" | "agents" | "tools" | "computer";
+export type ExplorerSection = "files" | "sessions" | "skills" | "agents" | "integrations" | "computer";
 
 const SECTIONS: { key: ExplorerSection; label: string; route: string; icon: React.ReactNode }[] = [
   { key: "files", label: "Files", route: "/files", icon: <FolderTree className="h-4 w-4 text-chart-4" /> },
   { key: "skills", label: "Skills", route: "/skills", icon: <GraduationCap className="h-4 w-4 text-chart-4" /> },
   { key: "sessions", label: "Sessions", route: "/sessions", icon: <MessagesSquare className="h-4 w-4 text-chart-4" /> },
-  { key: "tools", label: "Tools", route: "/tools", icon: <Plug className="h-4 w-4 text-chart-4" /> },
+  { key: "integrations", label: "Integrations", route: "/integrations", icon: <Plug className="h-4 w-4 text-chart-4" /> },
   { key: "computer", label: "VM", route: "/agents", icon: <Monitor className="h-4 w-4 text-chart-4" /> },
 ];
-const LABEL: Record<ExplorerSection, string> = { files: "Files", skills: "Skills", sessions: "Sessions", tools: "Tools", agents: "Agents", computer: "VM" };
+const LABEL: Record<ExplorerSection, string> = { files: "Files", skills: "Skills", sessions: "Sessions", integrations: "Integrations", agents: "Agents", computer: "VM" };
 
 /** Open any item as a workbench tab and sync the URL. A plain click navigates
  *  the current tab; cmd/ctrl-click (or an explicit newTab) opens a new one. */
@@ -53,9 +53,9 @@ function LoadingRow() {
   return <div className="flex items-center gap-2 px-3 py-2 text-[12px] text-muted-foreground"><Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading…</div>;
 }
 
-// Tools = every integration/connector (Slack, Granola, GitHub, …), connected or
-// not. Clicking opens the integrations manager to connect/configure.
-function ToolsSection() {
+// Every integration/connector (Slack, Granola, GitHub, …), connected or not.
+// Clicking opens the integrations manager to connect/configure.
+function IntegrationsSection() {
   const open = useOpenTab();
   // Extension connectors have no token — source presence is their "connected".
   // OAuth/api-key connectors use the integration status, so a provider that
@@ -179,8 +179,8 @@ function RootSection() {
   const setRailSection = useWorkspace((s) => s.setRailSection);
 
   function selectSection(section: ExplorerSection) {
-    // Skills/Sessions/Tools have no explorer panel — go to their pages instead.
-    if (section === "skills" || section === "sessions" || section === "tools") {
+    // Skills/Sessions/Integrations have no explorer panel — go to their pages instead.
+    if (section === "skills" || section === "sessions" || section === "integrations") {
       router.push(SECTIONS.find((s) => s.key === section)!.route);
       return;
     }
@@ -398,7 +398,7 @@ export default function Explorer({ section }: { section: ExplorerSection }) {
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto">
-        {atRoot ? <RootSection /> : section === "computer" ? <ComputerSection /> : <ToolsSection />}
+        {atRoot ? <RootSection /> : section === "computer" ? <ComputerSection /> : <IntegrationsSection />}
       </div>
     </div>
   );

--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -12,7 +12,6 @@ import { CONNECTORS, connectorIcon, providerForSourceType } from "@/components/i
 import { INTEGRATIONS_CHANGED_EVENT, listIntegrations } from "@/lib/integrations";
 import { opensNewTab } from "@/lib/tab-nav";
 import FilesExplorer, { type Item } from "./files-explorer";
-import VfsTree from "./vfs-tree";
 
 export type ExplorerSection = "files" | "sessions" | "skills" | "agents" | "integrations" | "computer";
 
@@ -344,9 +343,6 @@ export default function Explorer({ section }: { section: ExplorerSection }) {
   const createSessionFolderItem = useCallback(async () => { await createSessionFolder("New folder"); }, []);
 
   if (section === "agents") return <AgentsExplorer />;
-
-  // The VFS section docks the same tree the /files lens shows full-screen.
-  if (section === "files") return <VfsTree />;
 
   // Skills & Sessions are file managers (own breadcrumb/toolbar).
   if ((section === "skills" || section === "sessions") && !atRoot) {

--- a/frontend/src/components/workspace/rail.test.tsx
+++ b/frontend/src/components/workspace/rail.test.tsx
@@ -56,18 +56,18 @@ describe("Rail", () => {
     const labels = Array.from(document.querySelectorAll("[aria-label]")).map((el) =>
       el.getAttribute("aria-label"),
     );
-    expect(labels).toEqual(["Integrations", "Home", "Viz", "VFS", "Chat", "Settings"]);
+    expect(labels).toEqual(["Integrations", "Home", "Viz", "Files", "Chat", "Settings"]);
   });
 
-  it("shows sessions as part of the VFS, not a section of their own", () => {
+  it("shows sessions as part of Files, not a section of their own", () => {
     renderAt("/sessions/abc");
-    expect(currentSection()).toBe("VFS");
+    expect(currentSection()).toBe("Files");
     expect(screen.queryByLabelText("Sessions")).toBeNull();
   });
 
-  it("shows an opened skill as part of the VFS", () => {
+  it("shows an opened skill as part of Files", () => {
     renderAt("/skills/folder/abc");
-    expect(currentSection()).toBe("VFS");
+    expect(currentSection()).toBe("Files");
     expect(screen.queryByLabelText("Skills")).toBeNull();
   });
 

--- a/frontend/src/components/workspace/rail.test.tsx
+++ b/frontend/src/components/workspace/rail.test.tsx
@@ -56,7 +56,7 @@ describe("Rail", () => {
     const labels = Array.from(document.querySelectorAll("[aria-label]")).map((el) =>
       el.getAttribute("aria-label"),
     );
-    expect(labels).toEqual(["Connect", "Hopper", "Home", "Viz", "Files", "Chat", "Settings"]);
+    expect(labels).toEqual(["Home", "Connect", "Files", "Viz", "Hopper", "Chat", "Settings"]);
   });
 
   it("shows sessions as part of Files, not a section of their own", () => {

--- a/frontend/src/components/workspace/rail.test.tsx
+++ b/frontend/src/components/workspace/rail.test.tsx
@@ -1,0 +1,83 @@
+// The rail is the app's whole navigation surface, and its five sections are a
+// claim about where content lives: Sessions and Skills are VFS mounts, not
+// destinations of their own. If a session route stopped lighting up the VFS
+// button, the user would be inside a section the rail says they aren't in.
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import Rail from "./rail";
+import type { User } from "@/lib/types";
+
+const route = vi.hoisted(() => ({ pathname: "/", replace: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: route.replace }),
+  usePathname: () => route.pathname,
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...rest }: { href: string; children: ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/workspace-store", () => ({
+  useWorkspace: Object.assign(
+    (selector: (s: { setRailSection: () => void }) => unknown) =>
+      selector({ setRailSection: vi.fn() }),
+    { getState: () => ({ lastVfsUrl: null }) },
+  ),
+}));
+
+const user = { display_name: "Henry", email: "henry@ferganalabs.com", name: "henry" } as User;
+
+function renderAt(pathname: string) {
+  route.pathname = pathname;
+  render(<Rail user={user} onLogout={vi.fn()} />);
+}
+
+/** The label of the section the rail is showing as current. */
+function currentSection(): string | null {
+  const current = document.querySelector('[aria-current="page"]');
+  return current?.getAttribute("aria-label") ?? null;
+}
+
+afterEach(() => {
+  cleanup();
+  route.replace.mockClear();
+});
+
+describe("Rail", () => {
+  it("offers exactly the five sections", () => {
+    renderAt("/");
+    const labels = Array.from(document.querySelectorAll("[aria-label]")).map((el) =>
+      el.getAttribute("aria-label"),
+    );
+    expect(labels).toEqual(["Integrations", "Home", "Viz", "VFS", "Chat", "Settings"]);
+  });
+
+  it("shows sessions as part of the VFS, not a section of their own", () => {
+    renderAt("/sessions/abc");
+    expect(currentSection()).toBe("VFS");
+    expect(screen.queryByLabelText("Sessions")).toBeNull();
+  });
+
+  it("shows an opened skill as part of the VFS", () => {
+    renderAt("/skills/folder/abc");
+    expect(currentSection()).toBe("VFS");
+    expect(screen.queryByLabelText("Skills")).toBeNull();
+  });
+
+  it("lights up Integrations on a provider page", () => {
+    renderAt("/integrations/slack");
+    expect(currentSection()).toBe("Integrations");
+  });
+
+  it("lights up Viz on the visualizations page", () => {
+    renderAt("/viz");
+    expect(currentSection()).toBe("Viz");
+  });
+});

--- a/frontend/src/components/workspace/rail.tsx
+++ b/frontend/src/components/workspace/rail.tsx
@@ -1,19 +1,26 @@
 "use client";
 
-import { Fragment, useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useRef, useState, type ComponentType } from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Bot, FolderTree, MessagesSquare, GraduationCap, Home, Wrench, Settings } from "lucide-react";
+import HopperIcon from "@/components/HopperIcon";
 import { cn } from "@/lib/utils";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import { useWorkspace, type RailSection } from "@/lib/workspace-store";
 import type { User } from "@/lib/types";
 
-type RailItem = { key: RailSection; label: string; icon: typeof Bot; match: (p: string) => boolean };
+type RailItem = {
+  key: RailSection;
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  match: (p: string) => boolean;
+};
 
 // Primary sections — each opens its own explorer panel (see workspace-shell).
 const PRIMARY: RailItem[] = [
   { key: "home", label: "Home", icon: Home, match: (p) => p === "/" },
+  { key: "hopper", label: "Hopper", icon: HopperIcon, match: (p) => p.startsWith("/hopper") },
   { key: "files", label: "VFS", icon: FolderTree, match: (p) => p === "/files" || p.startsWith("/f/") || p.startsWith("/p/") || p.startsWith("/folders/") || p.startsWith("/tables/") },
   { key: "sessions", label: "Sessions", icon: MessagesSquare, match: (p) => p.startsWith("/sessions") || p.startsWith("/session-folders") },
   { key: "skills", label: "Skills", icon: GraduationCap, match: (p) => p.startsWith("/skills") },
@@ -22,7 +29,9 @@ const PRIMARY: RailItem[] = [
 ];
 
 // Home is the memory dashboard — the divider separates it from the VFS
-// sections. Chat sits last: it's a lens over the stash, not a place in it.
+// sections. Hopper opens that group because it is the way in: everything
+// dropped there lands in the VFS. Chat sits last: it's a lens over the stash,
+// not a place in it.
 // Apps lives at /apps. The VM has NO entry point since it left this rail: the
 // explorer's Home root is the only thing that lists it, and that root only
 // renders once you are already inside the VM section (?section=computer).
@@ -119,6 +128,7 @@ export default function Rail({ user, onLogout }: { user: User; onLogout: () => v
     // Every other section is a page; the rail is pure navigation.
     const LANDING: Record<Exclude<RailSection, "files" | "computer">, string> = {
       home: "/",
+      hopper: "/hopper",
       agents: "/agents",
       sessions: "/sessions",
       skills: "/skills",

--- a/frontend/src/components/workspace/rail.tsx
+++ b/frontend/src/components/workspace/rail.tsx
@@ -3,7 +3,7 @@
 import { Fragment, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Bot, FolderTree, MessagesSquare, GraduationCap, Home, Wrench, Settings } from "lucide-react";
+import { Bot, FolderTree, Home, Network, Plug, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import { useWorkspace, type RailSection } from "@/lib/workspace-store";
@@ -11,21 +11,22 @@ import type { User } from "@/lib/types";
 
 type RailItem = { key: RailSection; label: string; icon: typeof Bot; match: (p: string) => boolean };
 
-// Primary sections — each opens its own explorer panel (see workspace-shell).
+// The five sections. Sessions and Skills are not among them: they are mounts
+// in the VFS, which is where you browse everything the database holds.
 const PRIMARY: RailItem[] = [
+  { key: "integrations", label: "Integrations", icon: Plug, match: (p) => p.startsWith("/integrations") },
   { key: "home", label: "Home", icon: Home, match: (p) => p === "/" },
-  { key: "files", label: "VFS", icon: FolderTree, match: (p) => p === "/files" || p.startsWith("/f/") || p.startsWith("/p/") || p.startsWith("/folders/") || p.startsWith("/tables/") },
-  { key: "sessions", label: "Sessions", icon: MessagesSquare, match: (p) => p.startsWith("/sessions") || p.startsWith("/session-folders") },
-  { key: "skills", label: "Skills", icon: GraduationCap, match: (p) => p.startsWith("/skills") },
-  { key: "tools", label: "Tools", icon: Wrench, match: (p) => p.startsWith("/tools") || p.startsWith("/integrations") },
+  { key: "viz", label: "Viz", icon: Network, match: (p) => p.startsWith("/viz") },
+  { key: "files", label: "VFS", icon: FolderTree, match: (p) => p === "/files" || p.startsWith("/f/") || p.startsWith("/p/") || p.startsWith("/folders/") || p.startsWith("/tables/") || p.startsWith("/sessions") || p.startsWith("/session-folders") || p.startsWith("/skills") },
   { key: "agents", label: "Chat", icon: Bot, match: (p) => p.startsWith("/agents") },
 ];
 
-// Home is the memory dashboard — the divider separates it from the VFS
-// sections. Chat sits last: it's a lens over the stash, not a place in it.
-// Apps lives at /apps. The VM has NO entry point since it left this rail: the
-// explorer's Home root is the only thing that lists it, and that root only
-// renders once you are already inside the VM section (?section=computer).
+// Integrations is where content enters the stash; everything below the divider
+// is what you do with it once it's in. Chat sits last: it's a lens over the
+// stash, not a place in it. Apps lives at /apps. The VM has NO entry point
+// since it left this rail: the explorer's Home root is the only thing that
+// lists it, and that root only renders once you are already inside the VM
+// section (?section=computer).
 const DIVIDER_AFTER_INDEX = 0;
 
 function RailButton({
@@ -43,6 +44,7 @@ function RailButton({
       type="button"
       onClick={onClick}
       aria-label={item.label}
+      aria-current={active ? "page" : undefined}
       className={cn(
         "flex w-full flex-col items-center gap-1 rounded-lg py-2 transition-colors",
         active
@@ -120,9 +122,8 @@ export default function Rail({ user, onLogout }: { user: User; onLogout: () => v
     const LANDING: Record<Exclude<RailSection, "files" | "computer">, string> = {
       home: "/",
       agents: "/agents",
-      sessions: "/sessions",
-      skills: "/skills",
-      tools: "/tools",
+      integrations: "/integrations",
+      viz: "/viz",
     };
     setRailSection(section);
     router.replace(LANDING[section as keyof typeof LANDING]);

--- a/frontend/src/components/workspace/rail.tsx
+++ b/frontend/src/components/workspace/rail.tsx
@@ -20,22 +20,21 @@ type RailItem = {
 // The six sections. Sessions and Skills are not among them: they are rows in
 // Files, which is where you find everything the database holds.
 const PRIMARY: RailItem[] = [
-  { key: "integrations", label: "Connect", icon: Plug, match: (p) => p.startsWith("/integrations") },
-  { key: "hopper", label: "Hopper", icon: HopperIcon, match: (p) => p.startsWith("/hopper") },
   { key: "home", label: "Home", icon: Home, match: (p) => p === "/" },
-  { key: "viz", label: "Viz", icon: Network, match: (p) => p.startsWith("/viz") },
+  { key: "integrations", label: "Connect", icon: Plug, match: (p) => p.startsWith("/integrations") },
   { key: "files", label: "Files", icon: Files, match: (p) => p === "/files" || p.startsWith("/f/") || p.startsWith("/p/") || p.startsWith("/folders/") || p.startsWith("/tables/") || p.startsWith("/sessions") || p.startsWith("/session-folders") || p.startsWith("/skills") },
+  { key: "viz", label: "Viz", icon: Network, match: (p) => p.startsWith("/viz") },
+  { key: "hopper", label: "Hopper", icon: HopperIcon, match: (p) => p.startsWith("/hopper") },
   { key: "agents", label: "Chat", icon: Bot, match: (p) => p.startsWith("/agents") },
 ];
 
-// Connect and Hopper are where content enters the stash — sources sync in,
-// anything else gets dropped in; everything below the divider is what you do
-// with it once it's in. Chat sits last: it's a lens over the stash, not a
-// place in it. Apps lives at /apps. The VM has NO entry point since it left
-// this rail: the explorer's Home root is the only thing that lists it, and
-// that root only renders once you are already inside the VM section
+// Home leads; everything under the divider is the stash itself — how content
+// gets in (Connect, Hopper), where it's found (Files), and lenses over it
+// (Viz, Chat last). Apps lives at /apps. The VM has NO entry point since it
+// left this rail: the explorer's Home root is the only thing that lists it,
+// and that root only renders once you are already inside the VM section
 // (?section=computer).
-const DIVIDER_AFTER_INDEX = 1;
+const DIVIDER_AFTER_INDEX = 0;
 
 function RailButton({
   item,

--- a/frontend/src/components/workspace/rail.tsx
+++ b/frontend/src/components/workspace/rail.tsx
@@ -3,7 +3,7 @@
 import { Fragment, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Bot, FolderTree, Home, Network, Plug, Settings } from "lucide-react";
+import { Bot, Files, Home, Network, Plug, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import { useWorkspace, type RailSection } from "@/lib/workspace-store";
@@ -17,7 +17,7 @@ const PRIMARY: RailItem[] = [
   { key: "integrations", label: "Integrations", icon: Plug, match: (p) => p.startsWith("/integrations") },
   { key: "home", label: "Home", icon: Home, match: (p) => p === "/" },
   { key: "viz", label: "Viz", icon: Network, match: (p) => p.startsWith("/viz") },
-  { key: "files", label: "VFS", icon: FolderTree, match: (p) => p === "/files" || p.startsWith("/f/") || p.startsWith("/p/") || p.startsWith("/folders/") || p.startsWith("/tables/") || p.startsWith("/sessions") || p.startsWith("/session-folders") || p.startsWith("/skills") },
+  { key: "files", label: "Files", icon: Files, match: (p) => p === "/files" || p.startsWith("/f/") || p.startsWith("/p/") || p.startsWith("/folders/") || p.startsWith("/tables/") || p.startsWith("/sessions") || p.startsWith("/session-folders") || p.startsWith("/skills") },
   { key: "agents", label: "Chat", icon: Bot, match: (p) => p.startsWith("/agents") },
 ];
 

--- a/frontend/src/components/workspace/rail.tsx
+++ b/frontend/src/components/workspace/rail.tsx
@@ -21,7 +21,7 @@ type RailItem = {
 const PRIMARY: RailItem[] = [
   { key: "home", label: "Home", icon: Home, match: (p) => p === "/" },
   { key: "hopper", label: "Hopper", icon: HopperIcon, match: (p) => p.startsWith("/hopper") },
-  { key: "files", label: "VFS", icon: FolderTree, match: (p) => p === "/files" || p.startsWith("/f/") || p.startsWith("/p/") || p.startsWith("/folders/") || p.startsWith("/tables/") },
+  { key: "files", label: "VFS", icon: FolderTree, match: (p) => p === "/files" || p.startsWith("/vfs") || p.startsWith("/f/") || p.startsWith("/p/") || p.startsWith("/folders/") || p.startsWith("/tables/") },
   { key: "sessions", label: "Sessions", icon: MessagesSquare, match: (p) => p.startsWith("/sessions") || p.startsWith("/session-folders") },
   { key: "skills", label: "Skills", icon: GraduationCap, match: (p) => p.startsWith("/skills") },
   { key: "tools", label: "Tools", icon: Wrench, match: (p) => p.startsWith("/tools") || p.startsWith("/integrations") },

--- a/frontend/src/components/workspace/topbar.tsx
+++ b/frontend/src/components/workspace/topbar.tsx
@@ -2,30 +2,39 @@
 
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { Search } from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
+import { ArrowLeft, ArrowRight, Search } from "lucide-react";
 import CommandPalette from "@/components/CommandPalette";
 import { StashIcon } from "@/components/SkillIcons";
+import { useFilesSearch } from "@/components/content/flat-files/search-store";
 import ScopeSwitcher from "./scope-switcher";
 
 /** Full-width top bar: octopus logo + breadcrumb (left), ⌘K search (center),
- *  share action (right). Account actions live on the rail's bottom avatar. */
+ *  share action (right). Account actions live on the rail's bottom avatar.
+ *  On /files the search bar IS the page's search: it filters the flat list
+ *  live instead of opening the palette. */
 export default function Topbar() {
   const pathname = usePathname();
+  const router = useRouter();
   const [cmdkOpen, setCmdkOpen] = useState(false);
   const searchBarRef = useRef<HTMLDivElement>(null);
+  const filesInputRef = useRef<HTMLInputElement>(null);
   const isSearchPage = pathname === "/search";
+  const isFilesPage = pathname === "/files";
+  const filesQuery = useFilesSearch((s) => s.query);
+  const setFilesQuery = useFilesSearch((s) => s.setQuery);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && e.key === "k" && !isSearchPage) {
         e.preventDefault();
-        setCmdkOpen((o) => !o);
+        if (isFilesPage) filesInputRef.current?.focus();
+        else setCmdkOpen((o) => !o);
       }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [isSearchPage]);
+  }, [isSearchPage, isFilesPage]);
 
   return (
     <header className="flex h-12 shrink-0 items-center gap-3 bg-rail px-3">
@@ -35,17 +44,54 @@ export default function Topbar() {
           <span className="text-[15px] font-semibold tracking-tight text-foreground">Stash</span>
         </Link>
         <ScopeSwitcher />
+        {/* IDE-style history nav: back is "wherever I just was", not "up a
+            level" — the same arrows VS Code keeps beside its command center. */}
+        <div className="flex items-center">
+          <button
+            type="button"
+            onClick={() => router.back()}
+            aria-label="Go back"
+            title="Go back"
+            className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-raised hover:text-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={() => router.forward()}
+            aria-label="Go forward"
+            title="Go forward"
+            className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-raised hover:text-foreground"
+          >
+            <ArrowRight className="h-4 w-4" />
+          </button>
+        </div>
       </div>
       <div className="flex min-w-0 flex-1 justify-center">
         <div ref={searchBarRef} className="w-full max-w-2xl">
-          <button
-            onClick={() => setCmdkOpen(true)}
-            className="flex h-9 w-full items-center gap-2.5 rounded-full border border-border bg-surface px-4 text-left text-[13px] text-muted-foreground shadow-sm transition-colors hover:border-brand-300 hover:bg-raised hover:text-foreground"
-          >
-            <Search className="h-4 w-4 shrink-0" />
-            <span className="min-w-0 flex-1 truncate">Search</span>
-            <span className="rounded bg-base px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground ring-1 ring-border">⌘K</span>
-          </button>
+          {isFilesPage ? (
+            <div className="flex h-9 w-full items-center gap-2.5 rounded-full border border-border bg-surface px-4 text-[13px] shadow-sm transition-colors focus-within:border-brand-300">
+              <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <input
+                ref={filesInputRef}
+                autoFocus
+                value={filesQuery}
+                onChange={(e) => setFilesQuery(e.target.value)}
+                placeholder="Search everything in your stash…"
+                className="min-w-0 flex-1 bg-transparent text-foreground outline-none placeholder:text-muted-foreground"
+              />
+              <span className="rounded bg-base px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground ring-1 ring-border">⌘K</span>
+            </div>
+          ) : (
+            <button
+              onClick={() => setCmdkOpen(true)}
+              className="flex h-9 w-full items-center gap-2.5 rounded-full border border-border bg-surface px-4 text-left text-[13px] text-muted-foreground shadow-sm transition-colors hover:border-brand-300 hover:bg-raised hover:text-foreground"
+            >
+              <Search className="h-4 w-4 shrink-0" />
+              <span className="min-w-0 flex-1 truncate">Search</span>
+              <span className="rounded bg-base px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground ring-1 ring-border">⌘K</span>
+            </button>
+          )}
         </div>
       </div>
       <div className="w-[120px] shrink-0" />

--- a/frontend/src/components/workspace/vfs-tree.tsx
+++ b/frontend/src/components/workspace/vfs-tree.tsx
@@ -10,9 +10,11 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
-import { ArrowUpRight, ChevronRight } from "lucide-react";
+import { ArrowUpRight, ChevronRight, FolderPlus } from "lucide-react";
 import { create } from "zustand";
 import { Skeleton } from "@/components/ui/skeleton";
+import { createFolder } from "@/lib/api";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import type { VNode } from "@/components/content/files-overview/build";
 import { NodeIcon, useVfsMounts, type Mount } from "@/components/content/files-overview/useVfsMounts";
@@ -74,6 +76,26 @@ function ancestorsOf(nodes: VNode[], pathname: string, trail: string[]): string[
   return null;
 }
 
+// Each directory renders only its first SHOW_PER_DIR children, so an item can
+// be revealed — ancestors expanded, row marked active — and still not be on
+// screen because it fell past the "+N more" cut. This is the key of the
+// directory holding the match, whose list then has to be shown in full.
+function truncatedParentOf(
+  nodes: VNode[],
+  pathname: string,
+  parentKey: string,
+): string | null {
+  const index = nodes.findIndex((node) => pathOf(node.href) === pathname);
+  if (index >= SHOW_PER_DIR) return parentKey;
+  if (index !== -1) return null;
+  for (const node of nodes) {
+    if (!node.children) continue;
+    const found = truncatedParentOf(node.children, pathname, node.key);
+    if (found) return found;
+  }
+  return null;
+}
+
 function Row({
   depth,
   icon,
@@ -86,6 +108,7 @@ function Row({
   href,
   mono,
   onToggle,
+  onAddFolder,
 }: {
   depth: number;
   icon: React.ReactNode;
@@ -98,6 +121,8 @@ function Row({
   href?: string;
   mono?: boolean;
   onToggle?: () => void;
+  /** Present on rows that can hold folders; shown on hover. */
+  onAddFolder?: () => void;
 }) {
   const pad = { paddingLeft: 6 + depth * INDENT_PX };
   const inner = (
@@ -138,6 +163,21 @@ function Row({
       {annotation && (
         <span className="shrink-0 pl-1.5 font-mono text-[10.5px] text-muted-foreground">{annotation}</span>
       )}
+      {onAddFolder && (
+        <span
+          role="button"
+          aria-label="New folder"
+          title="New folder"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onAddFolder();
+          }}
+          className="ml-0.5 hidden shrink-0 rounded p-0.5 text-muted-foreground hover:bg-raised hover:text-brand-700 group-hover:block"
+        >
+          <FolderPlus className="h-3.5 w-3.5" />
+        </span>
+      )}
     </>
   );
   const cls = cn(
@@ -147,19 +187,78 @@ function Row({
   if (href) {
     return (
       // Navigating into a closed folder also opens it, like VS Code.
-      <Link href={href} style={pad} className={cls} onClick={() => { if (isDir && !open) onToggle?.(); }}>
+      <Link
+        href={href}
+        style={pad}
+        className={cls}
+        data-vfs-active={active || undefined}
+        onClick={() => { if (isDir && !open) onToggle?.(); }}
+      >
         {inner}
       </Link>
     );
   }
   if (isDir) {
     return (
-      <button type="button" onClick={onToggle} style={pad} className={cls}>
+      <button type="button" onClick={onToggle} style={pad} className={cls} data-vfs-active={active || undefined}>
         {inner}
       </button>
     );
   }
   return <div style={pad} className={cn(cls, "hover:bg-transparent")}>{inner}</div>;
+}
+
+/** The row that appears when you click +: type a name, Enter creates it,
+ *  Escape gives up. No dialog for something this small. */
+function NewFolderRow({
+  depth,
+  parentId,
+  onDone,
+}: {
+  depth: number;
+  parentId: string | null;
+  onDone: (created: boolean) => void;
+}) {
+  const [name, setName] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  async function create() {
+    const trimmed = name.trim();
+    if (!trimmed || saving) return;
+    setSaving(true);
+    try {
+      await createFolder(trimmed, parentId);
+      onDone(true);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Couldn't create that folder");
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div
+      style={{ paddingLeft: 6 + depth * INDENT_PX }}
+      className="flex w-full items-center gap-1.5 py-[3px] pr-1.5"
+    >
+      <span className="w-4 shrink-0" />
+      <span className="flex w-[15px] shrink-0 items-center justify-center text-brand-600">
+        <FolderPlus className="h-3.5 w-3.5" />
+      </span>
+      <input
+        autoFocus
+        value={name}
+        disabled={saving}
+        onChange={(e) => setName(e.target.value)}
+        onBlur={() => onDone(false)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") void create();
+          if (e.key === "Escape") onDone(false);
+        }}
+        placeholder="folder name"
+        className="min-w-0 flex-1 rounded-sm bg-transparent text-[13px] text-foreground outline-none ring-1 ring-brand-400 placeholder:text-muted-foreground"
+      />
+    </div>
+  );
 }
 
 function Nodes({
@@ -171,6 +270,10 @@ function Nodes({
   pathname,
   showAll,
   onRevealAll,
+  addingIn,
+  onAddFolder,
+  onAddDone,
+  foldable,
 }: {
   nodes: VNode[];
   depth: number;
@@ -180,6 +283,10 @@ function Nodes({
   pathname: string;
   showAll: Set<string>;
   onRevealAll: (key: string) => void;
+  addingIn: string | null;
+  onAddFolder: (parentId: string | null) => void;
+  onAddDone: (created: boolean) => void;
+  foldable: boolean;
 }) {
   const expanded = useVfsTreeStore((s) => s.expanded);
   const toggleNode = useVfsTreeStore((s) => s.toggleNode);
@@ -206,7 +313,13 @@ function Nodes({
               active={pathOf(node.href) === pathname}
               href={node.href}
               onToggle={() => toggleNode(node.key)}
+              onAddFolder={
+                foldable && node.kind === "folder" ? () => onAddFolder(node.key) : undefined
+              }
             />
+            {addingIn === node.key && (
+              <NewFolderRow depth={depth + 1} parentId={node.key} onDone={onAddDone} />
+            )}
             {open && (
               <Nodes
                 nodes={node.children!}
@@ -217,6 +330,10 @@ function Nodes({
                 pathname={pathname}
                 showAll={showAll}
                 onRevealAll={onRevealAll}
+                addingIn={addingIn}
+                onAddFolder={onAddFolder}
+                onAddDone={onAddDone}
+                foldable={foldable}
               />
             )}
           </div>
@@ -256,11 +373,17 @@ function MountBlock({
   pathname,
   showAll,
   onRevealAll,
+  addingIn,
+  onAddFolder,
+  onAddDone,
 }: {
   mount: Mount;
   pathname: string;
   showAll: Set<string>;
   onRevealAll: (key: string) => void;
+  addingIn: string | null;
+  onAddFolder: (parentId: string | null) => void;
+  onAddDone: (created: boolean) => void;
 }) {
   const collapsedMounts = useVfsTreeStore((s) => s.collapsedMounts);
   const toggleMount = useVfsTreeStore((s) => s.toggleMount);
@@ -268,6 +391,7 @@ function MountBlock({
   // In the lens /files is where you already are; docked, its row is the way
   // back to the full-screen view.
   const href = mount.path === "/files" ? "/files" : mount.href;
+  const foldable = mount.path === "/files";
   const pad = { paddingLeft: 6 + INDENT_PX };
 
   return (
@@ -282,7 +406,11 @@ function MountBlock({
         href={href}
         mono
         onToggle={() => toggleMount(mount.path)}
+        onAddFolder={foldable ? () => onAddFolder(null) : undefined}
       />
+      {foldable && addingIn === ROOT_KEY && (
+        <NewFolderRow depth={1} parentId={null} onDone={onAddDone} />
+      )}
       {open && (
         <>
           {mount.nodes.length === 0 && !mount.footer ? (
@@ -291,6 +419,10 @@ function MountBlock({
             </div>
           ) : (
             <Nodes
+              addingIn={addingIn}
+              onAddFolder={onAddFolder}
+              onAddDone={onAddDone}
+              foldable={foldable}
               nodes={mount.nodes}
               depth={1}
               parentKey={mount.path}
@@ -317,10 +449,16 @@ function MountBlock({
   );
 }
 
+// The sentinel for "creating at the top level of /files", where there is no
+// parent folder id to key off.
+const ROOT_KEY = "__root__";
+
 export default function VfsTree() {
   const pathname = usePathname();
-  const { mounts, coreLoaded, coreError, sourcesPending, sourcesError } = useVfsMounts();
+  const { mounts, coreLoaded, coreError, sourcesPending, sourcesError, reload } = useVfsMounts();
+  const [addingIn, setAddingIn] = useState<string | null>(null);
   const reveal = useVfsTreeStore((s) => s.reveal);
+  const expanded = useVfsTreeStore((s) => s.expanded);
   const [showAll, setShowAll] = useState<Set<string>>(new Set());
 
   // Whatever the workbench has open gets its ancestor chain expanded, so the
@@ -328,12 +466,20 @@ export default function VfsTree() {
   useEffect(() => {
     for (const mount of mounts) {
       const trail = ancestorsOf(mount.nodes, pathname, []);
-      if (trail) {
-        reveal(mount.path, trail);
-        return;
-      }
+      if (!trail) continue;
+      reveal(mount.path, trail);
+      const truncated = truncatedParentOf(mount.nodes, pathname, mount.path);
+      if (truncated) setShowAll((prev) => new Set(prev).add(truncated));
+      return;
     }
   }, [pathname, mounts, reveal]);
+
+  // Orientation needs the highlight on screen, and the row only exists once
+  // its ancestors are expanded and its directory un-truncated — so this runs
+  // after those, not with them. "nearest" leaves an already-visible row alone.
+  useEffect(() => {
+    document.querySelector("[data-vfs-active]")?.scrollIntoView({ block: "nearest" });
+  }, [pathname, expanded, showAll]);
 
   if (coreError) {
     return <div className="p-3 font-mono text-[12px] text-error">✗ couldn&apos;t read the stash: {coreError}</div>;
@@ -355,6 +501,16 @@ export default function VfsTree() {
           pathname={pathname}
           showAll={showAll}
           onRevealAll={(key) => setShowAll((prev) => new Set(prev).add(key))}
+          addingIn={addingIn}
+          onAddFolder={(parentId) => {
+            // Creating inside a folder only makes sense with it open.
+            if (parentId) reveal("/files", [parentId]);
+            setAddingIn(parentId ?? ROOT_KEY);
+          }}
+          onAddDone={(created) => {
+            setAddingIn(null);
+            if (created) reload();
+          }}
         />
       ))}
       {coreLoaded && sourcesPending && (

--- a/frontend/src/components/workspace/vfs-tree.tsx
+++ b/frontend/src/components/workspace/vfs-tree.tsx
@@ -388,9 +388,10 @@ function MountBlock({
   const collapsedMounts = useVfsTreeStore((s) => s.collapsedMounts);
   const toggleMount = useVfsTreeStore((s) => s.toggleMount);
   const open = !collapsedMounts.has(mount.path);
-  // In the lens /files is where you already are; docked, its row is the way
-  // back to the full-screen view.
-  const href = mount.path === "/files" ? "/files" : mount.href;
+  // Every mount row opens its own browse view, /files included. Zooming back
+  // out to the lens is the rail's VFS button, not a row that behaves unlike
+  // its neighbours.
+  const href = mount.href;
   const foldable = mount.path === "/files";
   const pad = { paddingLeft: 6 + INDENT_PX };
 

--- a/frontend/src/components/workspace/workspace-shell.test.tsx
+++ b/frontend/src/components/workspace/workspace-shell.test.tsx
@@ -1,16 +1,16 @@
 // A section route whose page.tsx isn't in rendersRouteContent silently shows
-// the workbench instead of the page — the Tools/MCP page shipped dead this way
+// the workbench instead of the page — the Integrations/MCP page shipped dead this way
 // (tests rendered the component directly, the shell never did). This locks the
 // route → content mapping so a new management page failing to register fails a
 // test instead of failing in prod.
 import { beforeEach, describe, expect, it } from "vitest";
-import { rendersRouteContent } from "./workspace-shell";
+import { rendersRouteContent, sectionForPath } from "./workspace-shell";
 import { WORKBENCH_TAB_KINDS, urlForTab, hasPermanentUrl } from "@/lib/workspace-routes";
 import { useWorkspace } from "@/lib/workspace-store";
 
 describe("rendersRouteContent", () => {
   it("renders management pages beside the explorer", () => {
-    expect(rendersRouteContent("/tools", null, null)).toBe(true);
+    expect(rendersRouteContent("/integrations", null, null)).toBe(true);
     expect(rendersRouteContent("/sessions", null, null)).toBe(true);
     expect(rendersRouteContent("/skills", null, null)).toBe(true);
     expect(rendersRouteContent("/files", null, null)).toBe(true);
@@ -30,12 +30,39 @@ describe("rendersRouteContent", () => {
   });
 
   it("an explicit explorer section always wins", () => {
-    expect(rendersRouteContent("/tools", "files", null)).toBe(false);
-    expect(rendersRouteContent("/sessions", "skills", null)).toBe(false);
+    expect(rendersRouteContent("/integrations", "files", null)).toBe(false);
+    expect(rendersRouteContent("/sessions", "files", null)).toBe(false);
   });
 
   it("sessions workspace view keeps the workbench", () => {
     expect(rendersRouteContent("/sessions", null, "1")).toBe(false);
+  });
+});
+
+// Sessions and Skills are VFS mounts, so their routes belong to the VFS
+// section: that is what docks the tree beside them and keeps the rail's VFS
+// button lit. Mapping them anywhere else strands the user in a section with
+// no panel and no rail entry.
+describe("sectionForPath", () => {
+  it("puts sessions and skills in the VFS", () => {
+    expect(sectionForPath("/sessions")).toBe("files");
+    expect(sectionForPath("/sessions/abc")).toBe("files");
+    expect(sectionForPath("/session-folders/team")).toBe("files");
+    expect(sectionForPath("/skills")).toBe("files");
+    expect(sectionForPath("/skills/folder/abc")).toBe("files");
+    expect(sectionForPath("/files")).toBe("files");
+  });
+
+  it("keeps integrations and chat in their own sections", () => {
+    expect(sectionForPath("/integrations")).toBe("integrations");
+    expect(sectionForPath("/integrations/slack")).toBe("integrations");
+    expect(sectionForPath("/agents")).toBe("agents");
+  });
+
+  it("leaves the full-page routes sectionless", () => {
+    expect(sectionForPath("/")).toBeNull();
+    expect(sectionForPath("/viz")).toBeNull();
+    expect(sectionForPath("/settings")).toBeNull();
   });
 });
 
@@ -48,7 +75,7 @@ describe("rendersRouteContent", () => {
 describe("tabs the workbench can host", () => {
   it("every hostable kind's URL still lands on the workbench", () => {
     for (const kind of WORKBENCH_TAB_KINDS) {
-      // `tool` with the legacy "integrations" refId routes to the /tools
+      // `tool` with the "integrations" refId routes to the /integrations
       // management page, so give every kind a content-shaped refId.
       const [path, query] = urlForTab({ kind, refId: "abc" }).split("?");
       const workspaceParam = new URLSearchParams(query).get("workspace");

--- a/frontend/src/components/workspace/workspace-shell.tsx
+++ b/frontend/src/components/workspace/workspace-shell.tsx
@@ -71,7 +71,10 @@ function ExplorerPanel({ section }: { section: ExplorerSection }) {
  *  render the tab workbench; `/sessions` keeps its full management page
  *  beside the Sessions explorer. */
 function sectionForPath(pathname: string): ExplorerSection | null {
-  if (pathname === "/files" || /^\/(p|f|folders|tables)\//.test(pathname)) return "files";
+  // /vfs/<mount>/... browses a mount as a filesystem, so it belongs to the
+  // Files section however deep it goes — including into /sessions or /skills,
+  // whose management pages are a different section entirely.
+  if (pathname === "/files" || pathname.startsWith("/vfs") || /^\/(p|f|folders|tables)\//.test(pathname)) return "files";
   if (pathname === "/sessions" || pathname.startsWith("/sessions/") || pathname.startsWith("/session-folders")) return "sessions";
   if (pathname === "/skills" || pathname.startsWith("/skills/folder")) return "skills";
   if (pathname === "/agents") return "agents";
@@ -91,6 +94,9 @@ export function rendersRouteContent(
   // The Files home is the bird's-eye view of the whole stash; opening any
   // item navigates to its own route, which returns to the workbench.
   if (pathname === "/files") return true;
+  // The VFS browse view is a page in its own right, beside the docked tree —
+  // it is what the tree is a miniature of, not something to open in a tab.
+  if (pathname.startsWith("/vfs")) return true;
   if (pathname === "/sessions") return workspaceParam !== "1";
   // The Skills home is the launcher — pick a skill, run it. Only the bare
   // path: /skills/folder/<id> is a skill you opened, which belongs in a tab.

--- a/frontend/src/components/workspace/workspace-shell.tsx
+++ b/frontend/src/components/workspace/workspace-shell.tsx
@@ -16,12 +16,11 @@ const MIN_W = 220;
 const MAX_W = 600;
 const EXPLORER_SECTIONS: ExplorerSection[] = ["files", "agents", "integrations", "computer"];
 
-// Only the VFS keeps the tree sidebar. Integrations and Agents render
-// full-width — the explorers were a second nav axis over the same content as
-// the rail, and the two looked independent. Agents brings its own
-// ChatGPT-style chat list; the VM (browser) keeps its panel because that
-// content lives nowhere else.
-const PANELLED_SECTIONS: ExplorerSection[] = ["files", "computer"];
+// Only the VM (browser) keeps a docked panel — that content lives nowhere
+// else. Files is a flat searchable list at /files with full-width detail
+// views; Integrations and Agents render full-width for the same reason the
+// explorers were dropped: a second nav axis over the rail's content.
+const PANELLED_SECTIONS: ExplorerSection[] = ["computer"];
 
 /** Resizable explorer panel — drag the right edge to set width (persisted). */
 function ExplorerPanel({ section }: { section: ExplorerSection }) {
@@ -139,10 +138,10 @@ export default function WorkspaceShell({
     setLastVfsUrl(query ? `${pathname}?${query}` : pathname);
   }, [section, pathname, searchParams, setLastVfsUrl]);
 
-  // /files IS a file tree — showing the explorer's tree beside it would be
-  // the same thing twice. An explicit ?section= still summons the panel.
+  // /files is the flat list itself; it renders as a plain full page, not
+  // inside the workbench chrome.
   const isFilesHome = pathname === "/files" && !selectedSection;
-  const showExplorer = section !== null && PANELLED_SECTIONS.includes(section) && !isFilesHome;
+  const showExplorer = section !== null && PANELLED_SECTIONS.includes(section);
 
   return (
     // Chrome surface — the content panel floats on top of it.

--- a/frontend/src/components/workspace/workspace-shell.tsx
+++ b/frontend/src/components/workspace/workspace-shell.tsx
@@ -14,13 +14,13 @@ import Workbench from "./workbench";
 const WIDTH_KEY = "moltchat_explorer_width";
 const MIN_W = 220;
 const MAX_W = 600;
-const EXPLORER_SECTIONS: ExplorerSection[] = ["files", "sessions", "skills", "agents", "tools", "computer"];
+const EXPLORER_SECTIONS: ExplorerSection[] = ["files", "agents", "integrations", "computer"];
 
-// Experiment (2026-08-10): only the VFS keeps the tree sidebar. Sessions,
-// Skills, Tools, and Agents render full-width — the explorers were a second
-// nav axis over the same content as the rail, and the two looked independent.
-// Agents brings its own ChatGPT-style chat list; the VM (browser) keeps its
-// panel because that content lives nowhere else.
+// Only the VFS keeps the tree sidebar. Integrations and Agents render
+// full-width — the explorers were a second nav axis over the same content as
+// the rail, and the two looked independent. Agents brings its own
+// ChatGPT-style chat list; the VM (browser) keeps its panel because that
+// content lives nowhere else.
 const PANELLED_SECTIONS: ExplorerSection[] = ["files", "computer"];
 
 /** Resizable explorer panel — drag the right edge to set width (persisted). */
@@ -70,12 +70,14 @@ function ExplorerPanel({ section }: { section: ExplorerSection }) {
  *  the wiki, Discover, Settings, published skill pages, …). Most sections
  *  render the tab workbench; `/sessions` keeps its full management page
  *  beside the Sessions explorer. */
-function sectionForPath(pathname: string): ExplorerSection | null {
+export function sectionForPath(pathname: string): ExplorerSection | null {
+  // Sessions and Skills are VFS mounts, not sections of their own: they open
+  // beside the same tree that lists them.
   if (pathname === "/files" || /^\/(p|f|folders|tables)\//.test(pathname)) return "files";
-  if (pathname === "/sessions" || pathname.startsWith("/sessions/") || pathname.startsWith("/session-folders")) return "sessions";
-  if (pathname === "/skills" || pathname.startsWith("/skills/folder")) return "skills";
+  if (pathname === "/sessions" || pathname.startsWith("/sessions/") || pathname.startsWith("/session-folders")) return "files";
+  if (pathname === "/skills" || pathname.startsWith("/skills/folder")) return "files";
   if (pathname === "/agents") return "agents";
-  if (pathname === "/tools" || pathname.startsWith("/integrations")) return "tools";
+  if (pathname.startsWith("/integrations")) return "integrations";
   return null;
 }
 
@@ -95,18 +97,18 @@ export function rendersRouteContent(
   // The Skills home is the launcher — pick a skill, run it. Only the bare
   // path: /skills/folder/<id> is a skill you opened, which belongs in a tab.
   if (pathname === "/skills") return true;
-  // The MCP-server registry is a management page like /sessions.
-  if (pathname === "/tools") return true;
+  // The connector + MCP-server registry is a management page like /sessions.
+  if (pathname === "/integrations") return true;
   // /agents is the ChatGPT-style chat page — its own sidebar, no workbench.
   return pathname === "/agents";
 }
 
 
 /**
- * The app shell — icon rail + top bar + main area. Each primary rail section
- * (Files/Sessions/Skills/Agents/Tools) shows its own explorer panel. The Files
- * section drives the tab workbench; other sections render their route content
- * beside the explorer. Secondary routes (Index/Discover/Settings) render full.
+ * The app shell — icon rail + top bar + main area. The VFS section shows the
+ * tree panel and drives the tab workbench; other sections render their route
+ * content in its place. Full-page routes (Home/Visualizations/Discover/
+ * Settings) render without either.
  */
 export default function WorkspaceShell({
   user,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2436,3 +2436,46 @@ export async function bulkEditRows(
     body: JSON.stringify(body),
   });
 }
+
+// --- Hopper ---
+
+// What a drop became in the VFS. A link has no target yet — a worker fetches
+// the page — so its id is the import job and app_url is null.
+export interface HopperDrop {
+  kind: "file" | "page" | "link";
+  id: string;
+  name: string;
+  app_url: string | null;
+}
+
+export async function dropHopperFile(file: File): Promise<HopperDrop> {
+  if (file.size > MAX_UPLOAD_BYTES) {
+    throw new Error(`${file.name} is too large (max 100 MB)`);
+  }
+  const token = await getAuthToken();
+  const formData = new FormData();
+  formData.append("file", file);
+  // Hand-rolled fetch (FormData sets its own Content-Type), so the auth and
+  // scope headers have to be attached here rather than by apiFetch.
+  const headers: Record<string, string> = {};
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  const scopeUserId = getScopeUserId();
+  if (scopeUserId) headers[SCOPE_HEADER] = scopeUserId;
+  const resp = await fetch(`${API_BASE}${ME}/hopper/file`, {
+    method: "POST",
+    headers,
+    body: formData,
+  });
+  if (!resp.ok) {
+    const detail = await resp.json().then((d) => d.detail).catch(() => resp.statusText);
+    throw new Error(typeof detail === "string" ? detail : `Upload failed (${resp.status})`);
+  }
+  return resp.json();
+}
+
+export async function dropHopperLink(url: string): Promise<HopperDrop> {
+  return apiFetch(`${ME}/hopper/link`, {
+    method: "POST",
+    body: JSON.stringify({ url }),
+  });
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1883,6 +1883,9 @@ export interface TreePage {
   name: string;
   content_type: "markdown" | "html";
   folder_id: string | null;
+  updated_at: string;
+  /** Agent that made the last edit; null when a human edited last. */
+  last_edit_agent_name: string | null;
 }
 export interface TreeFile {
   id: string;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2490,7 +2490,7 @@ export async function dropHopperFile(
 export async function classifyDrop(
   kind: "file" | "page",
   id: string,
-): Promise<{ filed_in: string | null }> {
+): Promise<{ filed_in: string | null; folder_id: string | null }> {
   return apiFetch(`${ME}/hopper/classify`, {
     method: "POST",
     body: JSON.stringify({ kind, id }),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2446,15 +2446,25 @@ export interface HopperDrop {
   id: string;
   name: string;
   app_url: string | null;
+  // True when the item was already there — a re-dropped folder skips rather
+  // than doubling its contents.
+  duplicate: boolean;
+  // True when it landed loose and is worth asking classifyDrop about.
+  classifiable: boolean;
 }
 
-export async function dropHopperFile(file: File): Promise<HopperDrop> {
+export async function dropHopperFile(
+  file: File,
+  options: { path?: string[]; signal?: AbortSignal } = {},
+): Promise<HopperDrop> {
   if (file.size > MAX_UPLOAD_BYTES) {
     throw new Error(`${file.name} is too large (max 100 MB)`);
   }
   const token = await getAuthToken();
   const formData = new FormData();
   formData.append("file", file);
+  // A dropped folder mirrors its structure; the server resolves the chain.
+  if (options.path?.length) formData.append("path", options.path.join("/"));
   // Hand-rolled fetch (FormData sets its own Content-Type), so the auth and
   // scope headers have to be attached here rather than by apiFetch.
   const headers: Record<string, string> = {};
@@ -2465,12 +2475,26 @@ export async function dropHopperFile(file: File): Promise<HopperDrop> {
     method: "POST",
     headers,
     body: formData,
+    signal: options.signal,
   });
   if (!resp.ok) {
     const detail = await resp.json().then((d) => d.detail).catch(() => resp.statusText);
     throw new Error(typeof detail === "string" ? detail : `Upload failed (${resp.status})`);
   }
   return resp.json();
+}
+
+/** Decide where a loose item belongs and move it. Asked for after the upload
+ *  has already been confirmed, so the model never sits between a person and
+ *  the news that their file arrived. */
+export async function classifyDrop(
+  kind: "file" | "page",
+  id: string,
+): Promise<{ filed_in: string | null }> {
+  return apiFetch(`${ME}/hopper/classify`, {
+    method: "POST",
+    body: JSON.stringify({ kind, id }),
+  });
 }
 
 export async function dropHopperLink(url: string): Promise<HopperDrop> {

--- a/frontend/src/lib/bulk-drop.test.ts
+++ b/frontend/src/lib/bulk-drop.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import { filesFromPicker, runPool } from "./bulk-drop";
+
+function pickedFile(name: string, relativePath?: string): File {
+  const file = new File(["x"], name);
+  if (relativePath) {
+    Object.defineProperty(file, "webkitRelativePath", { value: relativePath });
+  }
+  return file;
+}
+
+// A dropped folder is the one destination we never have to guess at: it is the
+// user's own filing. Losing the path would dump a structured backlog into one
+// flat pile.
+describe("filesFromPicker", () => {
+  it("keeps the folder path a directory picker reports", () => {
+    const picked = filesFromPicker([
+      pickedFile("brakes.pdf", "catalogs/meritor/brakes.pdf"),
+      pickedFile("loose.pdf"),
+    ]);
+    expect(picked[0].path).toEqual(["catalogs", "meritor"]);
+    expect(picked[1].path).toEqual([]);
+  });
+
+  it("drops tooling residue rather than stashing it", () => {
+    const picked = filesFromPicker([
+      pickedFile(".DS_Store", "catalogs/.DS_Store"),
+      pickedFile("real.pdf", "catalogs/.git/real.pdf"),
+    ]);
+    expect(picked).toHaveLength(1);
+    // The file survives, but the dot-directory never becomes a folder.
+    expect(picked[0].path).toEqual(["catalogs"]);
+  });
+});
+
+describe("runPool", () => {
+  it("runs at most `limit` workers at once", async () => {
+    // Each worker parks on a promise this test resolves by hand, so the
+    // assertion is about the pool rather than about timer scheduling.
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+    const parked: Array<() => void> = [];
+    let running = 0;
+    let peak = 0;
+
+    const pool = runPool(Array.from({ length: 20 }, (_, i) => i), 5, async () => {
+      running += 1;
+      peak = Math.max(peak, running);
+      await new Promise<void>((resolve) => parked.push(resolve));
+      running -= 1;
+    });
+
+    await flush();
+    expect(parked).toHaveLength(5);
+
+    while (parked.length) {
+      parked.shift()!();
+      await flush();
+    }
+    await pool;
+
+    expect(peak).toBe(5);
+  });
+
+  it("keeps going when one item fails, and reports which", async () => {
+    const results = await runPool([1, 2, 3], 2, async (n) => {
+      if (n === 2) throw new Error("bad file");
+      return n * 10;
+    });
+
+    expect(results[0]).toEqual({ ok: true, value: 10 });
+    expect(results[1]).toMatchObject({ ok: false });
+    expect(results[2]).toEqual({ ok: true, value: 30 });
+  });
+
+  it("stops starting work once cancelled", async () => {
+    const controller = new AbortController();
+    const worker = vi.fn(async (n: number) => {
+      if (n === 0) controller.abort();
+      return n;
+    });
+
+    const results = await runPool([0, 1, 2, 3], 1, worker, { signal: controller.signal });
+
+    expect(worker).toHaveBeenCalledTimes(1);
+    expect(results.slice(1).every((r) => r.ok === "skipped")).toBe(true);
+  });
+});

--- a/frontend/src/lib/bulk-drop.ts
+++ b/frontend/src/lib/bulk-drop.ts
@@ -1,0 +1,104 @@
+/** Reading a drop, and running it. A dropped directory arrives as a tree of
+ *  filesystem entries rather than a flat FileList, and eighty files uploaded
+ *  one after another take eighty round trips of dead time — so both live here,
+ *  away from the component, where they can be tested. */
+
+export type DroppedFile = {
+  file: File;
+  /** Folder path relative to what was dropped, e.g. ["catalogs", "meritor"]. */
+  path: string[];
+};
+
+/** How many uploads are in flight at once. Enough to hide latency; not so many
+ *  that a large drop saturates the connection or the extraction queue. */
+export const UPLOAD_CONCURRENCY = 5;
+
+// Directory listings arrive in batches and the reader must be drained until it
+// returns an empty one — a single readEntries call silently truncates at ~100.
+async function readAllEntries(reader: FileSystemDirectoryReader): Promise<FileSystemEntry[]> {
+  const all: FileSystemEntry[] = [];
+  for (;;) {
+    const batch: FileSystemEntry[] = await new Promise((resolve, reject) =>
+      reader.readEntries(resolve, reject),
+    );
+    if (!batch.length) return all;
+    all.push(...batch);
+  }
+}
+
+async function flatten(entries: FileSystemEntry[], prefix: string[]): Promise<DroppedFile[]> {
+  const out: DroppedFile[] = [];
+  for (const entry of entries) {
+    // Dotfiles and dot-directories are tooling residue (.DS_Store, .git,
+    // .obsidian); nobody drops a folder meaning to stash those.
+    if (entry.name.startsWith(".")) continue;
+    if (entry.isFile) {
+      const file = await new Promise<File>((resolve, reject) =>
+        (entry as FileSystemFileEntry).file(resolve, reject),
+      );
+      out.push({ file, path: prefix });
+    } else if (entry.isDirectory) {
+      const children = await readAllEntries((entry as FileSystemDirectoryEntry).createReader());
+      out.push(...(await flatten(children, [...prefix, entry.name])));
+    }
+  }
+  return out;
+}
+
+/** Every file in a drop, directories walked. Falls back to the flat file list
+ *  only when the browser gives us no entries API — the paths are then empty,
+ *  which is exactly right for a multi-file (non-folder) drop. */
+export async function filesFromDrop(dataTransfer: DataTransfer): Promise<DroppedFile[]> {
+  const entries = Array.from(dataTransfer.items ?? [])
+    .filter((item) => item.kind === "file")
+    .map((item) => item.webkitGetAsEntry?.())
+    .filter((entry): entry is FileSystemEntry => !!entry);
+  if (entries.length > 0) return flatten(entries, []);
+  return Array.from(dataTransfer.files).map((file) => ({ file, path: [] }));
+}
+
+/** Files chosen through a picker. A directory picker sets webkitRelativePath,
+ *  so choosing a folder mirrors it the same way dropping one does. */
+export function filesFromPicker(files: File[]): DroppedFile[] {
+  return files
+    .filter((file) => !file.name.startsWith("."))
+    .map((file) => {
+      const relative = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
+      const path = relative ? relative.split("/").slice(0, -1) : [];
+      return { file, path: path.filter((p) => !p.startsWith(".")) };
+    });
+}
+
+/** Run `worker` over every item, `limit` at a time, in order of start. Results
+ *  keep the input's order. Never rejects: a worker that throws yields its
+ *  error, so one bad file cannot abandon the other seventy-nine. */
+export async function runPool<T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<R>,
+  options: { signal?: AbortSignal } = {},
+): Promise<Array<{ ok: true; value: R } | { ok: false; error: unknown } | { ok: "skipped" }>> {
+  const results = new Array<
+    { ok: true; value: R } | { ok: false; error: unknown } | { ok: "skipped" }
+  >(items.length);
+  let next = 0;
+
+  async function pump(): Promise<void> {
+    for (;;) {
+      const index = next++;
+      if (index >= items.length) return;
+      if (options.signal?.aborted) {
+        results[index] = { ok: "skipped" };
+        continue;
+      }
+      try {
+        results[index] = { ok: true, value: await worker(items[index], index) };
+      } catch (error) {
+        results[index] = { ok: false, error };
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, pump));
+  return results;
+}

--- a/frontend/src/lib/hopper.test.ts
+++ b/frontend/src/lib/hopper.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { isLinkDrop } from "./hopper";
+
+// One box takes both links and notes, so this classification decides which
+// pipeline a drop enters. Getting it wrong either fetches a webpage the user
+// meant to jot down, or files a URL as a note nobody will ever fetch.
+describe("isLinkDrop", () => {
+  it("treats a bare URL as a link", () => {
+    expect(isLinkDrop("https://example.com/post")).toBe(true);
+    expect(isLinkDrop("  http://example.com  ")).toBe(true);
+  });
+
+  it("treats prose that merely mentions a URL as a note", () => {
+    expect(isLinkDrop("read https://example.com later")).toBe(false);
+    expect(isLinkDrop("Pricing call notes")).toBe(false);
+    expect(isLinkDrop("")).toBe(false);
+  });
+});

--- a/frontend/src/lib/hopper.test.ts
+++ b/frontend/src/lib/hopper.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isLinkDrop } from "./hopper";
+import { firstUrlFromDrag, isLinkDrop } from "./hopper";
 
 // One box takes both links and notes, so this classification decides which
 // pipeline a drop enters. Getting it wrong either fetches a webpage the user
@@ -14,5 +14,21 @@ describe("isLinkDrop", () => {
     expect(isLinkDrop("read https://example.com later")).toBe(false);
     expect(isLinkDrop("Pricing call notes")).toBe(false);
     expect(isLinkDrop("")).toBe(false);
+  });
+});
+
+describe("firstUrlFromDrag", () => {
+  it("takes the first real URL out of a uri-list", () => {
+    expect(firstUrlFromDrag("https://example.com/a\r\nhttps://example.com/b\r\n")).toBe(
+      "https://example.com/a",
+    );
+  });
+
+  it("ignores the comment lines the format allows", () => {
+    expect(firstUrlFromDrag("# a comment\r\nhttps://example.com/a")).toBe("https://example.com/a");
+  });
+
+  it("has nothing to offer for an empty list", () => {
+    expect(firstUrlFromDrag("\r\n")).toBe("");
   });
 });

--- a/frontend/src/lib/hopper.ts
+++ b/frontend/src/lib/hopper.ts
@@ -4,3 +4,14 @@
 export function isLinkDrop(text: string): boolean {
   return /^https?:\/\/\S+$/i.test(text.trim());
 }
+
+/** The URL a drag carries. `text/uri-list` is a list format: CRLF-separated,
+ *  with `#` comment lines — taking it whole meant a dragged tab could be
+ *  rejected as "not a link". */
+export function firstUrlFromDrag(uriList: string): string {
+  const line = uriList
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .find((l) => l && !l.startsWith("#"));
+  return line ?? "";
+}

--- a/frontend/src/lib/hopper.ts
+++ b/frontend/src/lib/hopper.ts
@@ -1,0 +1,6 @@
+/** Which drop a piece of typed or pasted text is. A bare URL is a link — we
+ *  fetch the page behind it — and everything else is the note it looks like.
+ *  Text that merely contains a URL is prose, not a link. */
+export function isLinkDrop(text: string): boolean {
+  return /^https?:\/\/\S+$/i.test(text.trim());
+}

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -99,7 +99,7 @@ export async function startConnect(
   window.location.href = authorize_url;
 }
 
-// Open surfaces that show connection status (e.g. the sidebar Tools list)
+// Open surfaces that show connection status (e.g. the Integrations list)
 // listen for this to refresh immediately after a connect or disconnect.
 export const INTEGRATIONS_CHANGED_EVENT = "integrations-changed";
 

--- a/frontend/src/lib/sessionGrouping.test.ts
+++ b/frontend/src/lib/sessionGrouping.test.ts
@@ -61,14 +61,25 @@ describe("groupSessionsByDayAndUser", () => {
 });
 
 describe("groupSessionsByUser", () => {
-  it("groups by user_name, largest-bucket-first, reverse-chronological inside", () => {
+  it("groups by user_name, largest-bucket-first", () => {
     const grouped = groupSessionsByUser([
-      session({ session_id: "ada-old", user_name: "Ada", last_event_at: "2026-05-13T12:00:00Z" }),
       session({ session_id: "ada-new", user_name: "Ada", last_event_at: "2026-05-14T13:00:00Z" }),
+      session({ session_id: "ada-old", user_name: "Ada", last_event_at: "2026-05-13T12:00:00Z" }),
       session({ session_id: "ben", user_name: "Ben", last_event_at: "2026-05-14T12:00:00Z" }),
     ]);
     expect(grouped.map((g) => g.key)).toEqual(["Ada", "Ben"]);
     expect(grouped[0].sessions.map((s) => s.session_id)).toEqual(["ada-new", "ada-old"]);
+  });
+
+  // Grouping must not impose its own row order: it used to re-sort every
+  // bucket reverse-chronologically, so choosing "most events" while grouped
+  // by ticket silently did nothing. The caller's sort is the row order.
+  it("keeps the order the caller sorted the sessions into", () => {
+    const grouped = groupSessionsByUser([
+      session({ session_id: "ada-old", user_name: "Ada", last_event_at: "2026-05-13T12:00:00Z" }),
+      session({ session_id: "ada-new", user_name: "Ada", last_event_at: "2026-05-14T13:00:00Z" }),
+    ]);
+    expect(grouped[0].sessions.map((s) => s.session_id)).toEqual(["ada-old", "ada-new"]);
   });
 
   it("fails when a session is missing the author's display name", () => {

--- a/frontend/src/lib/sessionGrouping.ts
+++ b/frontend/src/lib/sessionGrouping.ts
@@ -112,7 +112,7 @@ export function groupSessionsByFolder(
 ): SessionFlatGroup[] {
   const byFolder = new Map<string, SessionSummary[]>();
   const unfiled: SessionSummary[] = [];
-  for (const s of sortedSessions(sessions)) {
+  for (const s of sessions) {
     if (s.session_folder_id) {
       byFolder.set(s.session_folder_id, [...(byFolder.get(s.session_folder_id) ?? []), s]);
     } else {
@@ -133,13 +133,16 @@ export function groupSessionsByFolder(
   return groups;
 }
 
-// Groups + sorts: largest groups first, sessions inside groups reverse-chronological.
+// Groups only: largest groups first, and sessions keep the order they arrived
+// in. Re-sorting here used to silently override the caller's chosen sort, so
+// picking "most events" while grouped by ticket did nothing at all. Callers
+// sort before grouping; the sort control is the one source of row order.
 function groupBy(
   sessions: SessionSummary[],
   keyFn: (s: SessionSummary) => string
 ): SessionFlatGroup[] {
   const buckets = new Map<string, SessionSummary[]>();
-  for (const s of sortedSessions(sessions)) {
+  for (const s of sessions) {
     const k = keyFn(s);
     buckets.set(k, [...(buckets.get(k) ?? []), s]);
   }

--- a/frontend/src/lib/workspace-routes.ts
+++ b/frontend/src/lib/workspace-routes.ts
@@ -51,8 +51,9 @@ export function urlForTab(tab: Pick<WorkbenchTab, "kind" | "refId">): string {
       // page's ?chat= ref, the same one the skill launcher pushes.
       return `/agents?chat=${encodeURIComponent(tab.refId)}`;
     case "tool":
-      // A provider slug deep-links to its manager; the legacy list stays /tools.
-      return tab.refId === "integrations" ? `/tools` : `/integrations/${tab.refId}`;
+      // A provider slug deep-links to its manager; the list itself is the
+      // Integrations page.
+      return tab.refId === "integrations" ? `/integrations` : `/integrations/${tab.refId}`;
     case "machine-file":
     case "terminal":
     case "agent-config":

--- a/frontend/src/lib/workspace-store.ts
+++ b/frontend/src/lib/workspace-store.ts
@@ -13,7 +13,7 @@ import { WORKBENCH_TAB_KINDS } from "@/lib/workspace-routes";
  * components/workspace/persistence.tsx (localStorage).
  */
 
-export type RailSection = "home" | "files" | "agents" | "sessions" | "skills" | "tools" | "computer";
+export type RailSection = "home" | "hopper" | "files" | "agents" | "sessions" | "skills" | "tools" | "computer";
 
 export type TabKind = "page" | "file" | "table" | "session" | "sessions-home" | "skill" | "folder" | "agent" | "agent-config" | "tool" | "machine-file" | "terminal";
 

--- a/frontend/src/lib/workspace-store.ts
+++ b/frontend/src/lib/workspace-store.ts
@@ -13,7 +13,7 @@ import { WORKBENCH_TAB_KINDS } from "@/lib/workspace-routes";
  * components/workspace/persistence.tsx (localStorage).
  */
 
-export type RailSection = "home" | "files" | "agents" | "sessions" | "skills" | "tools" | "computer";
+export type RailSection = "home" | "files" | "agents" | "integrations" | "viz" | "computer";
 
 export type TabKind = "page" | "file" | "table" | "session" | "sessions-home" | "skill" | "folder" | "agent" | "agent-config" | "tool" | "machine-file" | "terminal";
 


### PR DESCRIPTION
The rail drops from six entries to five: **Integrations, Home, Viz, VFS, Chat**.

The claim it makes is that the VFS is where you browse everything the database holds — so the things that are already mounts in it stop being destinations of their own.

## What moves

| Today | Becomes | Why |
|---|---|---|
| Sessions | VFS · `/sessions` | Already a mount. The management page now renders *beside* the tree that lists it. |
| Skills | VFS · `/skills` | A skill is a folder with a SKILL.md. A rail entry claimed it was a different kind of thing. |
| Tools | Integrations | Connectors and MCP servers under the name people use. `/tools` → `/integrations`, where the provider pages already lived. |
| — | Viz (`/viz`) | New section. `WikiGraph`, `EmbeddingSpaceExplorer`, and `KnowledgeDensityMap` already existed; the last one had no callers at all. |
| Home | Home | Keeps the non-visual half: vitals, file activity, curator log. |

`sectionForPath` routes `/sessions`, `/session-folders`, and `/skills` into the `files` section, which docks the VFS tree beside them and keeps the VFS rail button lit.

## No redirect for /tools

Per the repo's no-back-compat rule, `/tools` is gone rather than redirected. Everything pointing at it moved in the same shot: the OAuth `return_to`, the `tool` tab route in `workspace-routes`, and the onboarding email, which told users to look under "Tools, in the sidebar".

## Home after the graphs leave

Vitals row (from counts Home already fetched), file-activity feed promoted to the wide column and flowing with the page instead of scrolling inside a 480px box, curator log beside it. Net −193 lines in `BrainDashboard`.

Worth deciding separately: Home is thinner than it was. Either it grows an explicit job ("what changed since you last looked") or Viz absorbs it and we're at four rails.

## Naming

The rail says **Viz**, not Visualizations — at 10px in a 74px rail, "Visualizations" clips ("Integrations" is already the widest label that fits). The page title is still Visualizations.

## Tests

`rail.test.tsx` and new `sectionForPath` tests pin the IA's actual claim: a session route must light up VFS, and Sessions/Skills must not exist as rail entries. `aria-current` was added to the rail buttons, which makes the active section legible to screen readers as well as to the test.

## Verified

`tsc --noEmit` clean · 317 vitest tests pass (8 new) · `npm run lint` adds no warnings · `next build` succeeds with `/integrations` and `/viz` present and `/tools` gone · backend `ruff check` + `ruff format` pass.

Also ran it locally against a seeded stash (36 pages, 6 sessions, 4 skills, a table, a 10-node memory wiki) and clicked through all five sections: the wiki graph, embedding space, and knowledge map all render; `/sessions` and `/skills` open beside the VFS tree.

## Known, not addressed here

- The Sessions/Skills branches in `explorer.tsx` are now permanently unreachable, but they were already dead before this change (`PANELLED_SECTIONS` has been `files` + `computer` since the 2026-08-10 experiment). Left for a separate cleanup rather than bundled here.
- Unrelated, found while testing: the knowledge-density labeler tokenizes page bodies and surfaces UUID fragments from `/p/<id>` wiki links as "topics". Real curator pages contain those links, so prod hits this too. Separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ingest (upload dedupe, folder creation, LLM filing), paid Gemini transcription, and background embedding workers; UI route removal (/tools) and large navigation surface changes increase regression surface but core auth paths are unchanged.
> 
> **Overview**
> Introduces **Hopper** as the front door into the VFS: drag/drop or paste files (including screenshots), paste URLs, and optional post-upload **`/hopper/classify`** that moves loose items into **existing** folders via `file_classifier` (LLM JSON, never invents folders) with **Images/Videos/Audio** fallbacks for generic media names. Backend **`/api/v1/me/hopper`** mirrors directory paths, dedupes re-drops, blocks reserved folders like Memory, and queues links through existing URL import workers.
> 
> **Uploaded images** now get searchable text: `extract_one` calls new **`image_ocr`** (Gemini vision, same spirit as PDF OCR); unsupported types store empty text. **Local embeddings** force `device="cpu"` on `SentenceTransformer` so Celery prefork workers don’t SIGABRT on Apple Silicon MPS after fork.
> 
> **Connect** replaces the old **Tools** page: `/integrations` is a searchable Inputs/Outputs grid (sources, Chrome extension, MCP servers with manage/remove dialogs, coding-agent install copy, MCP/CLI/API output surfaces); `/tools` is removed. Onboarding email points at Integrations in the sidebar.
> 
> **Files** defaults to an experimental **`FlatFilesPage`** — one reverse-chron table with topbar-driven search, kind chips, and keyboard navigation — instead of the tree overview. The shared file browser **shows all item types by default** (documents-only is explicit in the Type menu), supports optional detail columns for sessions/skills, and VFS mount links point at `/vfs/*` with richer session/skill metadata (`last_edit_agent_name` on sidebar pages). New **`/viz`** route wires existing visualization components. Viewer headers drop inline breadcrumb trails; Hopper gets dedicated styling and icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85448b50ecde76d40867bb7b148ea8f49425f672. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->