### PR TITLE
Integrations is one grid of boxes, and every box says which way it flows

### DIFF
--- a/frontend/src/app/(app)/integrations/page.test.tsx
+++ b/frontend/src/app/(app)/integrations/page.test.tsx
@@ -97,7 +97,8 @@ describe("IntegrationsPage", () => {
     render(<IntegrationsPage />);
     await screen.findByText("linear");
 
-    fireEvent.change(screen.getByLabelText("Server name"), { target: { value: "notion2" } });
+    fireEvent.click(screen.getByRole("button", { name: /add a custom server/i }));
+    fireEvent.change(await screen.findByLabelText("Server name"), { target: { value: "notion2" } });
     fireEvent.change(screen.getByLabelText("URL"), {
       target: { value: "https://mcp.example.com/mcp" },
     });
@@ -123,7 +124,8 @@ describe("IntegrationsPage", () => {
     render(<IntegrationsPage />);
     await screen.findByText("linear");
 
-    fireEvent.change(screen.getByLabelText("Server name"), { target: { value: "fs" } });
+    fireEvent.click(screen.getByRole("button", { name: /add a custom server/i }));
+    fireEvent.change(await screen.findByLabelText("Server name"), { target: { value: "fs" } });
     fireEvent.click(screen.getByRole("radio", { name: /local \(stdio\)/i }));
     fireEvent.change(screen.getByLabelText("Command"), {
       target: { value: "npx -y fs-mcp" },

--- a/frontend/src/app/(app)/integrations/page.test.tsx
+++ b/frontend/src/app/(app)/integrations/page.test.tsx
@@ -97,7 +97,7 @@ describe("IntegrationsPage", () => {
     render(<IntegrationsPage />);
     await screen.findByText("linear");
 
-    fireEvent.click(screen.getByRole("button", { name: /add a custom server/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^add$/i }));
     fireEvent.change(await screen.findByLabelText("Server name"), { target: { value: "notion2" } });
     fireEvent.change(screen.getByLabelText("URL"), {
       target: { value: "https://mcp.example.com/mcp" },
@@ -124,7 +124,7 @@ describe("IntegrationsPage", () => {
     render(<IntegrationsPage />);
     await screen.findByText("linear");
 
-    fireEvent.click(screen.getByRole("button", { name: /add a custom server/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^add$/i }));
     fireEvent.change(await screen.findByLabelText("Server name"), { target: { value: "fs" } });
     fireEvent.click(screen.getByRole("radio", { name: /local \(stdio\)/i }));
     fireEvent.change(screen.getByLabelText("Command"), {

--- a/frontend/src/app/(app)/integrations/page.test.tsx
+++ b/frontend/src/app/(app)/integrations/page.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import IntegrationsPage from "./page";
 import { createMcpServer, deleteMcpServer, listMcpServers, type McpServer } from "@/lib/api";
@@ -110,7 +110,8 @@ describe("IntegrationsPage", () => {
     render(<IntegrationsPage />);
     await screen.findByText("linear");
 
-    fireEvent.click(screen.getByRole("button", { name: /^add$/i }));
+    const addCard = screen.getByText("Custom MCP server").closest("div.rounded-xl")!;
+    fireEvent.click(within(addCard as HTMLElement).getByRole("button", { name: /^connect$/i }));
     fireEvent.change(await screen.findByLabelText("Server name"), { target: { value: "notion2" } });
     fireEvent.change(screen.getByLabelText("URL"), {
       target: { value: "https://mcp.example.com/mcp" },
@@ -118,7 +119,7 @@ describe("IntegrationsPage", () => {
     fireEvent.change(screen.getByLabelText("Headers"), {
       target: { value: "Authorization=Bearer abc" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /add server/i }));
+    fireEvent.click(screen.getByRole("button", { name: /connect server/i }));
 
     await waitFor(() =>
       expect(createMcpServer).toHaveBeenCalledWith({
@@ -137,13 +138,14 @@ describe("IntegrationsPage", () => {
     render(<IntegrationsPage />);
     await screen.findByText("linear");
 
-    fireEvent.click(screen.getByRole("button", { name: /^add$/i }));
+    const addCard = screen.getByText("Custom MCP server").closest("div.rounded-xl")!;
+    fireEvent.click(within(addCard as HTMLElement).getByRole("button", { name: /^connect$/i }));
     fireEvent.change(await screen.findByLabelText("Server name"), { target: { value: "fs" } });
     fireEvent.click(screen.getByRole("radio", { name: /local \(stdio\)/i }));
     fireEvent.change(screen.getByLabelText("Command"), {
       target: { value: "npx -y fs-mcp" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /add server/i }));
+    fireEvent.click(screen.getByRole("button", { name: /connect server/i }));
 
     await waitFor(() =>
       expect(createMcpServer).toHaveBeenCalledWith({

--- a/frontend/src/app/(app)/integrations/page.test.tsx
+++ b/frontend/src/app/(app)/integrations/page.test.tsx
@@ -81,14 +81,27 @@ afterEach(() => {
 });
 
 describe("IntegrationsPage", () => {
-  it("lists registered MCP servers with their targets", async () => {
+  it("lists registered MCP servers", async () => {
     render(<IntegrationsPage />);
 
     expect(await screen.findByText("linear")).toBeTruthy();
     expect(screen.getByText("notion")).toBeTruthy();
-    expect(screen.getByText(/npx -y linear-mcp/)).toBeTruthy();
+    // The card describes the server in words; the raw target belongs to the
+    // manage dialog, not the grid.
+    expect(screen.getByText(/a local npx process/)).toBeTruthy();
+    expect(screen.getByText(/mcp\.notion\.com/)).toBeTruthy();
+  });
+
+  it("shows a server's target and header names in manage, never header values", async () => {
+    render(<IntegrationsPage />);
+    await screen.findByText("notion");
+
+    // The http server is the one carrying headers.
+    fireEvent.click(screen.getAllByRole("button", { name: /^manage$/i })[1]);
+
+    expect(await screen.findByText("https://mcp.notion.com/mcp")).toBeTruthy();
     // Header values are secrets — only key names appear.
-    expect(screen.getByText(/headers: Authorization/)).toBeTruthy();
+    expect(screen.getByText("Authorization")).toBeTruthy();
     expect(screen.queryByText(/Bearer tok/)).toBeNull();
   });
 

--- a/frontend/src/app/(app)/integrations/page.test.tsx
+++ b/frontend/src/app/(app)/integrations/page.test.tsx
@@ -39,6 +39,8 @@ vi.mock("@/lib/api", () => ({
   deleteMcpServer: vi.fn(),
   // The integrations grid above the MCP registry loads these on mount.
   listSources: vi.fn().mockResolvedValue([]),
+  // The coding-agents section shows which agents are already sending sessions.
+  listAgentNames: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("@/lib/integrations", () => ({

--- a/frontend/src/app/(app)/integrations/page.test.tsx
+++ b/frontend/src/app/(app)/integrations/page.test.tsx
@@ -150,12 +150,18 @@ describe("IntegrationsPage", () => {
     expect(await screen.findByText(/integrations are down/)).toBeTruthy();
   });
 
-  it("removes a server", async () => {
+  // Removing is deliberately behind Manage: the grid's action must never
+  // delete a server in one click, since it sits where every other box has a
+  // harmless navigation.
+  it("removes a server from its manage dialog", async () => {
     vi.mocked(deleteMcpServer).mockResolvedValue(undefined);
     render(<IntegrationsPage />);
     await screen.findByText("linear");
 
-    fireEvent.click(screen.getAllByRole("button", { name: /remove/i })[0]);
+    expect(screen.queryByRole("button", { name: /^remove/i })).toBeNull();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /^manage$/i })[0]);
+    fireEvent.click(await screen.findByRole("button", { name: /remove server/i }));
 
     await waitFor(() => expect(deleteMcpServer).toHaveBeenCalledWith("s1"));
     await waitFor(() => expect(listMcpServers).toHaveBeenCalledTimes(2));

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -127,6 +127,20 @@ function TileIcon({ icon: Icon }: { icon: typeof Globe }) {
   );
 }
 
+/** What a registered server points at, in words: a remote host, or a local
+ *  process named by the binary it runs. */
+function mcpServerTarget(server: McpServer): string {
+  if (server.transport === "stdio") {
+    const binary = (server.command ?? "").trim().split(/\s+/)[0];
+    return binary ? `a local ${binary} process` : "a local process";
+  }
+  try {
+    return new URL(server.url!).hostname;
+  } catch {
+    return "a remote server";
+  }
+}
+
 function mcpServerIcon(server: McpServer) {
   if (server.url && new URL(server.url).hostname === "mcp.linear.app") {
     return connectorIcon("linear");
@@ -294,11 +308,10 @@ export default function IntegrationsPage() {
       key: `mcp:${s.id}`,
       name: s.name,
       direction: "in",
-      blurb:
-        (s.transport === "stdio" ? s.command : s.url) +
-        (Object.keys(s.headers).length > 0
-          ? ` · headers: ${Object.keys(s.headers).join(", ")}`
-          : ""),
+      // Every other box describes itself in a sentence; a bare URL here read
+      // as a missing description. The exact target and header names are one
+      // click away in Manage.
+      blurb: `Tools from ${mcpServerTarget(s)}, handed to your cloud agent before every turn.`,
       icon: mcpServerIcon(s),
       active: true,
       tier: TIER.work,

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -55,14 +55,27 @@ import { cn } from "@/lib/utils";
 // vocabulary to learn on top of the boxes themselves.
 type Direction = "in" | "out";
 
+// The list reads in the order a team adopts Stash: the agents they already
+// run, then the tools their work lives in, then the personal accounts they
+// save to.
+const TIER = { agents: 0, work: 1, personal: 2 };
+
+// Consumer accounts — the "save your own stuff" end of the list rather than
+// the ones a team wires up first.
+const PERSONAL_PROVIDERS = new Set(["x", "instagram"]);
+
 type Box = {
   key: string;
   name: string;
   direction: Direction;
   blurb: string;
   icon: ReactNode;
-  /** Connected boxes sort to the front — what you have before what you could add. */
+  /** Connected boxes sort to the front of their tier. */
   active: boolean;
+  /** Which band of the list this belongs to; see TIER. */
+  tier: number;
+  /** Sorts to the end of its tier — for the "add one" affordance. */
+  sortLast?: boolean;
   /** Everything the search field matches against. */
   search: string;
   /** Setup instructions, for boxes whose action is "Set up". */
@@ -241,6 +254,7 @@ export default function IntegrationsPage() {
         blurb: c.blurb,
         icon: connectorIcon(c.provider),
         active: connected,
+        tier: PERSONAL_PROVIDERS.has(c.provider) ? TIER.personal : TIER.work,
         search: `${c.label} ${c.blurb} ${c.provider} source`,
         action: connected ? (
           <Button asChild variant="ghost" size="sm" className="self-start px-2">
@@ -271,6 +285,7 @@ export default function IntegrationsPage() {
       blurb: "Clip any page or every open tab, import your bookmarks, keep your saves in sync.",
       icon: <TileIcon icon={Globe} />,
       active: false,
+      tier: TIER.personal,
       search: "browser chrome extension clip bookmarks tabs",
       action: (
         <Button asChild size="sm" variant="secondary" className="self-start">
@@ -290,6 +305,7 @@ export default function IntegrationsPage() {
           : ""),
       icon: <TileIcon icon={s.transport === "stdio" ? SquareTerminal : Globe} />,
       active: true,
+      tier: TIER.work,
       search: `${s.name} mcp server tool ${s.url ?? ""} ${s.command ?? ""}`,
       action: (
         <Button
@@ -310,6 +326,8 @@ export default function IntegrationsPage() {
       blurb: "Register any MCP server and your cloud agent gets it before every turn.",
       icon: <TileIcon icon={Plus} />,
       active: false,
+      tier: TIER.work,
+      sortLast: true,
       search: "custom mcp server add tool",
       action: (
         <Button
@@ -333,6 +351,7 @@ export default function IntegrationsPage() {
         blurb: AGENT_COPY[d].blurb,
         icon: <TileIcon icon={Bot} />,
         active: false,
+        tier: TIER.agents,
         search: `${agent.name} ${agent.binary} coding agent`,
         dialog: {
           title: AGENT_COPY[d].title(agent.name),
@@ -349,6 +368,7 @@ export default function IntegrationsPage() {
       blurb: s.blurb,
       icon: <TileIcon icon={s.icon} />,
       active: false,
+      tier: TIER.work,
       search: `${s.name} ${s.blurb} ${s.keywords}`,
       dialog: { title: s.name, description: s.blurb, body: s.body },
     }));
@@ -366,8 +386,9 @@ export default function IntegrationsPage() {
 
     return [...sourceBoxes, browserBox, ...serverBoxes, addServerBox, ...withSetup].sort(
       (a, b) =>
+        a.tier - b.tier ||
+        Number(!!a.sortLast) - Number(!!b.sortLast) ||
         Number(b.active) - Number(a.active) ||
-        a.direction.localeCompare(b.direction) ||
         a.name.localeCompare(b.name),
     );
   }, [statuses, servers, busy, isConnected, connectNow, removeServer]);

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -445,7 +445,7 @@ export default function IntegrationsPage() {
         dialog: {
           title: AGENT_COPY[d].title(agent.name),
           description: AGENT_COPY[d].description,
-          body: agentDialogBody(d),
+          body: agentDialogBody(),
         },
       })),
     );

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -22,7 +22,6 @@ import {
 import {
   ApiError,
   deleteMcpServer,
-  listAgentNames,
   listMcpServers,
   listSources,
   type McpServer,
@@ -91,7 +90,14 @@ type Box = {
 
 function IntegrationBox({ box, onOpen }: { box: Box; onOpen?: () => void }) {
   return (
-    <div className="flex flex-col gap-2.5 rounded-xl border border-border bg-surface p-4">
+    <div
+      className={cn(
+        "flex flex-col gap-2.5 rounded-xl border p-4",
+        box.active
+          ? "border-success/30 bg-success/[0.06]"
+          : "border-border bg-surface",
+      )}
+    >
       <div className="flex items-center gap-2.5">
         <span className="flex h-7 w-7 shrink-0 items-center justify-center [&_img]:h-6 [&_img]:w-6 [&_svg]:h-6 [&_svg]:w-6">
           {box.icon}
@@ -202,7 +208,6 @@ export default function IntegrationsPage() {
   const [sourceProviders, setSourceProviders] = useState<Set<string>>(new Set());
   const [statuses, setStatuses] = useState<Record<string, IntegrationStatus> | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [agentNames, setAgentNames] = useState<string[]>([]);
   const [servers, setServers] = useState<McpServer[]>([]);
   const [query, setQuery] = useState("");
   const [direction, setDirection] = useState<Direction>("in");
@@ -251,12 +256,6 @@ export default function IntegrationsPage() {
   useEffect(() => {
     void refreshServers();
   }, [refreshServers]);
-
-  // The agent roster is a nice-to-have line, not a gate: it says what is
-  // already sending sessions, and the page is complete without it.
-  useEffect(() => {
-    listAgentNames().then(setAgentNames).catch(() => setAgentNames([]));
-  }, []);
 
   const isConnected = useCallback(
     (c: Connector) =>
@@ -489,9 +488,9 @@ export default function IntegrationsPage() {
 
     return [...withDialogs].sort(
       (a, b) =>
+        Number(b.active) - Number(a.active) ||
         a.tier - b.tier ||
         Number(!!a.sortLast) - Number(!!b.sortLast) ||
-        Number(b.active) - Number(a.active) ||
         a.name.localeCompare(b.name),
     );
   }, [statuses, servers, busy, isConnected, connectNow, removeServer]);
@@ -529,10 +528,7 @@ export default function IntegrationsPage() {
             Integrations
           </h1>
           <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-            Everything that flows into Stash, and every way it flows back out to an agent.
-            {agentNames.length > 0 && (
-              <> {agentNames.length} agent{agentNames.length === 1 ? " is" : "s are"} sending sessions now.</>
-            )}
+            Choose what to add to your Stash, and who can read it.
           </p>
         </header>
 
@@ -560,6 +556,9 @@ export default function IntegrationsPage() {
               )}
             >
               {d === "in" ? "Inputs" : "Outputs"}
+              <span className="ml-1.5 text-[11px] opacity-60">
+                {boxes.filter((b) => b.direction === d).length}
+              </span>
             </button>
           ))}
           {connectedCount > 0 && (

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -427,7 +427,6 @@ export default function IntegrationsPage() {
       tier: TIER.work,
       sortLast: true,
       search: "custom mcp server add tool",
-      actionLabel: "Add",
       onAction: () => setAddingServer(true),
     };
 
@@ -528,7 +527,7 @@ export default function IntegrationsPage() {
             Integrations
           </h1>
           <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-            Choose what to add to your Stash, and who can read it.
+            Choose what to add to your Stash, and what can read it.
           </p>
         </header>
 
@@ -637,7 +636,7 @@ export default function IntegrationsPage() {
       <Dialog open={addingServer} onOpenChange={setAddingServer}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Add an MCP server</DialogTitle>
+            <DialogTitle>Connect an MCP server</DialogTitle>
             <DialogDescription>
               Your cloud agent gets it before every turn, alongside the tools Stash gives it
               natively.

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -83,20 +83,6 @@ type Box = {
   action: ReactNode;
 };
 
-function DirectionBadge({ direction }: { direction: Direction }) {
-  return (
-    <span
-      className={cn(
-        "shrink-0 rounded-full px-1.5 py-0.5 font-mono text-[10px] font-semibold leading-normal",
-        direction === "in" ? "bg-human/10 text-human" : "bg-chart-5/15 text-warning",
-      )}
-      title={direction === "in" ? "Flows into your stash" : "Reads your stash"}
-    >
-      {direction === "in" ? "→ IN" : "OUT →"}
-    </span>
-  );
-}
-
 function IntegrationBox({ box, onOpen }: { box: Box; onOpen?: () => void }) {
   return (
     <div className="flex flex-col gap-2.5 rounded-xl border border-border bg-surface p-4">
@@ -117,7 +103,6 @@ function IntegrationBox({ box, onOpen }: { box: Box; onOpen?: () => void }) {
             {box.name}
           </span>
         )}
-        <DirectionBadge direction={box.direction} />
       </div>
 
       <p className="min-h-[34px] break-words text-[12.5px] leading-snug text-muted-foreground">

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -377,7 +377,7 @@ export default function IntegrationsPage() {
     const agentBoxes: Omit<Box, "action">[] = (["in", "out"] as const).flatMap((d) =>
       CODING_AGENTS.map((agent) => ({
         key: `agent:${d}:${agent.binary}`,
-        name: agent.name,
+        name: AGENT_COPY[d].label(agent.name),
         direction: d,
         blurb: AGENT_COPY[d].blurb,
         icon: agent.icon,
@@ -491,7 +491,7 @@ export default function IntegrationsPage() {
             </button>
           ))}
           {connectedCount > 0 && (
-            <span className="ml-auto font-mono text-[11.5px] text-muted-foreground">
+            <span className="ml-auto text-[12.5px] text-muted-foreground">
               {connectedCount} connected
             </span>
           )}

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -1,16 +1,32 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
-import { Globe } from "lucide-react";
+import { Bot, Globe, Plus, SquareTerminal } from "lucide-react";
 import { toast } from "sonner";
 
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
 import { useAuth } from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ApiError, listAgentNames, listSources, type Source } from "@/lib/api";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  ApiError,
+  deleteMcpServer,
+  listAgentNames,
+  listMcpServers,
+  listSources,
+  type McpServer,
+  type Source,
+} from "@/lib/api";
 import {
   INTEGRATIONS_CHANGED_EVENT,
   listIntegrations,
@@ -23,219 +39,92 @@ import {
   providerForSourceType,
   type Connector,
 } from "@/components/integrations/connectors";
-import CodingAgents, { CODING_AGENTS } from "@/components/integrations/CodingAgents";
-import McpServers from "@/components/integrations/McpServers";
-import OutputSurfaces, { OUTPUT_SURFACES } from "@/components/integrations/OutputSurfaces";
+import {
+  AGENT_COPY,
+  CODING_AGENTS,
+  agentDialogBody,
+} from "@/components/integrations/CodingAgents";
+import { OUTPUT_SURFACES } from "@/components/integrations/OutputSurfaces";
+import AddServerForm from "@/components/integrations/McpServers";
 import PaywallModal from "@/components/PaywallModal";
 import { cn } from "@/lib/utils";
 
-// Direction is the page's first distinction: what puts content INTO the stash,
-// and what reads it back OUT. "MCP" means opposite things on the two sides —
-// servers Stash calls (in) versus Stash as a server agents call (out) — so
-// neither section is allowed to be called just "MCP".
+// One flat grid. Every way anything reaches Stash, or reads it back, is a box
+// with the same shape — the only structure is a direction badge and a search
+// field. Sections used to group these, but the groupings were a second
+// vocabulary to learn on top of the boxes themselves.
 type Direction = "in" | "out";
 
-type Category =
-  | "sources"
-  | "browser"
-  | "tools"
-  | "agent-sessions"
-  | "access"
-  | "agent-access";
-
-const CATEGORIES: {
-  key: Category;
+type Box = {
+  key: string;
+  name: string;
   direction: Direction;
-  label: string;
   blurb: string;
-}[] = [
-  {
-    key: "sources",
-    direction: "in",
-    label: "Sources",
-    blurb: "Connect an account and everything in it becomes searchable by every agent you point at Stash.",
-  },
-  {
-    key: "browser",
-    direction: "in",
-    label: "Browser",
-    blurb: "Clip any page, import your bookmarks, and sync what you save on X and Instagram.",
-  },
-  {
-    key: "tools",
-    direction: "in",
-    label: "Tools your agent can call",
-    blurb: "MCP servers you register here are handed to your cloud agent, on top of everything Stash gives it natively.",
-  },
-  {
-    key: "access",
-    direction: "out",
-    label: "Connect an agent",
-    blurb: "MCP, the CLI, and the HTTP API — how an agent or a script reads what you've collected.",
-  },
-  {
-    key: "agent-sessions",
-    direction: "in",
-    label: "Coding agents",
-    blurb: "Every session they run lands in your stash as a transcript, searchable like anything else.",
-  },
-  {
-    key: "agent-access",
-    direction: "out",
-    label: "Coding agents",
-    blurb: "Point them at your stash and they read it while they work — your notes, sources, and past sessions.",
-  },
-];
+  icon: ReactNode;
+  /** Connected boxes sort to the front — what you have before what you could add. */
+  active: boolean;
+  /** Everything the search field matches against. */
+  search: string;
+  /** Setup instructions, for boxes whose action is "Set up". */
+  dialog?: { title: string; description: string; body: ReactNode };
+  action: ReactNode;
+};
 
-/** One connector, as a card: what it is, what connecting gets you, and the
- *  action. OAuth providers connect in place; the rest route to their page,
- *  which holds the credential form or the extension install. */
-function ConnectorCard({
-  connector,
-  connected,
-  busy,
-  onOauthConnect,
-}: {
-  connector: Connector;
-  connected: boolean;
-  busy: boolean;
-  onOauthConnect: (() => void) | null;
-}) {
-  return (
-    <div className="flex flex-col gap-2.5 rounded-xl border border-border bg-surface p-4">
-      <div className="flex items-center gap-2.5">
-        <span className="flex h-7 w-7 shrink-0 items-center justify-center [&_img]:h-6 [&_img]:w-6 [&_svg]:h-6 [&_svg]:w-6">
-          {connectorIcon(connector.provider)}
-        </span>
-        <Link
-          href={`/integrations/${connector.provider}`}
-          className="truncate text-[14px] font-medium text-foreground hover:underline"
-        >
-          {connector.label}
-        </Link>
-        {connected && (
-          <span className="ml-auto flex items-center gap-1.5 rounded-full border border-border bg-base px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
-            <span className="h-1.5 w-1.5 rounded-full bg-success" />
-            Connected
-          </span>
-        )}
-      </div>
-
-      <p className="min-h-[34px] text-[12.5px] leading-snug text-muted-foreground">
-        {connector.blurb}
-      </p>
-
-      {connected ? (
-        <Button asChild variant="ghost" size="sm" className="self-start px-2">
-          <Link href={`/integrations/${connector.provider}`}>Manage</Link>
-        </Button>
-      ) : onOauthConnect ? (
-        <Button size="sm" variant="secondary" className="self-start" disabled={busy} onClick={onOauthConnect}>
-          {busy ? "Connecting…" : "Connect"}
-        </Button>
-      ) : (
-        <Button asChild size="sm" variant="secondary" className="self-start">
-          <Link href={`/integrations/${connector.provider}`}>Connect</Link>
-        </Button>
-      )}
-    </div>
-  );
-}
-
-/** Every source connector, connected ones first so the page answers "what do
- *  I already have?" before "what could I add?". */
-function SourcesGrid({
-  connectors,
-  statuses,
-  onConnected,
-}: {
-  connectors: Connector[];
-  statuses: Record<string, IntegrationStatus>;
-  onConnected: (c: Connector) => boolean;
-}) {
-  const [busy, setBusy] = useState<string | null>(null);
-  const [paywalled, setPaywalled] = useState(false);
-
-  // Straight to the consent screen; the OAuth flow returns to /integrations,
-  // where the card reads Connected. No successful-return path resets `busy` —
-  // the whole page navigates away.
-  async function connectNow(connector: Connector) {
-    setBusy(connector.provider);
-    try {
-      await startConnect(connector.provider, "/integrations");
-    } catch (e) {
-      if (e instanceof ApiError && e.status === 402) setPaywalled(true);
-      else toast.error(e instanceof Error ? e.message : "Could not start connection");
-      setBusy(null);
-    }
-  }
-
-  const sorted = [...connectors].sort(
-    (a, b) => Number(onConnected(b)) - Number(onConnected(a)) || a.label.localeCompare(b.label),
-  );
-
-  return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-      {sorted.map((c) => {
-        const status = statuses[c.provider];
-        const oauth =
-          c.kind !== "extension" && status?.auth_kind !== "api_key" && !status?.disabled_reason;
-        return (
-          <ConnectorCard
-            key={c.provider}
-            connector={c}
-            connected={onConnected(c)}
-            busy={busy === c.provider}
-            onOauthConnect={oauth ? () => void connectNow(c) : null}
-          />
-        );
-      })}
-      {paywalled && <PaywallModal onClose={() => setPaywalled(false)} />}
-    </div>
-  );
-}
-
-/** A direction badge — the same mark on the segmented control, the section
- *  headings. */
 function DirectionBadge({ direction }: { direction: Direction }) {
-  const label = direction === "in" ? "→ IN" : "OUT →";
   return (
     <span
       className={cn(
-        "rounded-full px-2 py-0.5 font-mono text-[10.5px] font-semibold leading-normal",
+        "shrink-0 rounded-full px-1.5 py-0.5 font-mono text-[10px] font-semibold leading-normal",
         direction === "in" ? "bg-human/10 text-human" : "bg-chart-5/15 text-warning",
       )}
+      title={direction === "in" ? "Flows into your stash" : "Reads your stash"}
     >
-      {label}
+      {direction === "in" ? "→ IN" : "OUT →"}
     </span>
   );
 }
 
-function Section({
-  category,
-  count,
-  children,
-}: {
-  category: (typeof CATEGORIES)[number];
-  count: number | null;
-  children: React.ReactNode;
-}) {
+function IntegrationBox({ box, onOpen }: { box: Box; onOpen?: () => void }) {
   return (
-    <section id={category.key}>
-      <div className="flex items-center gap-2">
-        <h2 className="font-display text-[16px] font-semibold text-foreground">{category.label}</h2>
-        {count !== null && (
-          <span className="font-mono text-[12px] text-muted-foreground">{count}</span>
+    <div className="flex flex-col gap-2.5 rounded-xl border border-border bg-surface p-4">
+      <div className="flex items-center gap-2.5">
+        <span className="flex h-7 w-7 shrink-0 items-center justify-center [&_img]:h-6 [&_img]:w-6 [&_svg]:h-6 [&_svg]:w-6">
+          {box.icon}
+        </span>
+        {onOpen ? (
+          <button
+            type="button"
+            onClick={onOpen}
+            className="min-w-0 flex-1 truncate text-left text-[14px] font-medium text-foreground hover:underline"
+          >
+            {box.name}
+          </button>
+        ) : (
+          <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-foreground">
+            {box.name}
+          </span>
         )}
-        <DirectionBadge direction={category.direction} />
+        <DirectionBadge direction={box.direction} />
       </div>
-      <p className="mt-0.5 max-w-2xl text-[13px] text-muted-foreground">{category.blurb}</p>
-      <div className="mt-4">{children}</div>
-    </section>
+
+      <p className="min-h-[34px] break-words text-[12.5px] leading-snug text-muted-foreground">
+        {box.blurb}
+      </p>
+
+      {box.action}
+    </div>
   );
 }
 
-const cat = (key: Category) => CATEGORIES.find((c) => c.key === key)!;
+/** A lucide glyph in the same tile the brand marks sit in, so a box with no
+ *  logo still lines up with one that has. */
+function TileIcon({ icon: Icon }: { icon: typeof Bot }) {
+  return (
+    <span className="flex h-7 w-7 items-center justify-center rounded-md bg-raised">
+      <Icon className="h-4 w-4 text-dim" />
+    </span>
+  );
+}
 
 export default function IntegrationsPage() {
   const router = useRouter();
@@ -244,9 +133,13 @@ export default function IntegrationsPage() {
   const [statuses, setStatuses] = useState<Record<string, IntegrationStatus> | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [agentNames, setAgentNames] = useState<string[]>([]);
-  const [mcpCount, setMcpCount] = useState(0);
-  const [direction, setDirection] = useState<Direction>("in");
-  const [filter, setFilter] = useState<Category | "all">("all");
+  const [servers, setServers] = useState<McpServer[]>([]);
+  const [query, setQuery] = useState("");
+  const [direction, setDirection] = useState<Direction | null>(null);
+  const [open, setOpen] = useState<Box | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [paywalled, setPaywalled] = useState(false);
+  const [addingServer, setAddingServer] = useState(false);
 
   useBreadcrumbs([{ label: "Integrations" }], "integrations");
 
@@ -254,8 +147,8 @@ export default function IntegrationsPage() {
     if (!loading && !user) router.push("/login");
   }, [user, loading, router]);
 
-  // Both calls decide what a card says — statuses which cards exist, sources
-  // whether an extension card reads Connected — so either one failing makes
+  // Both calls decide what a box says — statuses which boxes exist, sources
+  // whether an extension box reads Connected — so either one failing makes
   // the whole grid wrong. Fail together, loudly, instead of showing a grid
   // that lies or skeletons that never resolve.
   useEffect(() => {
@@ -277,6 +170,18 @@ export default function IntegrationsPage() {
     return () => window.removeEventListener(INTEGRATIONS_CHANGED_EVENT, load);
   }, []);
 
+  const refreshServers = useCallback(async () => {
+    try {
+      setServers(await listMcpServers());
+    } catch (e) {
+      toast.error(e instanceof ApiError ? e.message : "Failed to load MCP servers");
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshServers();
+  }, [refreshServers]);
+
   // The agent roster is a nice-to-have line, not a gate: it says what is
   // already sending sessions, and the page is complete without it.
   useEffect(() => {
@@ -291,118 +196,239 @@ export default function IntegrationsPage() {
     [sourceProviders, statuses],
   );
 
+  // Straight to the consent screen; the OAuth flow returns to /integrations,
+  // where the box reads Connected. No successful-return path resets `busy` —
+  // the whole page navigates away.
+  const connectNow = useCallback(async (connector: Connector) => {
+    setBusy(connector.provider);
+    try {
+      await startConnect(connector.provider, "/integrations");
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 402) setPaywalled(true);
+      else toast.error(e instanceof Error ? e.message : "Could not start connection");
+      setBusy(null);
+    }
+  }, []);
+
+  const removeServer = useCallback(
+    async (id: string) => {
+      try {
+        await deleteMcpServer(id);
+        await refreshServers();
+      } catch (e) {
+        toast.error(e instanceof ApiError ? e.message : "Failed to remove server");
+      }
+    },
+    [refreshServers],
+  );
+
+  const boxes = useMemo<Box[]>(() => {
+    if (!statuses) return [];
+
+    // The server omits providers this user may not use (customer-specific
+    // integrations like Heavi) — extension connectors are always available.
+    const connectors = CONNECTORS.filter((c) => c.kind === "extension" || c.provider in statuses);
+
+    const sourceBoxes: Box[] = connectors.map((c) => {
+      const connected = isConnected(c);
+      const status = statuses[c.provider];
+      const oauth =
+        c.kind !== "extension" && status?.auth_kind !== "api_key" && !status?.disabled_reason;
+      return {
+        key: `source:${c.provider}`,
+        name: c.label,
+        direction: "in" as const,
+        blurb: c.blurb,
+        icon: connectorIcon(c.provider),
+        active: connected,
+        search: `${c.label} ${c.blurb} ${c.provider} source`,
+        action: connected ? (
+          <Button asChild variant="ghost" size="sm" className="self-start px-2">
+            <Link href={`/integrations/${c.provider}`}>Manage</Link>
+          </Button>
+        ) : oauth ? (
+          <Button
+            size="sm"
+            variant="secondary"
+            className="self-start"
+            disabled={busy === c.provider}
+            onClick={() => void connectNow(c)}
+          >
+            {busy === c.provider ? "Connecting…" : "Connect"}
+          </Button>
+        ) : (
+          <Button asChild size="sm" variant="secondary" className="self-start">
+            <Link href={`/integrations/${c.provider}`}>Connect</Link>
+          </Button>
+        ),
+      };
+    });
+
+    const browserBox: Box = {
+      key: "browser",
+      name: "Stash for Chrome",
+      direction: "in",
+      blurb: "Clip any page or every open tab, import your bookmarks, keep your saves in sync.",
+      icon: <TileIcon icon={Globe} />,
+      active: false,
+      search: "browser chrome extension clip bookmarks tabs",
+      action: (
+        <Button asChild size="sm" variant="secondary" className="self-start">
+          <Link href="/extension">Install</Link>
+        </Button>
+      ),
+    };
+
+    const serverBoxes: Box[] = servers.map((s) => ({
+      key: `mcp:${s.id}`,
+      name: s.name,
+      direction: "in",
+      blurb:
+        (s.transport === "stdio" ? s.command : s.url) +
+        (Object.keys(s.headers).length > 0
+          ? ` · headers: ${Object.keys(s.headers).join(", ")}`
+          : ""),
+      icon: <TileIcon icon={s.transport === "stdio" ? SquareTerminal : Globe} />,
+      active: true,
+      search: `${s.name} mcp server tool ${s.url ?? ""} ${s.command ?? ""}`,
+      action: (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="self-start px-2"
+          onClick={() => void removeServer(s.id)}
+        >
+          Remove
+        </Button>
+      ),
+    }));
+
+    const addServerBox: Box = {
+      key: "mcp:add",
+      name: "Custom MCP server",
+      direction: "in",
+      blurb: "Register any MCP server and your cloud agent gets it before every turn.",
+      icon: <TileIcon icon={Plus} />,
+      active: false,
+      search: "custom mcp server add tool",
+      action: (
+        <Button
+          size="sm"
+          variant="secondary"
+          className="self-start"
+          onClick={() => setAddingServer(true)}
+        >
+          Add
+        </Button>
+      ),
+    };
+
+    // A coding agent is two integrations wearing one name, so it gets a box
+    // per direction with the half that applies.
+    const agentBoxes = (["in", "out"] as const).flatMap((d) =>
+      CODING_AGENTS.map((agent) => ({
+        key: `agent:${d}:${agent.binary}`,
+        name: agent.name,
+        direction: d,
+        blurb: AGENT_COPY[d].blurb,
+        icon: <TileIcon icon={Bot} />,
+        active: false,
+        search: `${agent.name} ${agent.binary} coding agent`,
+        dialog: {
+          title: AGENT_COPY[d].title(agent.name),
+          description: AGENT_COPY[d].description,
+          body: agentDialogBody(agent, d),
+        },
+      })),
+    );
+
+    const outputBoxes = OUTPUT_SURFACES.map((s) => ({
+      key: `out:${s.key}`,
+      name: s.name,
+      direction: "out" as const,
+      blurb: s.blurb,
+      icon: <TileIcon icon={s.icon} />,
+      active: false,
+      search: `${s.name} ${s.blurb} ${s.keywords}`,
+      dialog: { title: s.name, description: s.blurb, body: s.body },
+    }));
+
+    // Every box whose action is a dialog gets the same button, so the grid
+    // doesn't sprout a different verb per box type.
+    const withSetup: Box[] = [...agentBoxes, ...outputBoxes].map((b) => ({
+      ...b,
+      action: (
+        <Button size="sm" variant="secondary" className="self-start" onClick={() => setOpen(b as Box)}>
+          Set up
+        </Button>
+      ),
+    }));
+
+    return [...sourceBoxes, browserBox, ...serverBoxes, addServerBox, ...withSetup].sort(
+      (a, b) =>
+        Number(b.active) - Number(a.active) ||
+        a.direction.localeCompare(b.direction) ||
+        a.name.localeCompare(b.name),
+    );
+  }, [statuses, servers, busy, isConnected, connectNow, removeServer]);
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return boxes.filter(
+      (b) =>
+        (direction === null || b.direction === direction) &&
+        (q === "" || b.search.toLowerCase().includes(q)),
+    );
+  }, [boxes, query, direction]);
+
   if (loading || !user) return null;
 
-  // The server omits providers this user may not use (customer-specific
-  // integrations like Heavi) — extension connectors are always available.
-  const available = statuses
-    ? CONNECTORS.filter((c) => c.kind === "extension" || c.provider in statuses)
-    : [];
-  const connectedCount = available.filter(isConnected).length;
-
-  const counts: Record<Category, number> = {
-    sources: available.length,
-    browser: 1,
-    tools: mcpCount,
-    "agent-sessions": CODING_AGENTS.length,
-    access: OUTPUT_SURFACES.length,
-    "agent-access": CODING_AGENTS.length,
-  };
-
-  const inDirection = CATEGORIES.filter((c) => c.direction === direction);
-
-  // The sub-filter is scoped to the open direction, so switching direction
-  // resets it rather than leaving a filter selected that no longer exists.
-  const shows = (c: Category) =>
-    inDirection.some((cat) => cat.key === c) && (filter === "all" || filter === c);
-
-  function openDirection(next: Direction) {
-    setDirection(next);
-    setFilter("all");
-  }
+  const connectedCount = boxes.filter((b) => b.active).length;
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="mx-auto flex max-w-5xl flex-col gap-8 px-8 py-7">
+      <div className="mx-auto flex max-w-5xl flex-col gap-5 px-8 py-7">
         <header>
           <h1 className="font-display text-[22px] font-semibold tracking-tight text-foreground">
             Integrations
           </h1>
           <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-            The one place to connect everything to Stash. Everything that flows in, and every way
-            it flows back out to an agent.
+            Everything that flows into Stash, and every way it flows back out to an agent.
+            {agentNames.length > 0 && (
+              <> {agentNames.length} agent{agentNames.length === 1 ? " is" : "s are"} sending sessions now.</>
+            )}
           </p>
-          {statuses && (
-            <p className="mt-2.5 font-mono text-[12px] text-muted-foreground">
-              {connectedCount} of {available.length} sources connected
-              {mcpCount > 0 && ` · ${mcpCount} MCP server${mcpCount === 1 ? "" : "s"}`}
-              {agentNames.length > 0 &&
-                ` · ${agentNames.length} agent${agentNames.length === 1 ? "" : "s"} sending sessions`}
-            </p>
-          )}
         </header>
 
-        <div className="flex flex-col gap-3">
-          {/* Direction is the primary choice; categories nest under whichever
-              half is open. */}
-          <div className="flex w-full max-w-md overflow-hidden rounded-xl border border-border" role="tablist">
-            {(["in", "out"] as const).map((d) => (
-              <button
-                key={d}
-                type="button"
-                role="tab"
-                aria-selected={direction === d}
-                onClick={() => openDirection(d)}
-                className={cn(
-                  "flex flex-1 items-center justify-center gap-2 px-4 py-2.5 text-[13px] font-semibold transition-colors",
-                  d === "out" && "border-l border-border",
-                  direction === d
-                    ? d === "in"
-                      ? "bg-human/10 text-human"
-                      : "bg-chart-5/15 text-warning"
-                    : "bg-surface text-muted-foreground hover:text-foreground",
-                )}
-              >
-                <span className="font-mono text-[12px]">{d === "in" ? "→" : ""}</span>
-                {d === "in" ? "Flowing in" : "Flowing out"}
-                <span className="font-mono text-[12px]">{d === "out" ? "→" : ""}</span>
-              </button>
-            ))}
-          </div>
-
-          <p className="text-[12.5px] text-muted-foreground">
-            {direction === "in"
-              ? "What puts content into your stash."
-              : "How agents and scripts read what's in it."}
-          </p>
-
-          <div className="flex flex-wrap gap-1.5">
-            {(["all", ...inDirection.map((c) => c.key)] as (Category | "all")[]).map((key) => {
-              const label =
-                key === "all" ? "All" : CATEGORIES.find((c) => c.key === key)!.label;
-              const count =
-                key === "all"
-                  ? inDirection.reduce((sum, c) => sum + counts[c.key], 0)
-                  : counts[key as Category];
-              return (
-                <button
-                  key={key}
-                  type="button"
-                  aria-pressed={filter === key}
-                  onClick={() => setFilter(key)}
-                  className={cn(
-                    "flex items-center gap-1.5 rounded-full border px-3 py-1 text-[12.5px] font-medium transition-colors",
-                    filter === key
-                      ? "border-brand-500 bg-brand-500/10 text-brand-600"
-                      : "border-border bg-surface text-muted-foreground hover:text-foreground",
-                  )}
-                >
-                  {label}
-                  <span className="font-mono text-[11px] opacity-70">{count}</span>
-                </button>
-              );
-            })}
-          </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search integrations…"
+            aria-label="Search integrations"
+            className="h-9 max-w-xs"
+          />
+          {(["in", "out"] as const).map((d) => (
+            <button
+              key={d}
+              type="button"
+              aria-pressed={direction === d}
+              onClick={() => setDirection(direction === d ? null : d)}
+              className={cn(
+                "rounded-full border px-3 py-1.5 text-[12.5px] font-medium transition-colors",
+                direction === d
+                  ? d === "in"
+                    ? "border-human/40 bg-human/10 text-human"
+                    : "border-warning/40 bg-chart-5/15 text-warning"
+                  : "border-border bg-surface text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {d === "in" ? "→ Flowing in" : "Flowing out →"}
+            </button>
+          ))}
+          <span className="ml-auto font-mono text-[11.5px] text-muted-foreground">
+            {visible.length} of {boxes.length} · {connectedCount} connected
+          </span>
         </div>
 
         {loadError && (
@@ -411,67 +437,60 @@ export default function IntegrationsPage() {
           </div>
         )}
 
-        {shows("sources") && !loadError && (
-          <Section category={cat("sources")} count={counts.sources}>
-            {statuses === null ? (
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                {Array.from({ length: 6 }, (_, i) => (
-                  <Skeleton key={i} className="h-[124px] rounded-xl" />
-                ))}
-              </div>
-            ) : (
-              <SourcesGrid
-                connectors={available}
-                statuses={statuses}
-                onConnected={isConnected}
+        {statuses === null && !loadError ? (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: 9 }, (_, i) => (
+              <Skeleton key={i} className="h-[124px] rounded-xl" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {visible.map((box) => (
+              <IntegrationBox
+                key={box.key}
+                box={box}
+                onOpen={box.dialog ? () => setOpen(box) : undefined}
               />
-            )}
-          </Section>
+            ))}
+          </div>
         )}
 
-        {shows("browser") && (
-          <Section category={cat("browser")} count={counts.browser}>
-            <Link
-              href="/extension"
-              className="flex items-start gap-3 rounded-xl border border-border bg-surface p-4 transition-colors hover:bg-raised sm:max-w-md"
-            >
-              <Globe className="mt-0.5 h-6 w-6 shrink-0 text-muted-foreground" />
-              <span className="flex flex-col gap-1">
-                <span className="text-[14px] font-medium text-foreground">Stash for Chrome</span>
-                <span className="text-[12.5px] leading-snug text-muted-foreground">
-                  Clip any page or every open tab, import your bookmarks, and keep your X and
-                  Instagram saves in sync.
-                </span>
-              </span>
-            </Link>
-          </Section>
+        {statuses !== null && visible.length === 0 && (
+          <p className="py-8 text-center text-[13px] text-muted-foreground">
+            Nothing matches “{query}”.
+          </p>
         )}
-
-        {shows("tools") && (
-          <Section category={cat("tools")} count={counts.tools}>
-            <McpServers onCountChange={setMcpCount} />
-          </Section>
-        )}
-
-        {shows("access") && (
-          <Section category={cat("access")} count={counts.access}>
-            <OutputSurfaces />
-          </Section>
-        )}
-
-        {shows("agent-sessions") && (
-          <Section category={cat("agent-sessions")} count={counts["agent-sessions"]}>
-            <CodingAgents direction="in" agentNames={agentNames} />
-          </Section>
-        )}
-
-        {shows("agent-access") && (
-          <Section category={cat("agent-access")} count={counts["agent-access"]}>
-            <CodingAgents direction="out" />
-          </Section>
-        )}
-
       </div>
+
+      <Dialog open={open !== null} onOpenChange={(v) => !v && setOpen(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{open?.dialog?.title}</DialogTitle>
+            <DialogDescription>{open?.dialog?.description}</DialogDescription>
+          </DialogHeader>
+          {open?.dialog?.body}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={addingServer} onOpenChange={setAddingServer}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add an MCP server</DialogTitle>
+            <DialogDescription>
+              Your cloud agent gets it before every turn, alongside the tools Stash gives it
+              natively.
+            </DialogDescription>
+          </DialogHeader>
+          <AddServerForm
+            onAdded={() => {
+              setAddingServer(false);
+              void refreshServers();
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {paywalled && <PaywallModal onClose={() => setPaywalled(false)} />}
     </div>
   );
 }

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -35,11 +35,17 @@ import { cn } from "@/lib/utils";
 // neither section is allowed to be called just "MCP".
 type Direction = "in" | "out";
 
-type Category = "sources" | "browser" | "tools" | "access" | "agents";
+type Category =
+  | "sources"
+  | "browser"
+  | "tools"
+  | "agent-sessions"
+  | "access"
+  | "agent-access";
 
 const CATEGORIES: {
   key: Category;
-  direction: Direction | "both";
+  direction: Direction;
   label: string;
   blurb: string;
 }[] = [
@@ -68,10 +74,16 @@ const CATEGORIES: {
     blurb: "MCP, the CLI, and the HTTP API — how an agent or a script reads what you've collected.",
   },
   {
-    key: "agents",
-    direction: "both",
+    key: "agent-sessions",
+    direction: "in",
     label: "Coding agents",
-    blurb: "The one surface that runs both ways: their transcripts land in your stash, and they read the rest of it while they work.",
+    blurb: "Every session they run lands in your stash as a transcript, searchable like anything else.",
+  },
+  {
+    key: "agent-access",
+    direction: "out",
+    label: "Coding agents",
+    blurb: "Point them at your stash and they read it while they work — your notes, sources, and past sessions.",
   },
 ];
 
@@ -184,16 +196,14 @@ function SourcesGrid({
 }
 
 /** A direction badge — the same mark on the segmented control, the section
- *  headings, and the one category that carries both. */
-function DirectionBadge({ direction }: { direction: Direction | "both" }) {
-  const label = direction === "in" ? "→ IN" : direction === "out" ? "OUT →" : "⇄ BOTH";
+ *  headings. */
+function DirectionBadge({ direction }: { direction: Direction }) {
+  const label = direction === "in" ? "→ IN" : "OUT →";
   return (
     <span
       className={cn(
         "rounded-full px-2 py-0.5 font-mono text-[10.5px] font-semibold leading-normal",
-        direction === "in" && "bg-human/10 text-human",
-        direction === "out" && "bg-chart-5/15 text-warning",
-        direction === "both" && "bg-brand-500/10 text-brand-600",
+        direction === "in" ? "bg-human/10 text-human" : "bg-chart-5/15 text-warning",
       )}
     >
       {label}
@@ -294,15 +304,12 @@ export default function IntegrationsPage() {
     sources: available.length,
     browser: 1,
     tools: mcpCount,
+    "agent-sessions": CODING_AGENTS.length,
     access: OUTPUT_SURFACES.length,
-    agents: CODING_AGENTS.length,
+    "agent-access": CODING_AGENTS.length,
   };
 
-  // A category belongs to the open direction if it points that way, or if it
-  // runs both ways — coding agents genuinely do, so they appear under each.
-  const inDirection = CATEGORIES.filter(
-    (c) => c.direction === direction || c.direction === "both",
-  );
+  const inDirection = CATEGORIES.filter((c) => c.direction === direction);
 
   // The sub-filter is scoped to the open direction, so switching direction
   // resets it rather than leaving a filter selected that no longer exists.
@@ -452,9 +459,15 @@ export default function IntegrationsPage() {
           </Section>
         )}
 
-        {shows("agents") && (
-          <Section category={cat("agents")} count={counts.agents}>
-            <CodingAgents agentNames={agentNames} />
+        {shows("agent-sessions") && (
+          <Section category={cat("agent-sessions")} count={counts["agent-sessions"]}>
+            <CodingAgents direction="in" agentNames={agentNames} />
+          </Section>
+        )}
+
+        {shows("agent-access") && (
+          <Section category={cat("agent-access")} count={counts["agent-access"]}>
+            <CodingAgents direction="out" />
           </Section>
         )}
 

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -395,8 +395,7 @@ export default function IntegrationsPage() {
 
   if (loading || !user) return null;
 
-  const inDirection = boxes.filter((b) => b.direction === direction);
-  const connectedCount = inDirection.filter((b) => b.active).length;
+  const connectedCount = boxes.filter((b) => b.direction === direction && b.active).length;
 
   return (
     <div className="h-full overflow-y-auto">
@@ -439,10 +438,11 @@ export default function IntegrationsPage() {
               {d === "in" ? "Inputs" : "Outputs"}
             </button>
           ))}
-          <span className="ml-auto font-mono text-[11.5px] text-muted-foreground">
-            {visible.length} of {inDirection.length}
-            {connectedCount > 0 && ` · ${connectedCount} connected`}
-          </span>
+          {connectedCount > 0 && (
+            <span className="ml-auto font-mono text-[11.5px] text-muted-foreground">
+              {connectedCount} connected
+            </span>
+          )}
         </div>
 
         {loadError && (

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -84,6 +84,8 @@ type Box = {
   dialog?: { title: string; description: string; body: ReactNode };
   /** Verb on the button that opens the dialog. */
   actionLabel?: string;
+  /** For the one box that isn't a detail view: opens the add-server form. */
+  onAction?: () => void;
   action: ReactNode;
 };
 
@@ -114,6 +116,50 @@ function IntegrationBox({ box, onOpen }: { box: Box; onOpen?: () => void }) {
       </p>
 
       {box.action}
+    </div>
+  );
+}
+
+/** A source connector's detail view. Also the only place `disabled_reason`
+ *  is ever shown: a server without INTEGRATIONS_ENCRYPTION_KEY offers a
+ *  Connect button that can only 503, and until now said nothing about why. */
+function ConnectorDialogBody({
+  connector,
+  status,
+  connected,
+  busy,
+  onConnect,
+}: {
+  connector: Connector;
+  status: IntegrationStatus | undefined;
+  connected: boolean;
+  busy: boolean;
+  onConnect: (() => void) | null;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-3">
+      {status?.disabled_reason && (
+        <p className="rounded-lg border border-warning/30 bg-chart-5/10 px-3 py-2 text-[12.5px] text-warning">
+          {status.disabled_reason}
+        </p>
+      )}
+      <p className="text-[12.5px] text-muted-foreground">
+        {connected
+          ? "Connected. Choose what syncs, check sync status, or disconnect on its settings page."
+          : "Connecting opens the provider's consent screen. Nothing syncs until you pick what to include."}
+      </p>
+      <div className="flex flex-wrap items-center gap-2">
+        {!connected && onConnect && (
+          <Button size="sm" disabled={busy} onClick={onConnect}>
+            {busy ? "Connecting…" : `Connect ${connector.label}`}
+          </Button>
+        )}
+        <Button asChild size="sm" variant={connected || !onConnect ? "secondary" : "ghost"}>
+          <Link href={`/integrations/${connector.provider}`}>
+            {connected ? "Manage sources" : `Open ${connector.label} settings`}
+          </Link>
+        </Button>
+      </div>
     </div>
   );
 }
@@ -253,7 +299,7 @@ export default function IntegrationsPage() {
     // integrations like Heavi) — extension connectors are always available.
     const connectors = CONNECTORS.filter((c) => c.kind === "extension" || c.provider in statuses);
 
-    const sourceBoxes: Box[] = connectors.map((c) => {
+    const sourceBoxes: Omit<Box, "action">[] = connectors.map((c) => {
       const connected = isConnected(c);
       const status = statuses[c.provider];
       const oauth =
@@ -267,29 +313,24 @@ export default function IntegrationsPage() {
         active: connected,
         tier: PERSONAL_PROVIDERS.has(c.provider) ? TIER.personal : TIER.work,
         search: `${c.label} ${c.blurb} ${c.provider} source`,
-        action: connected ? (
-          <Button asChild variant="ghost" size="sm" className="self-start px-2">
-            <Link href={`/integrations/${c.provider}`}>Manage</Link>
-          </Button>
-        ) : oauth ? (
-          <Button
-            size="sm"
-            variant="secondary"
-            className="self-start"
-            disabled={busy === c.provider}
-            onClick={() => void connectNow(c)}
-          >
-            {busy === c.provider ? "Connecting…" : "Connect"}
-          </Button>
-        ) : (
-          <Button asChild size="sm" variant="secondary" className="self-start">
-            <Link href={`/integrations/${c.provider}`}>Connect</Link>
-          </Button>
-        ),
+        actionLabel: connected ? "Manage" : "Connect",
+        dialog: {
+          title: c.label,
+          description: c.blurb,
+          body: (
+            <ConnectorDialogBody
+              connector={c}
+              status={status}
+              connected={connected}
+              busy={busy === c.provider}
+              onConnect={oauth ? () => void connectNow(c) : null}
+            />
+          ),
+        },
       };
     });
 
-    const browserBox: Box = {
+    const browserBox: Omit<Box, "action"> = {
       key: "browser",
       name: "Stash for Chrome",
       direction: "in",
@@ -298,11 +339,24 @@ export default function IntegrationsPage() {
       active: false,
       tier: TIER.personal,
       search: "browser chrome extension clip bookmarks tabs",
-      action: (
-        <Button asChild size="sm" variant="secondary" className="self-start">
-          <Link href="/extension">Install</Link>
-        </Button>
-      ),
+      actionLabel: "Connect",
+      dialog: {
+        title: "Stash for Chrome",
+        description: "Save from the browser without leaving the page.",
+        body: (
+          <div className="flex min-w-0 flex-col gap-3">
+            <ul className="flex list-disc flex-col gap-1 pl-4 text-[12.5px] text-muted-foreground">
+              <li>Clip any page, or every open tab at once.</li>
+              <li>Import your bookmarks — Stash fetches what&apos;s behind each link.</li>
+              <li>Keep your X and Instagram saves in sync.</li>
+              <li>Stream your ChatGPT and Claude chats in.</li>
+            </ul>
+            <Button asChild size="sm" className="self-start">
+              <Link href="/extension">Get the extension</Link>
+            </Button>
+          </div>
+        ),
+      },
     };
 
     const serverBoxes: Omit<Box, "action">[] = servers.map((s) => ({
@@ -364,7 +418,7 @@ export default function IntegrationsPage() {
       },
     }));
 
-    const addServerBox: Box = {
+    const addServerBox: Omit<Box, "action"> = {
       key: "mcp:add",
       name: "Custom MCP server",
       direction: "in",
@@ -374,16 +428,8 @@ export default function IntegrationsPage() {
       tier: TIER.work,
       sortLast: true,
       search: "custom mcp server add tool",
-      action: (
-        <Button
-          size="sm"
-          variant="secondary"
-          className="self-start"
-          onClick={() => setAddingServer(true)}
-        >
-          Add
-        </Button>
-      ),
+      actionLabel: "Add",
+      onAction: () => setAddingServer(true),
     };
 
     // A coding agent is two integrations wearing one name, so it gets a box
@@ -393,7 +439,7 @@ export default function IntegrationsPage() {
         key: `agent:${d}:${agent.binary}`,
         name: AGENT_COPY[d].label(agent.name),
         direction: d,
-        blurb: AGENT_COPY[d].blurb,
+        blurb: AGENT_COPY[d].blurb(agent.name),
         icon: agent.icon,
         active: false,
         tier: TIER.agents,
@@ -401,7 +447,7 @@ export default function IntegrationsPage() {
         dialog: {
           title: AGENT_COPY[d].title(agent.name),
           description: AGENT_COPY[d].description,
-          body: agentDialogBody(agent, d),
+          body: agentDialogBody(d),
         },
       })),
     );
@@ -420,16 +466,28 @@ export default function IntegrationsPage() {
 
     // Every box that opens a dialog gets its button built here, so the grid
     // can't sprout a different shape of action per box type.
-    const withDialogs: Box[] = [...serverBoxes, ...agentBoxes, ...outputBoxes].map((b) => ({
+    const withDialogs: Box[] = [
+      ...sourceBoxes,
+      browserBox,
+      addServerBox,
+      ...serverBoxes,
+      ...agentBoxes,
+      ...outputBoxes,
+    ].map((b) => ({
       ...b,
       action: (
-        <Button size="sm" variant="secondary" className="self-start" onClick={() => setOpen({ ...b, action: null })}>
+        <Button
+          size="sm"
+          variant="secondary"
+          className="self-start"
+          onClick={() => (b.onAction ? b.onAction() : setOpen({ ...b, action: null }))}
+        >
           {b.actionLabel ?? "Connect"}
         </Button>
       ),
     }));
 
-    return [...sourceBoxes, browserBox, addServerBox, ...withDialogs].sort(
+    return [...withDialogs].sort(
       (a, b) =>
         a.tier - b.tier ||
         Number(!!a.sortLast) - Number(!!b.sortLast) ||

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -25,35 +25,53 @@ import {
 } from "@/components/integrations/connectors";
 import CodingAgents, { CODING_AGENTS } from "@/components/integrations/CodingAgents";
 import McpServers from "@/components/integrations/McpServers";
+import OutputSurfaces from "@/components/integrations/OutputSurfaces";
 import PaywallModal from "@/components/PaywallModal";
 import { cn } from "@/lib/utils";
 
-// The four ways anything reaches Stash. This page exists to make that list
-// legible in one screen: before this, connectors and MCP servers were on it
-// and the other two lived in onboarding, so "what can I connect?" had no
-// single answer.
-type Category = "sources" | "agents" | "mcp" | "browser";
+// Direction is the page's first distinction: what puts content INTO the stash,
+// and what reads it back OUT. "MCP" means opposite things on the two sides —
+// servers Stash calls (in) versus Stash as a server agents call (out) — so
+// neither section is allowed to be called just "MCP".
+type Direction = "in" | "out";
 
-const CATEGORIES: { key: Category; label: string; blurb: string }[] = [
+type Category = "sources" | "browser" | "tools" | "access" | "agents";
+
+const CATEGORIES: {
+  key: Category;
+  direction: Direction | "both";
+  label: string;
+  blurb: string;
+}[] = [
   {
     key: "sources",
+    direction: "in",
     label: "Sources",
     blurb: "Connect an account and everything in it becomes searchable by every agent you point at Stash.",
   },
   {
-    key: "agents",
-    label: "Coding agents",
-    blurb: "Their sessions land in your stash, and they can read the rest of it while they work.",
-  },
-  {
-    key: "mcp",
-    label: "MCP servers",
-    blurb: "Tools your cloud agent can call, on top of everything Stash gives it natively.",
-  },
-  {
     key: "browser",
+    direction: "in",
     label: "Browser",
     blurb: "Clip any page, import your bookmarks, and sync what you save on X and Instagram.",
+  },
+  {
+    key: "tools",
+    direction: "in",
+    label: "Tools your agent can call",
+    blurb: "MCP servers you register here are handed to your cloud agent, on top of everything Stash gives it natively.",
+  },
+  {
+    key: "access",
+    direction: "out",
+    label: "Connect an agent",
+    blurb: "MCP, the CLI, and the HTTP API — how an agent or a script reads what you've collected.",
+  },
+  {
+    key: "agents",
+    direction: "both",
+    label: "Coding agents",
+    blurb: "The one surface that runs both ways: their transcripts land in your stash, and they read the rest of it while they work.",
   },
 ];
 
@@ -165,26 +183,52 @@ function SourcesGrid({
   );
 }
 
+/** A direction badge — the same mark on the segmented control, the section
+ *  headings, and the one category that carries both. */
+function DirectionBadge({ direction }: { direction: Direction | "both" }) {
+  const label = direction === "in" ? "→ IN" : direction === "out" ? "OUT →" : "⇄ BOTH";
+  return (
+    <span
+      className={cn(
+        "rounded-full px-2 py-0.5 font-mono text-[10.5px] font-semibold leading-normal",
+        direction === "in" && "bg-human/10 text-human",
+        direction === "out" && "bg-chart-5/15 text-warning",
+        direction === "both" && "bg-brand-500/10 text-brand-600",
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
 function Section({
   category,
   count,
   children,
 }: {
   category: (typeof CATEGORIES)[number];
-  count: number;
+  count: number | null;
   children: React.ReactNode;
 }) {
   return (
     <section id={category.key}>
-      <div className="flex items-baseline gap-2">
+      <div className="flex items-center gap-2">
         <h2 className="font-display text-[16px] font-semibold text-foreground">{category.label}</h2>
-        <span className="font-mono text-[12px] text-muted-foreground">{count}</span>
+        {count !== null && (
+          <span className="font-mono text-[12px] text-muted-foreground">{count}</span>
+        )}
+        <DirectionBadge direction={category.direction} />
       </div>
       <p className="mt-0.5 max-w-2xl text-[13px] text-muted-foreground">{category.blurb}</p>
       <div className="mt-4">{children}</div>
     </section>
   );
 }
+
+// How many ways out of the stash OutputSurfaces renders: MCP, CLI, API.
+const OUTPUT_SURFACES = 3;
+
+const cat = (key: Category) => CATEGORIES.find((c) => c.key === key)!;
 
 export default function IntegrationsPage() {
   const router = useRouter();
@@ -194,6 +238,7 @@ export default function IntegrationsPage() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [agentNames, setAgentNames] = useState<string[]>([]);
   const [mcpCount, setMcpCount] = useState(0);
+  const [direction, setDirection] = useState<Direction>("in");
   const [filter, setFilter] = useState<Category | "all">("all");
 
   useBreadcrumbs([{ label: "Integrations" }], "integrations");
@@ -250,12 +295,27 @@ export default function IntegrationsPage() {
 
   const counts: Record<Category, number> = {
     sources: available.length,
-    agents: CODING_AGENTS.length,
-    mcp: mcpCount,
     browser: 1,
+    tools: mcpCount,
+    access: OUTPUT_SURFACES,
+    agents: CODING_AGENTS.length,
   };
 
-  const shows = (c: Category) => filter === "all" || filter === c;
+  // A category belongs to the open direction if it points that way, or if it
+  // runs both ways — coding agents genuinely do, so they appear under each.
+  const inDirection = CATEGORIES.filter(
+    (c) => c.direction === direction || c.direction === "both",
+  );
+
+  // The sub-filter is scoped to the open direction, so switching direction
+  // resets it rather than leaving a filter selected that no longer exists.
+  const shows = (c: Category) =>
+    inDirection.some((cat) => cat.key === c) && (filter === "all" || filter === c);
+
+  function openDirection(next: Direction) {
+    setDirection(next);
+    setFilter("all");
+  }
 
   return (
     <div className="h-full overflow-y-auto">
@@ -265,8 +325,8 @@ export default function IntegrationsPage() {
             Integrations
           </h1>
           <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-            The one place to connect everything to Stash — the accounts your agents read from, the
-            coding agents that read them, the tools they can call, and the browser you save from.
+            The one place to connect everything to Stash. Everything that flows in, and every way
+            it flows back out to an agent.
           </p>
           {statuses && (
             <p className="mt-2.5 font-mono text-[12px] text-muted-foreground">
@@ -278,32 +338,67 @@ export default function IntegrationsPage() {
           )}
         </header>
 
-        <div className="flex flex-wrap gap-1.5">
-          {(["all", ...CATEGORIES.map((c) => c.key)] as const).map((key) => {
-            const label =
-              key === "all" ? "All" : CATEGORIES.find((c) => c.key === key)!.label;
-            const count =
-              key === "all"
-                ? Object.values(counts).reduce((a, b) => a + b, 0)
-                : counts[key as Category];
-            return (
+        <div className="flex flex-col gap-3">
+          {/* Direction is the primary choice; categories nest under whichever
+              half is open. */}
+          <div className="flex w-full max-w-md overflow-hidden rounded-xl border border-border" role="tablist">
+            {(["in", "out"] as const).map((d) => (
               <button
-                key={key}
+                key={d}
                 type="button"
-                aria-pressed={filter === key}
-                onClick={() => setFilter(key as Category | "all")}
+                role="tab"
+                aria-selected={direction === d}
+                onClick={() => openDirection(d)}
                 className={cn(
-                  "flex items-center gap-1.5 rounded-full border px-3 py-1 text-[12.5px] font-medium transition-colors",
-                  filter === key
-                    ? "border-brand-500 bg-brand-500/10 text-brand-600"
-                    : "border-border bg-surface text-muted-foreground hover:text-foreground",
+                  "flex flex-1 items-center justify-center gap-2 px-4 py-2.5 text-[13px] font-semibold transition-colors",
+                  d === "out" && "border-l border-border",
+                  direction === d
+                    ? d === "in"
+                      ? "bg-human/10 text-human"
+                      : "bg-chart-5/15 text-warning"
+                    : "bg-surface text-muted-foreground hover:text-foreground",
                 )}
               >
-                {label}
-                <span className="font-mono text-[11px] opacity-70">{count}</span>
+                <span className="font-mono text-[12px]">{d === "in" ? "→" : ""}</span>
+                {d === "in" ? "Flowing in" : "Flowing out"}
+                <span className="font-mono text-[12px]">{d === "out" ? "→" : ""}</span>
               </button>
-            );
-          })}
+            ))}
+          </div>
+
+          <p className="text-[12.5px] text-muted-foreground">
+            {direction === "in"
+              ? "What puts content into your stash."
+              : "How agents and scripts read what's in it."}
+          </p>
+
+          <div className="flex flex-wrap gap-1.5">
+            {(["all", ...inDirection.map((c) => c.key)] as (Category | "all")[]).map((key) => {
+              const label =
+                key === "all" ? "All" : CATEGORIES.find((c) => c.key === key)!.label;
+              const count =
+                key === "all"
+                  ? inDirection.reduce((sum, c) => sum + counts[c.key], 0)
+                  : counts[key as Category];
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  aria-pressed={filter === key}
+                  onClick={() => setFilter(key)}
+                  className={cn(
+                    "flex items-center gap-1.5 rounded-full border px-3 py-1 text-[12.5px] font-medium transition-colors",
+                    filter === key
+                      ? "border-brand-500 bg-brand-500/10 text-brand-600"
+                      : "border-border bg-surface text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {label}
+                  <span className="font-mono text-[11px] opacity-70">{count}</span>
+                </button>
+              );
+            })}
+          </div>
         </div>
 
         {loadError && (
@@ -313,7 +408,7 @@ export default function IntegrationsPage() {
         )}
 
         {shows("sources") && !loadError && (
-          <Section category={CATEGORIES[0]} count={counts.sources}>
+          <Section category={cat("sources")} count={counts.sources}>
             {statuses === null ? (
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
                 {Array.from({ length: 6 }, (_, i) => (
@@ -330,20 +425,8 @@ export default function IntegrationsPage() {
           </Section>
         )}
 
-        {shows("agents") && (
-          <Section category={CATEGORIES[1]} count={counts.agents}>
-            <CodingAgents agentNames={agentNames} />
-          </Section>
-        )}
-
-        {shows("mcp") && (
-          <Section category={CATEGORIES[2]} count={counts.mcp}>
-            <McpServers onCountChange={setMcpCount} />
-          </Section>
-        )}
-
         {shows("browser") && (
-          <Section category={CATEGORIES[3]} count={counts.browser}>
+          <Section category={cat("browser")} count={counts.browser}>
             <Link
               href="/extension"
               className="flex items-start gap-3 rounded-xl border border-border bg-surface p-4 transition-colors hover:bg-raised sm:max-w-md"
@@ -359,6 +442,25 @@ export default function IntegrationsPage() {
             </Link>
           </Section>
         )}
+
+        {shows("tools") && (
+          <Section category={cat("tools")} count={counts.tools}>
+            <McpServers onCountChange={setMcpCount} />
+          </Section>
+        )}
+
+        {shows("access") && (
+          <Section category={cat("access")} count={counts.access}>
+            <OutputSurfaces />
+          </Section>
+        )}
+
+        {shows("agents") && (
+          <Section category={cat("agents")} count={counts.agents}>
+            <CodingAgents agentNames={agentNames} />
+          </Section>
+        )}
+
       </div>
     </div>
   );

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -436,7 +436,7 @@ export default function IntegrationsPage() {
                   : "border-border bg-surface text-muted-foreground hover:text-foreground",
               )}
             >
-              {d === "in" ? "→ Flowing in" : "Flowing out →"}
+              {d === "in" ? "Inputs" : "Outputs"}
             </button>
           ))}
           <span className="ml-auto font-mono text-[11.5px] text-muted-foreground">
@@ -481,7 +481,7 @@ export default function IntegrationsPage() {
                   className="font-medium text-brand-600 hover:underline"
                 >
                   {elsewhere} {elsewhere === 1 ? "match" : "matches"} in{" "}
-                  {direction === "in" ? "Flowing out" : "Flowing in"} →
+                  {direction === "in" ? "Outputs" : "Inputs"} →
                 </button>
               </>
             )}

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -79,8 +79,10 @@ type Box = {
   sortLast?: boolean;
   /** Everything the search field matches against. */
   search: string;
-  /** Setup instructions, for boxes whose action is "Set up". */
+  /** What the dialog holds: setup steps, or an integration's own settings. */
   dialog?: { title: string; description: string; body: ReactNode };
+  /** Verb on the button that opens the dialog. */
+  actionLabel?: string;
   action: ReactNode;
 };
 
@@ -288,7 +290,7 @@ export default function IntegrationsPage() {
       ),
     };
 
-    const serverBoxes: Box[] = servers.map((s) => ({
+    const serverBoxes: Omit<Box, "action">[] = servers.map((s) => ({
       key: `mcp:${s.id}`,
       name: s.name,
       direction: "in",
@@ -301,16 +303,51 @@ export default function IntegrationsPage() {
       active: true,
       tier: TIER.work,
       search: `${s.name} mcp server tool ${s.url ?? ""} ${s.command ?? ""}`,
-      action: (
-        <Button
-          variant="ghost"
-          size="sm"
-          className="self-start px-2"
-          onClick={() => void removeServer(s.id)}
-        >
-          Remove
-        </Button>
-      ),
+      actionLabel: "Manage",
+      dialog: {
+        title: s.name,
+        description: "An MCP server your cloud agent can call before every turn.",
+        body: (
+          <div className="flex min-w-0 flex-col gap-3">
+            <dl className="flex flex-col gap-2 text-[12.5px]">
+              <div className="flex gap-2">
+                <dt className="w-20 shrink-0 text-muted-foreground">Transport</dt>
+                <dd className="font-mono">
+                  {s.transport === "stdio" ? "Local (stdio)" : "Remote (HTTP)"}
+                </dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="w-20 shrink-0 text-muted-foreground">
+                  {s.transport === "stdio" ? "Command" : "URL"}
+                </dt>
+                <dd className="min-w-0 break-all font-mono">
+                  {s.transport === "stdio" ? s.command : s.url}
+                </dd>
+              </div>
+              {Object.keys(s.headers).length > 0 && (
+                <div className="flex gap-2">
+                  <dt className="w-20 shrink-0 text-muted-foreground">Headers</dt>
+                  {/* Values are secrets — the registry only ever shows key names. */}
+                  <dd className="min-w-0 break-all font-mono">
+                    {Object.keys(s.headers).join(", ")}
+                  </dd>
+                </div>
+              )}
+            </dl>
+            <Button
+              variant="destructive"
+              size="sm"
+              className="self-start"
+              onClick={async () => {
+                await removeServer(s.id);
+                setOpen(null);
+              }}
+            >
+              Remove server
+            </Button>
+          </div>
+        ),
+      },
     }));
 
     const addServerBox: Box = {
@@ -337,7 +374,7 @@ export default function IntegrationsPage() {
 
     // A coding agent is two integrations wearing one name, so it gets a box
     // per direction with the half that applies.
-    const agentBoxes = (["in", "out"] as const).flatMap((d) =>
+    const agentBoxes: Omit<Box, "action">[] = (["in", "out"] as const).flatMap((d) =>
       CODING_AGENTS.map((agent) => ({
         key: `agent:${d}:${agent.binary}`,
         name: agent.name,
@@ -355,7 +392,7 @@ export default function IntegrationsPage() {
       })),
     );
 
-    const outputBoxes = OUTPUT_SURFACES.map((s) => ({
+    const outputBoxes: Omit<Box, "action">[] = OUTPUT_SURFACES.map((s) => ({
       key: `out:${s.key}`,
       name: s.name,
       direction: "out" as const,
@@ -367,18 +404,18 @@ export default function IntegrationsPage() {
       dialog: { title: s.name, description: s.blurb, body: s.body },
     }));
 
-    // Every box whose action is a dialog gets the same button, so the grid
-    // doesn't sprout a different verb per box type.
-    const withSetup: Box[] = [...agentBoxes, ...outputBoxes].map((b) => ({
+    // Every box that opens a dialog gets its button built here, so the grid
+    // can't sprout a different shape of action per box type.
+    const withDialogs: Box[] = [...serverBoxes, ...agentBoxes, ...outputBoxes].map((b) => ({
       ...b,
       action: (
-        <Button size="sm" variant="secondary" className="self-start" onClick={() => setOpen(b as Box)}>
-          Set up
+        <Button size="sm" variant="secondary" className="self-start" onClick={() => setOpen({ ...b, action: null })}>
+          {b.actionLabel ?? "Set up"}
         </Button>
       ),
     }));
 
-    return [...sourceBoxes, browserBox, ...serverBoxes, addServerBox, ...withSetup].sort(
+    return [...sourceBoxes, browserBox, addServerBox, ...withDialogs].sort(
       (a, b) =>
         a.tier - b.tier ||
         Number(!!a.sortLast) - Number(!!b.sortLast) ||

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/integrations/connectors";
 import CodingAgents, { CODING_AGENTS } from "@/components/integrations/CodingAgents";
 import McpServers from "@/components/integrations/McpServers";
-import OutputSurfaces from "@/components/integrations/OutputSurfaces";
+import OutputSurfaces, { OUTPUT_SURFACES } from "@/components/integrations/OutputSurfaces";
 import PaywallModal from "@/components/PaywallModal";
 import { cn } from "@/lib/utils";
 
@@ -225,9 +225,6 @@ function Section({
   );
 }
 
-// How many ways out of the stash OutputSurfaces renders: MCP, CLI, API.
-const OUTPUT_SURFACES = 3;
-
 const cat = (key: Category) => CATEGORIES.find((c) => c.key === key)!;
 
 export default function IntegrationsPage() {
@@ -297,7 +294,7 @@ export default function IntegrationsPage() {
     sources: available.length,
     browser: 1,
     tools: mcpCount,
-    access: OUTPUT_SURFACES,
+    access: OUTPUT_SURFACES.length,
     agents: CODING_AGENTS.length,
   };
 

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -15,6 +15,7 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -423,7 +424,7 @@ export default function IntegrationsPage() {
       ...b,
       action: (
         <Button size="sm" variant="secondary" className="self-start" onClick={() => setOpen({ ...b, action: null })}>
-          {b.actionLabel ?? "Set up"}
+          {b.actionLabel ?? "Connect"}
         </Button>
       ),
     }));
@@ -557,10 +558,22 @@ export default function IntegrationsPage() {
       <Dialog open={open !== null} onOpenChange={(v) => !v && setOpen(null)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>{open?.dialog?.title}</DialogTitle>
-            <DialogDescription>{open?.dialog?.description}</DialogDescription>
+            <div className="flex items-start gap-3">
+              <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center [&_img]:h-7 [&_img]:w-7 [&_svg]:h-7 [&_svg]:w-7">
+                {open?.icon}
+              </span>
+              <div className="flex min-w-0 flex-col gap-1">
+                <DialogTitle>{open?.dialog?.title}</DialogTitle>
+                <DialogDescription>{open?.dialog?.description}</DialogDescription>
+              </div>
+            </div>
           </DialogHeader>
           {open?.dialog?.body}
+          <DialogFooter>
+            <Button size="sm" onClick={() => setOpen(null)}>
+              Done
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
-import { Bot, Globe, Plus, SquareTerminal } from "lucide-react";
+import { Globe, Server, SquareTerminal } from "lucide-react";
 import { toast } from "sonner";
 
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
@@ -47,6 +47,7 @@ import {
 import { OUTPUT_SURFACES } from "@/components/integrations/OutputSurfaces";
 import AddServerForm from "@/components/integrations/McpServers";
 import PaywallModal from "@/components/PaywallModal";
+import { ChromeIcon } from "@/components/integrations/BrandIcons";
 import { cn } from "@/lib/utils";
 
 // One flat grid. Every way anything reaches Stash, or reads it back, is a box
@@ -116,12 +117,20 @@ function IntegrationBox({ box, onOpen }: { box: Box; onOpen?: () => void }) {
 
 /** A lucide glyph in the same tile the brand marks sit in, so a box with no
  *  logo still lines up with one that has. */
-function TileIcon({ icon: Icon }: { icon: typeof Bot }) {
+function TileIcon({ icon: Icon }: { icon: typeof Globe }) {
   return (
     <span className="flex h-7 w-7 items-center justify-center rounded-md bg-raised">
       <Icon className="h-4 w-4 text-dim" />
     </span>
   );
+}
+
+function mcpServerIcon(server: McpServer) {
+  if (server.url && new URL(server.url).hostname === "mcp.linear.app") {
+    return connectorIcon("linear");
+  }
+
+  return <TileIcon icon={server.transport === "stdio" ? SquareTerminal : Globe} />;
 }
 
 export default function IntegrationsPage() {
@@ -268,7 +277,7 @@ export default function IntegrationsPage() {
       name: "Stash for Chrome",
       direction: "in",
       blurb: "Clip any page or every open tab, import your bookmarks, keep your saves in sync.",
-      icon: <TileIcon icon={Globe} />,
+      icon: <ChromeIcon />,
       active: false,
       tier: TIER.personal,
       search: "browser chrome extension clip bookmarks tabs",
@@ -288,7 +297,7 @@ export default function IntegrationsPage() {
         (Object.keys(s.headers).length > 0
           ? ` · headers: ${Object.keys(s.headers).join(", ")}`
           : ""),
-      icon: <TileIcon icon={s.transport === "stdio" ? SquareTerminal : Globe} />,
+      icon: mcpServerIcon(s),
       active: true,
       tier: TIER.work,
       search: `${s.name} mcp server tool ${s.url ?? ""} ${s.command ?? ""}`,
@@ -309,7 +318,7 @@ export default function IntegrationsPage() {
       name: "Custom MCP server",
       direction: "in",
       blurb: "Register any MCP server and your cloud agent gets it before every turn.",
-      icon: <TileIcon icon={Plus} />,
+      icon: <TileIcon icon={Server} />,
       active: false,
       tier: TIER.work,
       sortLast: true,
@@ -334,7 +343,7 @@ export default function IntegrationsPage() {
         name: agent.name,
         direction: d,
         blurb: AGENT_COPY[d].blurb,
-        icon: <TileIcon icon={Bot} />,
+        icon: agent.icon,
         active: false,
         tier: TIER.agents,
         search: `${agent.name} ${agent.binary} coding agent`,

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -3,23 +3,14 @@
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Globe, Plus, Terminal } from "lucide-react";
+import { Globe } from "lucide-react";
 import { toast } from "sonner";
+
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
 import { useAuth } from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  ApiError,
-  createMcpServer,
-  deleteMcpServer,
-  listMcpServers,
-  listSources,
-  type McpServer,
-  type Source,
-} from "@/lib/api";
+import { ApiError, listAgentNames, listSources, type Source } from "@/lib/api";
 import {
   INTEGRATIONS_CHANGED_EVENT,
   listIntegrations,
@@ -32,14 +23,44 @@ import {
   providerForSourceType,
   type Connector,
 } from "@/components/integrations/connectors";
+import CodingAgents, { CODING_AGENTS } from "@/components/integrations/CodingAgents";
+import McpServers from "@/components/integrations/McpServers";
 import PaywallModal from "@/components/PaywallModal";
+import { cn } from "@/lib/utils";
 
-// One row per connector — the standard integrations list. The row is a link
-// to the provider's page (manage, pick sources, disconnect). For OAuth
-// providers the Connect button skips the page and goes straight to the
-// consent screen, returning here; api-key and extension providers still
-// route through their page (credential form / extension install).
-function IntegrationRow({
+// The four ways anything reaches Stash. This page exists to make that list
+// legible in one screen: before this, connectors and MCP servers were on it
+// and the other two lived in onboarding, so "what can I connect?" had no
+// single answer.
+type Category = "sources" | "agents" | "mcp" | "browser";
+
+const CATEGORIES: { key: Category; label: string; blurb: string }[] = [
+  {
+    key: "sources",
+    label: "Sources",
+    blurb: "Connect an account and everything in it becomes searchable by every agent you point at Stash.",
+  },
+  {
+    key: "agents",
+    label: "Coding agents",
+    blurb: "Their sessions land in your stash, and they can read the rest of it while they work.",
+  },
+  {
+    key: "mcp",
+    label: "MCP servers",
+    blurb: "Tools your cloud agent can call, on top of everything Stash gives it natively.",
+  },
+  {
+    key: "browser",
+    label: "Browser",
+    blurb: "Clip any page, import your bookmarks, and sync what you save on X and Instagram.",
+  },
+];
+
+/** One connector, as a card: what it is, what connecting gets you, and the
+ *  action. OAuth providers connect in place; the rest route to their page,
+ *  which holds the credential form or the extension install. */
+function ConnectorCard({
   connector,
   connected,
   busy,
@@ -51,56 +72,62 @@ function IntegrationRow({
   onOauthConnect: (() => void) | null;
 }) {
   return (
-    <Link
-      href={`/integrations/${connector.provider}`}
-      className="group flex items-center gap-4 px-4 py-3.5 transition-colors hover:bg-raised"
-    >
-      <span className="flex h-7 w-7 shrink-0 items-center justify-center [&_img]:h-6 [&_img]:w-6 [&_svg]:h-6 [&_svg]:w-6">
-        {connectorIcon(connector.provider)}
-      </span>
-      <div className="min-w-0 flex-1">
-        <div className="text-[13.5px] font-semibold text-foreground">{connector.label}</div>
-        <p className="truncate text-[12.5px] text-dim">{connector.blurb}</p>
-      </div>
-      {connected ? (
-        <span className="flex shrink-0 items-center gap-1.5 text-[12px] font-medium text-[var(--color-success)]">
-          <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-success)]" />
-          Connected
+    <div className="flex flex-col gap-2.5 rounded-xl border border-border bg-surface p-4">
+      <div className="flex items-center gap-2.5">
+        <span className="flex h-7 w-7 shrink-0 items-center justify-center [&_img]:h-6 [&_img]:w-6 [&_svg]:h-6 [&_svg]:w-6">
+          {connectorIcon(connector.provider)}
         </span>
-      ) : onOauthConnect ? (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onOauthConnect();
-          }}
-          disabled={busy}
-          className="shrink-0 cursor-pointer text-[12px] font-medium text-muted-foreground transition-colors hover:text-brand-700 disabled:cursor-not-allowed"
+        <Link
+          href={`/integrations/${connector.provider}`}
+          className="truncate text-[14px] font-medium text-foreground hover:underline"
         >
+          {connector.label}
+        </Link>
+        {connected && (
+          <span className="ml-auto flex items-center gap-1.5 rounded-full border border-border bg-base px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+            <span className="h-1.5 w-1.5 rounded-full bg-success" />
+            Connected
+          </span>
+        )}
+      </div>
+
+      <p className="min-h-[34px] text-[12.5px] leading-snug text-muted-foreground">
+        {connector.blurb}
+      </p>
+
+      {connected ? (
+        <Button asChild variant="ghost" size="sm" className="self-start px-2">
+          <Link href={`/integrations/${connector.provider}`}>Manage</Link>
+        </Button>
+      ) : onOauthConnect ? (
+        <Button size="sm" variant="secondary" className="self-start" disabled={busy} onClick={onOauthConnect}>
           {busy ? "Connecting…" : "Connect"}
-        </button>
+        </Button>
       ) : (
-        <span className="shrink-0 text-[12px] font-medium text-muted-foreground transition-colors group-hover:text-brand-700">
-          Connect
-        </span>
+        <Button asChild size="sm" variant="secondary" className="self-start">
+          <Link href={`/integrations/${connector.provider}`}>Connect</Link>
+        </Button>
       )}
-    </Link>
+    </div>
   );
 }
 
-function IntegrationsGrid() {
-  // Extension connectors have no token — source presence is their "connected".
-  // OAuth/api-key connectors use the integration status, so a provider that
-  // was disconnected with its data kept reads "Connect", not "Connected".
-  const [sourceProviders, setSourceProviders] = useState<Set<string>>(new Set());
-  const [statuses, setStatuses] = useState<Record<string, IntegrationStatus> | null>(null);
-  const [loadError, setLoadError] = useState<string | null>(null);
+/** Every source connector, connected ones first so the page answers "what do
+ *  I already have?" before "what could I add?". */
+function SourcesGrid({
+  connectors,
+  statuses,
+  onConnected,
+}: {
+  connectors: Connector[];
+  statuses: Record<string, IntegrationStatus>;
+  onConnected: (c: Connector) => boolean;
+}) {
   const [busy, setBusy] = useState<string | null>(null);
   const [paywalled, setPaywalled] = useState(false);
 
   // Straight to the consent screen; the OAuth flow returns to /integrations,
-  // where the row reads Connected. No successful-return path resets `busy` —
+  // where the card reads Connected. No successful-return path resets `busy` —
   // the whole page navigates away.
   async function connectNow(connector: Connector) {
     setBusy(connector.provider);
@@ -113,9 +140,71 @@ function IntegrationsGrid() {
     }
   }
 
-  // Both calls decide what a row says — statuses which rows exist, sources
-  // whether an extension row reads Connected — so either one failing makes
-  // the whole list wrong. Fail together, loudly, instead of showing a list
+  const sorted = [...connectors].sort(
+    (a, b) => Number(onConnected(b)) - Number(onConnected(a)) || a.label.localeCompare(b.label),
+  );
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {sorted.map((c) => {
+        const status = statuses[c.provider];
+        const oauth =
+          c.kind !== "extension" && status?.auth_kind !== "api_key" && !status?.disabled_reason;
+        return (
+          <ConnectorCard
+            key={c.provider}
+            connector={c}
+            connected={onConnected(c)}
+            busy={busy === c.provider}
+            onOauthConnect={oauth ? () => void connectNow(c) : null}
+          />
+        );
+      })}
+      {paywalled && <PaywallModal onClose={() => setPaywalled(false)} />}
+    </div>
+  );
+}
+
+function Section({
+  category,
+  count,
+  children,
+}: {
+  category: (typeof CATEGORIES)[number];
+  count: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={category.key}>
+      <div className="flex items-baseline gap-2">
+        <h2 className="font-display text-[16px] font-semibold text-foreground">{category.label}</h2>
+        <span className="font-mono text-[12px] text-muted-foreground">{count}</span>
+      </div>
+      <p className="mt-0.5 max-w-2xl text-[13px] text-muted-foreground">{category.blurb}</p>
+      <div className="mt-4">{children}</div>
+    </section>
+  );
+}
+
+export default function IntegrationsPage() {
+  const router = useRouter();
+  const { user, loading } = useAuth();
+  const [sourceProviders, setSourceProviders] = useState<Set<string>>(new Set());
+  const [statuses, setStatuses] = useState<Record<string, IntegrationStatus> | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [agentNames, setAgentNames] = useState<string[]>([]);
+  const [mcpCount, setMcpCount] = useState(0);
+  const [filter, setFilter] = useState<Category | "all">("all");
+
+  useBreadcrumbs([{ label: "Integrations" }], "integrations");
+
+  useEffect(() => {
+    if (!loading && !user) router.push("/login");
+  }, [user, loading, router]);
+
+  // Both calls decide what a card says — statuses which cards exist, sources
+  // whether an extension card reads Connected — so either one failing makes
+  // the whole grid wrong. Fail together, loudly, instead of showing a grid
   // that lies or skeletons that never resolve.
   useEffect(() => {
     const load = () => {
@@ -128,7 +217,7 @@ function IntegrationsGrid() {
           setStatuses(byProvider);
         })
         .catch((e) =>
-          setLoadError(e instanceof Error ? e.message : "Failed to load integrations")
+          setLoadError(e instanceof Error ? e.message : "Failed to load integrations"),
         );
     };
     load();
@@ -136,263 +225,140 @@ function IntegrationsGrid() {
     return () => window.removeEventListener(INTEGRATIONS_CHANGED_EVENT, load);
   }, []);
 
-  if (loadError) {
-    return (
-      <div className="rounded-xl border border-border bg-surface px-4 py-6 text-center text-[13px] text-destructive">
-        Couldn&apos;t load integrations: {loadError}
-      </div>
-    );
-  }
+  // The agent roster is a nice-to-have line, not a gate: it says what is
+  // already sending sessions, and the page is complete without it.
+  useEffect(() => {
+    listAgentNames().then(setAgentNames).catch(() => setAgentNames([]));
+  }, []);
 
-  if (statuses === null) {
-    return (
-      <div className="flex flex-col gap-2">
-        {Array.from({ length: 6 }, (_, i) => (
-          <Skeleton key={i} className="h-[54px] rounded-lg" />
-        ))}
-      </div>
-    );
-  }
+  const isConnected = useCallback(
+    (c: Connector) =>
+      c.kind === "extension"
+        ? sourceProviders.has(c.provider)
+        : !!statuses?.[c.provider]?.connected,
+    [sourceProviders, statuses],
+  );
+
+  if (loading || !user) return null;
 
   // The server omits providers this user may not use (customer-specific
   // integrations like Heavi) — extension connectors are always available.
-  const rows = CONNECTORS.filter((c) => c.kind === "extension" || c.provider in statuses);
-  return (
-    <div className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
-      {rows.map((c) => {
-        const status = statuses[c.provider];
-        const oauth =
-          c.kind !== "extension" && status?.auth_kind !== "api_key" && !status?.disabled_reason;
-        return (
-          <IntegrationRow
-            key={c.provider}
-            connector={c}
-            connected={c.kind === "extension" ? sourceProviders.has(c.provider) : !!status?.connected}
-            busy={busy === c.provider}
-            onOauthConnect={oauth ? () => void connectNow(c) : null}
-          />
-        );
-      })}
-      {paywalled && <PaywallModal onClose={() => setPaywalled(false)} />}
-    </div>
-  );
-}
+  const available = statuses
+    ? CONNECTORS.filter((c) => c.kind === "extension" || c.provider in statuses)
+    : [];
+  const connectedCount = available.filter(isConnected).length;
 
-// One "KEY=VALUE" line per header, parsed at submit time.
-function parseHeaderLines(raw: string): Record<string, string> {
-  const headers: Record<string, string> = {};
-  for (const line of raw.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    const eq = trimmed.indexOf("=");
-    if (eq <= 0) throw new Error(`Headers must be KEY=VALUE lines; got "${trimmed}"`);
-    headers[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
-  }
-  return headers;
-}
+  const counts: Record<Category, number> = {
+    sources: available.length,
+    agents: CODING_AGENTS.length,
+    mcp: mcpCount,
+    browser: 1,
+  };
 
-function AddServerForm({ onAdded }: { onAdded: () => void }) {
-  const [name, setName] = useState("");
-  const [transport, setTransport] = useState<"stdio" | "http">("http");
-  const [command, setCommand] = useState("");
-  const [url, setUrl] = useState("");
-  const [headerLines, setHeaderLines] = useState("");
-  const [saving, setSaving] = useState(false);
-
-  async function submit() {
-    setSaving(true);
-    try {
-      const headers = transport === "http" ? parseHeaderLines(headerLines) : {};
-      await createMcpServer({
-        name: name.trim(),
-        transport,
-        ...(transport === "stdio" ? { command: command.trim() } : { url: url.trim(), headers }),
-      });
-      setName("");
-      setCommand("");
-      setUrl("");
-      setHeaderLines("");
-      onAdded();
-    } catch (e) {
-      toast.error(e instanceof ApiError || e instanceof Error ? e.message : "Failed to add server");
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  const targetMissing = transport === "stdio" ? !command.trim() : !url.trim();
-
-  return (
-    <form
-      className="rounded-lg border border-border bg-surface p-4"
-      onSubmit={(e) => {
-        e.preventDefault();
-        void submit();
-      }}
-    >
-      <h2 className="text-sm font-semibold">Add an MCP server</h2>
-      <div className="mt-3 flex flex-col gap-3">
-        <Input
-          aria-label="Server name"
-          placeholder="Name (e.g. linear)"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <div className="flex gap-1 rounded-md bg-muted p-1 self-start" role="radiogroup">
-          {(["http", "stdio"] as const).map((t) => (
-            <button
-              key={t}
-              type="button"
-              role="radio"
-              aria-checked={transport === t}
-              onClick={() => setTransport(t)}
-              className={`rounded px-3 py-1 text-xs font-medium ${
-                transport === t
-                  ? "bg-surface text-foreground shadow-sm"
-                  : "text-muted-foreground"
-              }`}
-            >
-              {t === "http" ? "Remote (HTTP)" : "Local (stdio)"}
-            </button>
-          ))}
-        </div>
-        {transport === "stdio" ? (
-          <Input
-            aria-label="Command"
-            placeholder="Command (e.g. npx -y linear-mcp)"
-            value={command}
-            onChange={(e) => setCommand(e.target.value)}
-          />
-        ) : (
-          <>
-            <Input
-              aria-label="URL"
-              placeholder="URL (e.g. https://mcp.example.com/mcp)"
-              value={url}
-              onChange={(e) => setUrl(e.target.value)}
-            />
-            <Textarea
-              aria-label="Headers"
-              placeholder={"Optional headers, one per line:\nAuthorization=Bearer …"}
-              rows={2}
-              value={headerLines}
-              onChange={(e) => setHeaderLines(e.target.value)}
-            />
-          </>
-        )}
-        <Button type="submit" disabled={saving || !name.trim() || targetMissing} className="self-start">
-          <Plus className="h-4 w-4" />
-          Add server
-        </Button>
-      </div>
-    </form>
-  );
-}
-
-function ServerRow({ server, onRemoved }: { server: McpServer; onRemoved: () => void }) {
-  const [removing, setRemoving] = useState(false);
-
-  async function remove() {
-    setRemoving(true);
-    try {
-      await deleteMcpServer(server.id);
-      onRemoved();
-    } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Failed to remove server");
-      setRemoving(false);
-    }
-  }
-
-  const headerKeys = Object.keys(server.headers);
-  return (
-    <li className="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3">
-      {server.transport === "stdio" ? (
-        <Terminal className="h-4 w-4 shrink-0 text-muted-foreground" />
-      ) : (
-        <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
-      )}
-      <div className="min-w-0 flex-1">
-        <div className="text-sm font-medium">{server.name}</div>
-        <div className="truncate text-xs text-muted-foreground">
-          {server.transport === "stdio" ? server.command : server.url}
-          {headerKeys.length > 0 && `, headers: ${headerKeys.join(", ")}`}
-        </div>
-      </div>
-      <Button variant="ghost" size="sm" onClick={() => void remove()} disabled={removing}>
-        Remove
-      </Button>
-    </li>
-  );
-}
-
-export default function IntegrationsPage() {
-  const router = useRouter();
-  const { user, loading } = useAuth();
-  const [servers, setServers] = useState<McpServer[] | null>(null);
-
-  useBreadcrumbs([{ label: "Integrations" }], "integrations");
-
-  const refresh = useCallback(async () => {
-    try {
-      setServers(await listMcpServers());
-    } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Failed to load MCP servers");
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!loading && !user) router.push("/login");
-  }, [user, loading, router]);
-
-  useEffect(() => {
-    if (user) void refresh();
-  }, [user, refresh]);
-
-  if (loading || !user) return null;
+  const shows = (c: Category) => filter === "all" || filter === c;
 
   return (
     <div className="h-full overflow-y-auto">
       <div className="mx-auto flex max-w-5xl flex-col gap-8 px-8 py-7">
-        <div>
+        <header>
           <h1 className="font-display text-[22px] font-semibold tracking-tight text-foreground">
             Integrations
           </h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Everything your agent can reach — connected sources and MCP servers.
+          <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+            The one place to connect everything to Stash — the accounts your agents read from, the
+            coding agents that read them, the tools they can call, and the browser you save from.
           </p>
+          {statuses && (
+            <p className="mt-2.5 font-mono text-[12px] text-muted-foreground">
+              {connectedCount} of {available.length} sources connected
+              {mcpCount > 0 && ` · ${mcpCount} MCP server${mcpCount === 1 ? "" : "s"}`}
+              {agentNames.length > 0 &&
+                ` · ${agentNames.length} agent${agentNames.length === 1 ? "" : "s"} sending sessions`}
+            </p>
+          )}
+        </header>
+
+        <div className="flex flex-wrap gap-1.5">
+          {(["all", ...CATEGORIES.map((c) => c.key)] as const).map((key) => {
+            const label =
+              key === "all" ? "All" : CATEGORIES.find((c) => c.key === key)!.label;
+            const count =
+              key === "all"
+                ? Object.values(counts).reduce((a, b) => a + b, 0)
+                : counts[key as Category];
+            return (
+              <button
+                key={key}
+                type="button"
+                aria-pressed={filter === key}
+                onClick={() => setFilter(key as Category | "all")}
+                className={cn(
+                  "flex items-center gap-1.5 rounded-full border px-3 py-1 text-[12.5px] font-medium transition-colors",
+                  filter === key
+                    ? "border-brand-500 bg-brand-500/10 text-brand-600"
+                    : "border-border bg-surface text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {label}
+                <span className="font-mono text-[11px] opacity-70">{count}</span>
+              </button>
+            );
+          })}
         </div>
 
-        <section>
-          <h2 className="text-[15px] font-semibold text-foreground">Connected sources</h2>
-          <p className="mt-0.5 text-[13px] text-muted-foreground">
-            Connect accounts and choose what your agent can read. Click one to connect or manage
-            it.
-          </p>
-          <div className="mt-4">
-            <IntegrationsGrid />
+        {loadError && (
+          <div className="rounded-xl border border-border bg-surface px-4 py-6 text-center text-[13px] text-destructive">
+            Couldn&apos;t load integrations: {loadError}
           </div>
-        </section>
+        )}
 
-        <section>
-          <h2 className="text-[15px] font-semibold text-foreground">MCP servers</h2>
-          <p className="mt-0.5 text-[13px] text-muted-foreground">
-            Available to your cloud agent, and installable locally with{" "}
-            <code className="text-xs">stash tools install</code>.
-          </p>
-          <div className="mt-4 flex flex-col gap-3">
-            {servers !== null && servers.length === 0 && (
-              <p className="text-sm text-muted-foreground">No MCP servers yet — add one below.</p>
-            )}
-            {servers !== null && servers.length > 0 && (
-              <ul className="flex flex-col gap-2">
-                {servers.map((s) => (
-                  <ServerRow key={s.id} server={s} onRemoved={() => void refresh()} />
+        {shows("sources") && !loadError && (
+          <Section category={CATEGORIES[0]} count={counts.sources}>
+            {statuses === null ? (
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {Array.from({ length: 6 }, (_, i) => (
+                  <Skeleton key={i} className="h-[124px] rounded-xl" />
                 ))}
-              </ul>
+              </div>
+            ) : (
+              <SourcesGrid
+                connectors={available}
+                statuses={statuses}
+                onConnected={isConnected}
+              />
             )}
-            <AddServerForm onAdded={() => void refresh()} />
-          </div>
-        </section>
+          </Section>
+        )}
+
+        {shows("agents") && (
+          <Section category={CATEGORIES[1]} count={counts.agents}>
+            <CodingAgents agentNames={agentNames} />
+          </Section>
+        )}
+
+        {shows("mcp") && (
+          <Section category={CATEGORIES[2]} count={counts.mcp}>
+            <McpServers onCountChange={setMcpCount} />
+          </Section>
+        )}
+
+        {shows("browser") && (
+          <Section category={CATEGORIES[3]} count={counts.browser}>
+            <Link
+              href="/extension"
+              className="flex items-start gap-3 rounded-xl border border-border bg-surface p-4 transition-colors hover:bg-raised sm:max-w-md"
+            >
+              <Globe className="mt-0.5 h-6 w-6 shrink-0 text-muted-foreground" />
+              <span className="flex flex-col gap-1">
+                <span className="text-[14px] font-medium text-foreground">Stash for Chrome</span>
+                <span className="text-[12.5px] leading-snug text-muted-foreground">
+                  Clip any page or every open tab, import your bookmarks, and keep your X and
+                  Instagram saves in sync.
+                </span>
+              </span>
+            </Link>
+          </Section>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/app/(app)/integrations/page.tsx
+++ b/frontend/src/app/(app)/integrations/page.tsx
@@ -135,7 +135,7 @@ export default function IntegrationsPage() {
   const [agentNames, setAgentNames] = useState<string[]>([]);
   const [servers, setServers] = useState<McpServer[]>([]);
   const [query, setQuery] = useState("");
-  const [direction, setDirection] = useState<Direction | null>(null);
+  const [direction, setDirection] = useState<Direction>("in");
   const [open, setOpen] = useState<Box | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [paywalled, setPaywalled] = useState(false);
@@ -372,18 +372,31 @@ export default function IntegrationsPage() {
     );
   }, [statuses, servers, busy, isConnected, connectNow, removeServer]);
 
-  const visible = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return boxes.filter(
-      (b) =>
-        (direction === null || b.direction === direction) &&
-        (q === "" || b.search.toLowerCase().includes(q)),
-    );
-  }, [boxes, query, direction]);
+  const matchesQuery = useCallback(
+    (b: Box) => {
+      const q = query.trim().toLowerCase();
+      return q === "" || b.search.toLowerCase().includes(q);
+    },
+    [query],
+  );
+
+  const visible = useMemo(
+    () => boxes.filter((b) => b.direction === direction && matchesQuery(b)),
+    [boxes, direction, matchesQuery],
+  );
+
+  // Only one direction is on screen, so a search that matches nothing here but
+  // something in the other half would otherwise read as "no results" when
+  // there are results one click away.
+  const elsewhere = useMemo(
+    () => boxes.filter((b) => b.direction !== direction && matchesQuery(b)).length,
+    [boxes, direction, matchesQuery],
+  );
 
   if (loading || !user) return null;
 
-  const connectedCount = boxes.filter((b) => b.active).length;
+  const inDirection = boxes.filter((b) => b.direction === direction);
+  const connectedCount = inDirection.filter((b) => b.active).length;
 
   return (
     <div className="h-full overflow-y-auto">
@@ -413,7 +426,7 @@ export default function IntegrationsPage() {
               key={d}
               type="button"
               aria-pressed={direction === d}
-              onClick={() => setDirection(direction === d ? null : d)}
+              onClick={() => setDirection(d)}
               className={cn(
                 "rounded-full border px-3 py-1.5 text-[12.5px] font-medium transition-colors",
                 direction === d
@@ -427,7 +440,8 @@ export default function IntegrationsPage() {
             </button>
           ))}
           <span className="ml-auto font-mono text-[11.5px] text-muted-foreground">
-            {visible.length} of {boxes.length} · {connectedCount} connected
+            {visible.length} of {inDirection.length}
+            {connectedCount > 0 && ` · ${connectedCount} connected`}
           </span>
         </div>
 
@@ -457,7 +471,20 @@ export default function IntegrationsPage() {
 
         {statuses !== null && visible.length === 0 && (
           <p className="py-8 text-center text-[13px] text-muted-foreground">
-            Nothing matches “{query}”.
+            Nothing matches “{query}” here.
+            {elsewhere > 0 && (
+              <>
+                {" "}
+                <button
+                  type="button"
+                  onClick={() => setDirection(direction === "in" ? "out" : "in")}
+                  className="font-medium text-brand-600 hover:underline"
+                >
+                  {elsewhere} {elsewhere === 1 ? "match" : "matches"} in{" "}
+                  {direction === "in" ? "Flowing out" : "Flowing in"} →
+                </button>
+              </>
+            )}
           </p>
         )}
       </div>

--- a/frontend/src/components/CopyableCommandBlock.tsx
+++ b/frontend/src/components/CopyableCommandBlock.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 
 const COPIED_RESET_MS = 1500;
 
@@ -9,8 +10,16 @@ const COPIED_RESET_MS = 1500;
 export default function CopyableCommandBlock({ commands }: { commands: string }) {
   const [copied, setCopied] = useState(false);
 
+  // The Clipboard API rejects for reasons the page can't prevent — a denied
+  // permission, an unfocused document, an embedded context. Unhandled, the
+  // button just does nothing and the user has no idea the copy failed.
   async function copy() {
-    await navigator.clipboard.writeText(commands);
+    try {
+      await navigator.clipboard.writeText(commands);
+    } catch {
+      toast.error("Couldn't copy — select the command and copy it manually.");
+      return;
+    }
     setCopied(true);
     setTimeout(() => setCopied(false), COPIED_RESET_MS);
   }

--- a/frontend/src/components/CopyableCommandBlock.tsx
+++ b/frontend/src/components/CopyableCommandBlock.tsx
@@ -16,8 +16,11 @@ export default function CopyableCommandBlock({ commands }: { commands: string })
   }
 
   return (
-    <div className="relative inline-block text-left">
-      <pre className="overflow-x-auto rounded-md border border-border bg-surface px-3 py-2 pr-16 font-mono text-[11.5px] leading-relaxed text-foreground">
+    <div className="relative inline-block max-w-full text-left">
+      {/* Wrap rather than scroll: a scrolling line slides underneath the
+          absolutely-positioned copy button, which reads as broken in a narrow
+          container like a dialog. */}
+      <pre className="whitespace-pre-wrap break-all rounded-md border border-border bg-surface px-3 py-2 pr-16 font-mono text-[11.5px] leading-relaxed text-foreground">
         {commands}
       </pre>
       <button

--- a/frontend/src/components/CopyableCommandBlock.tsx
+++ b/frontend/src/components/CopyableCommandBlock.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { Check, Copy } from "lucide-react";
 import { toast } from "sonner";
 
 const COPIED_RESET_MS = 1500;
@@ -29,15 +30,19 @@ export default function CopyableCommandBlock({ commands }: { commands: string })
       {/* Wrap rather than scroll: a scrolling line slides underneath the
           absolutely-positioned copy button, which reads as broken in a narrow
           container like a dialog. */}
-      <pre className="whitespace-pre-wrap break-all rounded-md border border-border bg-surface px-3 py-2 pr-16 font-mono text-[11.5px] leading-relaxed text-foreground">
+      <pre className="whitespace-pre-wrap break-all rounded-md border border-border bg-surface px-3 py-2.5 pr-10 font-mono text-[11.5px] leading-relaxed text-foreground">
         {commands}
       </pre>
+      {/* Icon-only, so a long command keeps as much width as possible and the
+          block reads as code rather than as a form control. */}
       <button
         type="button"
         onClick={() => void copy()}
-        className="absolute right-1.5 top-1.5 cursor-pointer rounded border border-border bg-base px-1.5 py-0.5 text-[10.5px] font-medium text-muted-foreground hover:text-foreground"
+        aria-label={copied ? "Copied" : "Copy to clipboard"}
+        title={copied ? "Copied" : "Copy"}
+        className="absolute right-1.5 top-1.5 cursor-pointer rounded p-1.5 text-muted-foreground transition-colors hover:bg-raised hover:text-foreground"
       >
-        {copied ? "Copied" : "Copy"}
+        {copied ? <Check className="h-3.5 w-3.5 text-success" /> : <Copy className="h-3.5 w-3.5" />}
       </button>
     </div>
   );

--- a/frontend/src/components/integrations/BrandIcons.tsx
+++ b/frontend/src/components/integrations/BrandIcons.tsx
@@ -2,6 +2,133 @@ type Props = { className?: string; size?: number };
 
 const defaultSize = 18;
 
+export function ClaudeCodeIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" aria-hidden>
+      <path
+        fill="#D97757"
+        fillRule="evenodd"
+        d="M21 10.95h3v3.1h-3v3.03h-1.49V20H18v-2.92h-1.49V20H15v-2.92H9V20H7.49v-2.92H6V20H4.49v-2.92H3v-3.03H0v-3.1h3V5h18v5.95ZM6 10.95h1.49V8.1H6v2.85Zm10.51 0H18V8.1h-1.49v2.85Z"
+      />
+    </svg>
+  );
+}
+
+export function CodexIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" aria-hidden>
+      <defs>
+        <linearGradient id="codex-gradient" x1="12" x2="12" y1="3" y2="21" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#B1A7FF" />
+          <stop offset=".5" stopColor="#7A9DFF" />
+          <stop offset="1" stopColor="#3941FF" />
+        </linearGradient>
+      </defs>
+      <rect width="24" height="24" rx="4.5" fill="white" />
+      <path
+        fill="url(#codex-gradient)"
+        d="M9.06 3.34a4.58 4.58 0 0 1 4.96.97.1.1 0 0 0 .08.02 4.55 4.55 0 0 1 3.05.27 4.58 4.58 0 0 1 2.35 2.48c.21.51.31 1.04.31 1.6 0 .41-.04.82-.13 1.22a.12.12 0 0 0 .03.11 4.48 4.48 0 0 1 1.18 2.17 4.46 4.46 0 0 1-.89 3.86 4.55 4.55 0 0 1-2.33 1.55.12.12 0 0 0-.08.08 4.58 4.58 0 0 1-4.48 3.33 4.55 4.55 0 0 1-3.16-1.3.11.11 0 0 0-.1-.03 4.43 4.43 0 0 1-3.15-.33 4.54 4.54 0 0 1-1.61-1.34 4.69 4.69 0 0 1-.79-1.58 4.58 4.58 0 0 1-.01-2.3.12.12 0 0 0-.02-.1 4.47 4.47 0 0 1-1.04-1.65 4.56 4.56 0 0 1 1.82-5.41c.42-.28.91-.49 1.54-.68a.1.1 0 0 0 .07-.06 4.52 4.52 0 0 1 2.66-2.9Zm3.49 10.57a.64.64 0 0 0 0 1.27h3.63a.64.64 0 1 0 0-1.27h-3.63ZM8.46 9.23a.64.64 0 0 0-1.1.63l1.27 2.23-1.27 2.13a.64.64 0 1 0 1.1.65l1.45-2.46a.64.64 0 0 0 .01-.64L8.46 9.23Z"
+      />
+    </svg>
+  );
+}
+
+export function CursorIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M22.11 5.68 12.5.14a1 1 0 0 0-1 0L1.89 5.68a.84.84 0 0 0-.42.73v11.18c0 .3.16.58.42.73l9.61 5.55a1 1 0 0 0 1 0l9.61-5.55a.84.84 0 0 0 .42-.73V6.41a.84.84 0 0 0-.42-.73Zm-.61 1.18-9.27 16.06c-.06.11-.23.06-.23-.06V12.34a.59.59 0 0 0-.3-.51L2.6 6.57c-.11-.06-.06-.23.06-.23h18.55c.26 0 .43.29.3.52Z" />
+    </svg>
+  );
+}
+
+export function OpenCodeIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M16 6H8v12h8V6Zm4 16H4V2h16v20Z" />
+    </svg>
+  );
+}
+
+export function GeminiCliIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" aria-hidden>
+      <defs>
+        <linearGradient id="gemini-cli-gradient" x1="24" x2="0" y1="6.59" y2="16.49" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#EE4D5D" />
+          <stop offset=".33" stopColor="#B381DD" />
+          <stop offset=".48" stopColor="#207CFE" />
+        </linearGradient>
+      </defs>
+      <rect width="24" height="24" rx="4.39" fill="url(#gemini-cli-gradient)" />
+      <path fill="#1E1E2E" d="m7.24 8.56 7.75 3.73-7.75 3.73v2.8l9.55-4.6v-3.86l-9.55-4.6v2.8Z" />
+    </svg>
+  );
+}
+
+export function OpenClawIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 24 24" aria-hidden>
+      <defs>
+        <linearGradient id="openclaw-gradient" x1="0" x2="24" y1="2" y2="22" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#FF4D4D" />
+          <stop offset="1" stopColor="#991B1B" />
+        </linearGradient>
+      </defs>
+      <path fill="url(#openclaw-gradient)" d="M12 2.57c-6.33 0-9.5 5.27-9.5 9.49s3.17 8.44 6.33 9.5v2.1h2.11v-2.1s1.06.42 2.11 0v2.1h2.11v-2.1c3.17-1.06 6.33-5.28 6.33-9.5S18.33 2.57 12 2.57Z" />
+      <path fill="url(#openclaw-gradient)" d="M3.56 9.95C.4 8.9-.66 11.01.4 13.12c1.05 2.11 3.16 1.05 4.22-1.06.63-1.47 0-2.1-1.06-2.1Zm16.88 0c3.16-1.05 4.22 1.06 3.16 3.17-1.05 2.11-3.16 1.05-4.22-1.06-.63-1.47 0-2.1 1.06-2.1Z" />
+      <path fill="#FF4D4D" d="M5.51 1.88c.47-.29 1.03-.24 1.61.03.58.27 1.22.78 1.94 1.49a.32.32 0 0 1-.45.45 7.14 7.14 0 0 0-1.76-1.36c-.47-.23-.79-.21-1.02-.07a.32.32 0 0 1-.32-.54Zm11.37.03c.58-.27 1.14-.32 1.61-.03a.32.32 0 0 1-.32.54c-.23-.14-.55-.16-1.03.07-.47.22-1.06.67-1.75 1.36a.32.32 0 1 1-.45-.45c.72-.71 1.36-1.22 1.94-1.49Z" />
+      <circle cx="8.84" cy="7.84" r="1.27" fill="#050810" />
+      <circle cx="15.16" cy="7.84" r="1.27" fill="#050810" />
+      <circle cx="9.05" cy="7.63" r=".53" fill="#00E5CC" />
+      <circle cx="15.38" cy="7.63" r=".53" fill="#00E5CC" />
+    </svg>
+  );
+}
+
+export function HermesIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 64 64" aria-hidden>
+      <defs>
+        <linearGradient id="hermes-gold" x1="0" y1="0" x2="0" y2="1">
+          <stop stopColor="#F5C542" />
+          <stop offset="1" stopColor="#D4961C" />
+        </linearGradient>
+      </defs>
+      <rect x="30" y="10" width="4" height="46" rx="2" fill="url(#hermes-gold)" />
+      <path d="M30 18c-6-4-16-4-20 0 4-2 12-2 18 2m2 2c-4-3-12-3-16 0 4-2 10-2 14 2" fill="none" stroke="#F5C542" strokeWidth="3" />
+      <path d="M34 18c6-4 16-4 20 0-4-2-12-2-18 2m-2 2c4-3 12-3 16 0-4-2-10-2-14 2" fill="none" stroke="#D4961C" strokeWidth="3" />
+      <path d="M32 48c-10-4-12-10-6-14-6 2-8 8-2 12-6-6-2-16 6-18M32 48c10-4 12-10 6-14 6 2 8 8 2 12 6-6 2-16-6-18" fill="none" stroke="url(#hermes-gold)" strokeWidth="2.5" strokeLinecap="round" />
+      <circle cx="32" cy="10" r="4" fill="#F5C542" />
+    </svg>
+  );
+}
+
+export function ChromeIcon({ className, size = defaultSize }: Props) {
+  return (
+    <svg className={className} width={size} height={size} viewBox="0 0 48 48" aria-hidden>
+      <defs>
+        <linearGradient id="chrome-red" x1="3.22" y1="15" x2="44.78" y2="15" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#D93025" />
+          <stop offset="1" stopColor="#EA4335" />
+        </linearGradient>
+        <linearGradient id="chrome-yellow" x1="20.72" y1="47.68" x2="41.5" y2="11.68" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#FCC934" />
+          <stop offset="1" stopColor="#FBBC04" />
+        </linearGradient>
+        <linearGradient id="chrome-green" x1="26.6" y1="46.5" x2="5.82" y2="10.51" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#1E8E3E" />
+          <stop offset="1" stopColor="#34A853" />
+        </linearGradient>
+      </defs>
+      <path fill="url(#chrome-red)" d="M24 12h20.78A24 24 0 0 0 3.22 12L13.61 30a12 12 0 0 1 10.4-18Z" />
+      <path fill="url(#chrome-yellow)" d="M34.39 30 24 48a24 24 0 0 0 20.78-36H24a12 12 0 0 1 10.39 18Z" />
+      <path fill="url(#chrome-green)" d="M13.61 30 3.22 12A24 24 0 0 0 24 48l10.39-18a12 12 0 0 1-20.78 0Z" />
+      <circle cx="24" cy="24" r="10.5" fill="white" />
+      <circle cx="24" cy="24" r="9.5" fill="#1A73E8" />
+    </svg>
+  );
+}
+
 export function GitHubIcon({ className, size = defaultSize }: Props) {
   return (
     <svg
@@ -229,16 +356,10 @@ export function InstagramIcon({ className, size = defaultSize }: Props) {
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
+      fill="#FF0069"
       aria-hidden
     >
-      <rect x="2" y="2" width="20" height="20" rx="5" />
-      <circle cx="12" cy="12" r="4" />
-      <circle cx="17.5" cy="6.5" r="0.6" fill="currentColor" />
+      <path d="M7.0301.084c-1.2768.0602-2.1487.264-2.911.5634-.7888.3075-1.4575.72-2.1228 1.3877-.6652.6677-1.075 1.3368-1.3802 2.127-.2954.7638-.4956 1.6365-.552 2.914-.0564 1.2775-.0689 1.6882-.0626 4.947.0062 3.2586.0206 3.6671.0825 4.9473.061 1.2765.264 2.1482.5635 2.9107.308.7889.72 1.4573 1.388 2.1228.6679.6655 1.3365 1.0743 2.1285 1.38.7632.295 1.6361.4961 2.9134.552 1.2773.056 1.6884.069 4.9462.0627 3.2578-.0062 3.668-.0207 4.9478-.0814 1.28-.0607 2.147-.2652 2.9098-.5633.7889-.3086 1.4578-.72 2.1228-1.3881.665-.6682 1.0745-1.3378 1.3795-2.1284.2957-.7632.4966-1.636.552-2.9124.056-1.2809.0692-1.6898.063-4.948-.0063-3.2583-.021-3.6668-.0817-4.9465-.0607-1.2797-.264-2.1487-.5633-2.9117-.3084-.7889-.72-1.4568-1.3876-2.1228C21.2982 1.33 20.628.9208 19.8378.6165 19.074.321 18.2017.1197 16.9244.0645 15.6471.0093 15.236-.005 11.977.0014 8.718.0076 8.31.0215 7.0301.0839m.1402 21.6932c-1.17-.0509-1.8053-.2453-2.2287-.408-.5606-.216-.96-.4771-1.3819-.895-.422-.4178-.6811-.8186-.9-1.378-.1644-.4234-.3624-1.058-.4171-2.228-.0595-1.2645-.072-1.6442-.079-4.848-.007-3.2037.0053-3.583.0607-4.848.05-1.169.2456-1.805.408-2.2282.216-.5613.4762-.96.895-1.3816.4188-.4217.8184-.6814 1.3783-.9003.423-.1651 1.0575-.3614 2.227-.4171 1.2655-.06 1.6447-.072 4.848-.079 3.2033-.007 3.5835.005 4.8495.0608 1.169.0508 1.8053.2445 2.228.408.5608.216.96.4754 1.3816.895.4217.4194.6816.8176.9005 1.3787.1653.4217.3617 1.056.4169 2.2263.0602 1.2655.0739 1.645.0796 4.848.0058 3.203-.0055 3.5834-.061 4.848-.051 1.17-.245 1.8055-.408 2.2294-.216.5604-.4763.96-.8954 1.3814-.419.4215-.8181.6811-1.3783.9-.4224.1649-1.0577.3617-2.2262.4174-1.2656.0595-1.6448.072-4.8493.079-3.2045.007-3.5825-.006-4.848-.0608M16.953 5.5864A1.44 1.44 0 1 0 18.39 4.144a1.44 1.44 0 0 0-1.437 1.4424M5.8385 12.012c.0067 3.4032 2.7706 6.1557 6.173 6.1493 3.4026-.0065 6.157-2.7701 6.1506-6.1733-.0065-3.4032-2.771-6.1565-6.174-6.1498-3.403.0067-6.156 2.771-6.1496 6.1738M8 12.0077a4 4 0 1 1 4.008 3.9921A3.9996 3.9996 0 0 1 8 12.0077" />
     </svg>
   );
 }

--- a/frontend/src/components/integrations/CodingAgents.tsx
+++ b/frontend/src/components/integrations/CodingAgents.tsx
@@ -28,19 +28,63 @@ export const CODING_AGENTS = [
 
 const INSTALL_COMMAND = `bash -c "$(curl -fsSL https://joinstash.ai/install)"`;
 
+const MCP_CLIENT_CONFIG = `{
+  "mcpServers": {
+    "stash": { "command": "stash-mcp" }
+  }
+}`;
+
 type Agent = (typeof CODING_AGENTS)[number];
 
-/** Coding agents connect by running one command, which finds every agent on
- *  the machine and wires its hooks. There is deliberately no per-agent
- *  connected/disconnected state: the uploaded `agent_name` is whatever the
- *  user named their agent, not which harness produced it, so claiming
- *  "Claude Code: connected" would be a guess dressed as a fact. */
-export default function CodingAgents({ agentNames }: { agentNames: string[] }) {
+// A coding agent is two integrations wearing one name — it writes transcripts
+// in and reads the stash back out — so it's listed under each direction with
+// the half that applies. One install command serves both, which is why the
+// dialogs differ in what they explain rather than what they run.
+const COPY = {
+  in: {
+    blurb: "Its sessions land in your stash as transcripts, searchable like anything else.",
+    dialogTitle: (name: string) => `Record ${name} sessions`,
+    dialogDescription: "One command turns on session recording for every coding agent on your machine, this one included.",
+    note: (binary: string) => (
+      <>
+        The installer signs you in, looks for <code className="font-mono text-[11.5px] text-foreground">{binary}</code>{" "}
+        on your PATH, and hooks it so every session it runs is uploaded when it ends.
+      </>
+    ),
+  },
+  out: {
+    blurb: "Give it read access to everything in your stash while it works.",
+    dialogTitle: (name: string) => `Give ${name} access`,
+    dialogDescription: "Two ways in, depending on what the agent speaks.",
+    note: (binary: string) => (
+      <>
+        The installer adds Stash&apos;s commands to{" "}
+        <code className="font-mono text-[11.5px] text-foreground">{binary}</code>&apos;s context, so
+        it can search and read your stash mid-session.
+      </>
+    ),
+  },
+} as const;
+
+/** The coding agents Stash can wire up, one card each. Rendered once per
+ *  direction: under Inputs they're where transcripts come from, under Outputs
+ *  they're something you hand the stash to. There is deliberately no per-agent
+ *  connected state — the uploaded `agent_name` is whatever the user named
+ *  their agent, not which harness produced it, so "Claude Code: connected"
+ *  would be a guess dressed as a fact. */
+export default function CodingAgents({
+  direction,
+  agentNames = [],
+}: {
+  direction: "in" | "out";
+  agentNames?: string[];
+}) {
   const [open, setOpen] = useState<Agent | null>(null);
+  const copy = COPY[direction];
 
   return (
     <div className="flex flex-col gap-3">
-      {agentNames.length > 0 && (
+      {direction === "in" && agentNames.length > 0 && (
         <p className="text-[12.5px] text-muted-foreground">
           Sending sessions now: <span className="text-foreground">{agentNames.join(", ")}</span>
         </p>
@@ -66,8 +110,7 @@ export default function CodingAgents({ agentNames }: { agentNames: string[] }) {
             </div>
 
             <p className="min-h-[34px] text-[12.5px] leading-snug text-muted-foreground">
-              Its transcripts land in your stash, and it reads everything else in there while it
-              works.
+              {copy.blurb}
             </p>
 
             <Button
@@ -85,19 +128,20 @@ export default function CodingAgents({ agentNames }: { agentNames: string[] }) {
       <Dialog open={open !== null} onOpenChange={(v) => !v && setOpen(null)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Connect {open?.name}</DialogTitle>
-            <DialogDescription>
-              One command wires up every coding agent on your machine, this one included.
-            </DialogDescription>
+            <DialogTitle>{open && copy.dialogTitle(open.name)}</DialogTitle>
+            <DialogDescription>{copy.dialogDescription}</DialogDescription>
           </DialogHeader>
           <div className="flex min-w-0 flex-col gap-3">
             <CopyableCommandBlock commands={INSTALL_COMMAND} />
-            <p className="text-[12.5px] text-muted-foreground">
-              The installer signs you in, looks for{" "}
-              <code className="font-mono text-[11.5px] text-foreground">{open?.binary}</code> on your
-              PATH, and turns on session recording for it. Run it again any time you add another
-              agent.
-            </p>
+            <p className="text-[12.5px] text-muted-foreground">{open && copy.note(open.binary)}</p>
+            {direction === "out" && (
+              <>
+                <div className="text-[12px] font-medium text-dim">
+                  Or, if it speaks MCP, point it at the Stash server
+                </div>
+                <CopyableCommandBlock commands={MCP_CLIENT_CONFIG} />
+              </>
+            )}
           </div>
         </DialogContent>
       </Dialog>

--- a/frontend/src/components/integrations/CodingAgents.tsx
+++ b/frontend/src/components/integrations/CodingAgents.tsx
@@ -1,17 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { Bot } from "lucide-react";
-
 import CopyableCommandBlock from "@/components/CopyableCommandBlock";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { MCP_CLIENT_CONFIG } from "@/components/integrations/OutputSurfaces";
 
 // The agents `stash install` wires up — the same list the CLI walks
 // (_SUPPORTED_AGENTS in cli/main.py). Keep the two in step: an agent listed
@@ -26,125 +16,54 @@ export const CODING_AGENTS = [
   { name: "Hermes", binary: "hermes" },
 ];
 
+export type CodingAgent = (typeof CODING_AGENTS)[number];
+
 const INSTALL_COMMAND = `bash -c "$(curl -fsSL https://joinstash.ai/install)"`;
 
-const MCP_CLIENT_CONFIG = `{
-  "mcpServers": {
-    "stash": { "command": "stash-mcp" }
-  }
-}`;
-
-type Agent = (typeof CODING_AGENTS)[number];
-
 // A coding agent is two integrations wearing one name — it writes transcripts
-// in and reads the stash back out — so it's listed under each direction with
-// the half that applies. One install command serves both, which is why the
-// dialogs differ in what they explain rather than what they run.
-const COPY = {
+// in and reads the stash back out — so it gets a box per direction with the
+// half that applies. One install command serves both, which is why the two
+// dialogs differ in what they explain rather than what they run. There is
+// deliberately no per-agent connected state: the uploaded `agent_name` is
+// whatever the user named their agent, not which harness produced it, so
+// "Claude Code: connected" would be a guess dressed as a fact.
+export const AGENT_COPY = {
   in: {
     blurb: "Its sessions land in your stash as transcripts, searchable like anything else.",
-    dialogTitle: (name: string) => `Record ${name} sessions`,
-    dialogDescription: "One command turns on session recording for every coding agent on your machine, this one included.",
-    note: (binary: string) => (
-      <>
-        The installer signs you in, looks for <code className="font-mono text-[11.5px] text-foreground">{binary}</code>{" "}
-        on your PATH, and hooks it so every session it runs is uploaded when it ends.
-      </>
-    ),
+    title: (name: string) => `Record ${name} sessions`,
+    description:
+      "One command turns on session recording for every coding agent on your machine, this one included.",
   },
   out: {
     blurb: "Give it read access to everything in your stash while it works.",
-    dialogTitle: (name: string) => `Give ${name} access`,
-    dialogDescription: "Two ways in, depending on what the agent speaks.",
-    note: (binary: string) => (
-      <>
-        The installer adds Stash&apos;s commands to{" "}
-        <code className="font-mono text-[11.5px] text-foreground">{binary}</code>&apos;s context, so
-        it can search and read your stash mid-session.
-      </>
-    ),
+    title: (name: string) => `Give ${name} access`,
+    description: "Two ways in, depending on what the agent speaks.",
   },
 } as const;
 
-/** The coding agents Stash can wire up, one card each. Rendered once per
- *  direction: under Inputs they're where transcripts come from, under Outputs
- *  they're something you hand the stash to. There is deliberately no per-agent
- *  connected state — the uploaded `agent_name` is whatever the user named
- *  their agent, not which harness produced it, so "Claude Code: connected"
- *  would be a guess dressed as a fact. */
-export default function CodingAgents({
-  direction,
-  agentNames = [],
-}: {
-  direction: "in" | "out";
-  agentNames?: string[];
-}) {
-  const [open, setOpen] = useState<Agent | null>(null);
-  const copy = COPY[direction];
-
+export function agentDialogBody(agent: CodingAgent, direction: "in" | "out") {
   return (
-    <div className="flex flex-col gap-3">
-      {direction === "in" && agentNames.length > 0 && (
+    <div className="flex min-w-0 flex-col gap-3">
+      <CopyableCommandBlock commands={INSTALL_COMMAND} />
+      {direction === "in" ? (
         <p className="text-[12.5px] text-muted-foreground">
-          Sending sessions now: <span className="text-foreground">{agentNames.join(", ")}</span>
+          The installer signs you in, looks for{" "}
+          <code className="font-mono text-[11.5px] text-foreground">{agent.binary}</code> on your
+          PATH, and hooks it so every session it runs is uploaded when it ends.
         </p>
+      ) : (
+        <>
+          <p className="text-[12.5px] text-muted-foreground">
+            The installer adds Stash&apos;s commands to{" "}
+            <code className="font-mono text-[11.5px] text-foreground">{agent.binary}</code>&apos;s
+            context, so it can search and read your stash mid-session.
+          </p>
+          <div className="text-[12px] font-medium text-dim">
+            Or, if it speaks MCP, point it at the Stash server
+          </div>
+          <CopyableCommandBlock commands={MCP_CLIENT_CONFIG} />
+        </>
       )}
-
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {CODING_AGENTS.map((agent) => (
-          <div
-            key={agent.binary}
-            className="flex flex-col gap-2.5 rounded-xl border border-border bg-surface p-4"
-          >
-            <div className="flex items-center gap-2.5">
-              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-raised">
-                <Bot className="h-4 w-4 text-dim" />
-              </span>
-              <button
-                type="button"
-                onClick={() => setOpen(agent)}
-                className="truncate text-left text-[14px] font-medium text-foreground hover:underline"
-              >
-                {agent.name}
-              </button>
-            </div>
-
-            <p className="min-h-[34px] text-[12.5px] leading-snug text-muted-foreground">
-              {copy.blurb}
-            </p>
-
-            <Button
-              size="sm"
-              variant="secondary"
-              className="self-start"
-              onClick={() => setOpen(agent)}
-            >
-              Set up
-            </Button>
-          </div>
-        ))}
-      </div>
-
-      <Dialog open={open !== null} onOpenChange={(v) => !v && setOpen(null)}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{open && copy.dialogTitle(open.name)}</DialogTitle>
-            <DialogDescription>{copy.dialogDescription}</DialogDescription>
-          </DialogHeader>
-          <div className="flex min-w-0 flex-col gap-3">
-            <CopyableCommandBlock commands={INSTALL_COMMAND} />
-            <p className="text-[12.5px] text-muted-foreground">{open && copy.note(open.binary)}</p>
-            {direction === "out" && (
-              <>
-                <div className="text-[12px] font-medium text-dim">
-                  Or, if it speaks MCP, point it at the Stash server
-                </div>
-                <CopyableCommandBlock commands={MCP_CLIENT_CONFIG} />
-              </>
-            )}
-          </div>
-        </DialogContent>
-      </Dialog>
     </div>
   );
 }

--- a/frontend/src/components/integrations/CodingAgents.tsx
+++ b/frontend/src/components/integrations/CodingAgents.tsx
@@ -2,18 +2,27 @@
 
 import CopyableCommandBlock from "@/components/CopyableCommandBlock";
 import { MCP_CLIENT_CONFIG } from "@/components/integrations/OutputSurfaces";
+import {
+  ClaudeCodeIcon,
+  CodexIcon,
+  CursorIcon,
+  GeminiCliIcon,
+  HermesIcon,
+  OpenClawIcon,
+  OpenCodeIcon,
+} from "@/components/integrations/BrandIcons";
 
 // The agents `stash install` wires up — the same list the CLI walks
 // (_SUPPORTED_AGENTS in cli/main.py). Keep the two in step: an agent listed
 // here that the CLI can't wire is a promise the product doesn't keep.
 export const CODING_AGENTS = [
-  { name: "Claude Code", binary: "claude" },
-  { name: "Codex", binary: "codex" },
-  { name: "Cursor", binary: "cursor-agent" },
-  { name: "OpenCode", binary: "opencode" },
-  { name: "Gemini CLI", binary: "gemini" },
-  { name: "OpenClaw", binary: "openclaw" },
-  { name: "Hermes", binary: "hermes" },
+  { name: "Claude Code", binary: "claude", icon: <ClaudeCodeIcon /> },
+  { name: "Codex", binary: "codex", icon: <CodexIcon /> },
+  { name: "Cursor", binary: "cursor-agent", icon: <CursorIcon /> },
+  { name: "OpenCode", binary: "opencode", icon: <OpenCodeIcon /> },
+  { name: "Gemini CLI", binary: "gemini", icon: <GeminiCliIcon /> },
+  { name: "OpenClaw", binary: "openclaw", icon: <OpenClawIcon /> },
+  { name: "Hermes", binary: "hermes", icon: <HermesIcon /> },
 ];
 
 export type CodingAgent = (typeof CODING_AGENTS)[number];

--- a/frontend/src/components/integrations/CodingAgents.tsx
+++ b/frontend/src/components/integrations/CodingAgents.tsx
@@ -39,36 +39,25 @@ const INSTALL_COMMAND = `bash -c "$(curl -fsSL https://joinstash.ai/install)"`;
 export const AGENT_COPY = {
   in: {
     label: (name: string) => `${name} transcripts`,
-    blurb: "Its sessions land in your stash as transcripts, searchable like anything else.",
+    blurb: (name: string) => `Add ${name} transcripts to your Stash.`,
     title: (name: string) => `Record ${name} sessions`,
     description:
       "One command turns on session recording for every coding agent on your machine, this one included.",
   },
   out: {
     label: (name: string) => `${name} access`,
-    blurb: "Give it read access to everything in your stash while it works.",
+    blurb: (name: string) => `Give ${name} read access to your Stash.`,
     title: (name: string) => `Give ${name} access`,
     description: "Two ways in, depending on what the agent speaks.",
   },
 } as const;
 
-export function agentDialogBody(agent: CodingAgent, direction: "in" | "out") {
+export function agentDialogBody(direction: "in" | "out") {
   return (
     <div className="flex min-w-0 flex-col gap-3">
       <CopyableCommandBlock commands={INSTALL_COMMAND} />
-      {direction === "in" ? (
-        <p className="text-[12.5px] text-muted-foreground">
-          The installer signs you in, looks for{" "}
-          <code className="font-mono text-[11.5px] text-foreground">{agent.binary}</code> on your
-          PATH, and hooks it so every session it runs is uploaded when it ends.
-        </p>
-      ) : (
+      {direction === "out" && (
         <>
-          <p className="text-[12.5px] text-muted-foreground">
-            The installer adds Stash&apos;s commands to{" "}
-            <code className="font-mono text-[11.5px] text-foreground">{agent.binary}</code>&apos;s
-            context, so it can search and read your stash mid-session.
-          </p>
           <div className="text-[12px] font-medium text-dim">
             Or, if it speaks MCP, point it at the Stash server
           </div>

--- a/frontend/src/components/integrations/CodingAgents.tsx
+++ b/frontend/src/components/integrations/CodingAgents.tsx
@@ -38,12 +38,14 @@ const INSTALL_COMMAND = `bash -c "$(curl -fsSL https://joinstash.ai/install)"`;
 // "Claude Code: connected" would be a guess dressed as a fact.
 export const AGENT_COPY = {
   in: {
+    label: (name: string) => `${name} transcripts`,
     blurb: "Its sessions land in your stash as transcripts, searchable like anything else.",
     title: (name: string) => `Record ${name} sessions`,
     description:
       "One command turns on session recording for every coding agent on your machine, this one included.",
   },
   out: {
+    label: (name: string) => `${name} access`,
     blurb: "Give it read access to everything in your stash while it works.",
     title: (name: string) => `Give ${name} access`,
     description: "Two ways in, depending on what the agent speaks.",

--- a/frontend/src/components/integrations/CodingAgents.tsx
+++ b/frontend/src/components/integrations/CodingAgents.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import CopyableCommandBlock from "@/components/CopyableCommandBlock";
-import { MCP_CLIENT_CONFIG } from "@/components/integrations/OutputSurfaces";
 import {
   ClaudeCodeIcon,
   CodexIcon,
@@ -48,22 +47,18 @@ export const AGENT_COPY = {
     label: (name: string) => `${name} access`,
     blurb: (name: string) => `Give ${name} read access to your Stash.`,
     title: (name: string) => `Give ${name} access`,
-    description: "Two ways in, depending on what the agent speaks.",
+    description:
+      "One command gives every coding agent on your machine read access, this one included.",
   },
 } as const;
 
-export function agentDialogBody(direction: "in" | "out") {
+/** One command, both directions. The MCP route to a stash is its own box
+ *  under Outputs — repeating it inside every agent dialog turned one answer
+ *  into a choice the user has no basis to make. */
+export function agentDialogBody() {
   return (
     <div className="flex min-w-0 flex-col gap-3">
       <CopyableCommandBlock commands={INSTALL_COMMAND} />
-      {direction === "out" && (
-        <>
-          <div className="text-[12px] font-medium text-dim">
-            Or, if it speaks MCP, point it at the Stash server
-          </div>
-          <CopyableCommandBlock commands={MCP_CLIENT_CONFIG} />
-        </>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/integrations/CodingAgents.tsx
+++ b/frontend/src/components/integrations/CodingAgents.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import CopyableCommandBlock from "@/components/CopyableCommandBlock";
+
+// The agents `stash install` wires up — the same list the CLI walks
+// (_SUPPORTED_AGENTS in cli/main.py). Keep the two in step: an agent listed
+// here that the CLI can't wire is a promise the product doesn't keep.
+export const CODING_AGENTS = [
+  { name: "Claude Code", binary: "claude" },
+  { name: "Codex", binary: "codex" },
+  { name: "Cursor", binary: "cursor-agent" },
+  { name: "OpenCode", binary: "opencode" },
+  { name: "Gemini CLI", binary: "gemini" },
+  { name: "OpenClaw", binary: "openclaw" },
+  { name: "Hermes", binary: "hermes" },
+];
+
+const INSTALL_COMMAND = `bash -c "$(curl -fsSL https://joinstash.ai/install)"`;
+
+/** Coding agents connect by running one command, which finds every agent on
+ *  the machine and wires its hooks. There is deliberately no per-agent
+ *  connected/disconnected state: the uploaded `agent_name` is whatever the
+ *  user named their agent, not which harness produced it, so claiming
+ *  "Claude Code: connected" would be a guess dressed as a fact. */
+export default function CodingAgents({ agentNames }: { agentNames: string[] }) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="rounded-xl border border-border bg-surface p-5">
+        <h3 className="text-[14px] font-semibold text-foreground">
+          One command wires up every agent on your machine
+        </h3>
+        <p className="mt-1 max-w-2xl text-[13px] text-muted-foreground">
+          The installer signs you in, finds the coding agents you already have, and turns on
+          session recording. From then on their transcripts land in your stash, and they can read
+          everything else in it.
+        </p>
+        <div className="mt-3">
+          <CopyableCommandBlock commands={INSTALL_COMMAND} />
+        </div>
+        {agentNames.length > 0 && (
+          <p className="mt-3 text-[12.5px] text-muted-foreground">
+            Sending sessions now:{" "}
+            <span className="text-foreground">{agentNames.join(", ")}</span>
+          </p>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+        {CODING_AGENTS.map((agent) => (
+          <div
+            key={agent.binary}
+            className="flex flex-col gap-1 rounded-xl border border-border bg-surface px-4 py-3.5"
+          >
+            <div className="text-[13.5px] font-medium text-foreground">{agent.name}</div>
+            <code className="font-mono text-[11.5px] text-muted-foreground">{agent.binary}</code>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/integrations/CodingAgents.tsx
+++ b/frontend/src/components/integrations/CodingAgents.tsx
@@ -1,6 +1,17 @@
 "use client";
 
+import { useState } from "react";
+import { Bot } from "lucide-react";
+
 import CopyableCommandBlock from "@/components/CopyableCommandBlock";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 // The agents `stash install` wires up — the same list the CLI walks
 // (_SUPPORTED_AGENTS in cli/main.py). Keep the two in step: an agent listed
@@ -17,45 +28,79 @@ export const CODING_AGENTS = [
 
 const INSTALL_COMMAND = `bash -c "$(curl -fsSL https://joinstash.ai/install)"`;
 
+type Agent = (typeof CODING_AGENTS)[number];
+
 /** Coding agents connect by running one command, which finds every agent on
  *  the machine and wires its hooks. There is deliberately no per-agent
  *  connected/disconnected state: the uploaded `agent_name` is whatever the
  *  user named their agent, not which harness produced it, so claiming
  *  "Claude Code: connected" would be a guess dressed as a fact. */
 export default function CodingAgents({ agentNames }: { agentNames: string[] }) {
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="rounded-xl border border-border bg-surface p-5">
-        <h3 className="text-[14px] font-semibold text-foreground">
-          One command wires up every agent on your machine
-        </h3>
-        <p className="mt-1 max-w-2xl text-[13px] text-muted-foreground">
-          The installer signs you in, finds the coding agents you already have, and turns on
-          session recording. From then on their transcripts land in your stash, and they can read
-          everything else in it.
-        </p>
-        <div className="mt-3">
-          <CopyableCommandBlock commands={INSTALL_COMMAND} />
-        </div>
-        {agentNames.length > 0 && (
-          <p className="mt-3 text-[12.5px] text-muted-foreground">
-            Sending sessions now:{" "}
-            <span className="text-foreground">{agentNames.join(", ")}</span>
-          </p>
-        )}
-      </div>
+  const [open, setOpen] = useState<Agent | null>(null);
 
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+  return (
+    <div className="flex flex-col gap-3">
+      {agentNames.length > 0 && (
+        <p className="text-[12.5px] text-muted-foreground">
+          Sending sessions now: <span className="text-foreground">{agentNames.join(", ")}</span>
+        </p>
+      )}
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {CODING_AGENTS.map((agent) => (
           <div
             key={agent.binary}
-            className="flex flex-col gap-1 rounded-xl border border-border bg-surface px-4 py-3.5"
+            className="flex flex-col gap-2.5 rounded-xl border border-border bg-surface p-4"
           >
-            <div className="text-[13.5px] font-medium text-foreground">{agent.name}</div>
-            <code className="font-mono text-[11.5px] text-muted-foreground">{agent.binary}</code>
+            <div className="flex items-center gap-2.5">
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-raised">
+                <Bot className="h-4 w-4 text-dim" />
+              </span>
+              <button
+                type="button"
+                onClick={() => setOpen(agent)}
+                className="truncate text-left text-[14px] font-medium text-foreground hover:underline"
+              >
+                {agent.name}
+              </button>
+            </div>
+
+            <p className="min-h-[34px] text-[12.5px] leading-snug text-muted-foreground">
+              Its transcripts land in your stash, and it reads everything else in there while it
+              works.
+            </p>
+
+            <Button
+              size="sm"
+              variant="secondary"
+              className="self-start"
+              onClick={() => setOpen(agent)}
+            >
+              Set up
+            </Button>
           </div>
         ))}
       </div>
+
+      <Dialog open={open !== null} onOpenChange={(v) => !v && setOpen(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Connect {open?.name}</DialogTitle>
+            <DialogDescription>
+              One command wires up every coding agent on your machine, this one included.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex min-w-0 flex-col gap-3">
+            <CopyableCommandBlock commands={INSTALL_COMMAND} />
+            <p className="text-[12.5px] text-muted-foreground">
+              The installer signs you in, looks for{" "}
+              <code className="font-mono text-[11.5px] text-foreground">{open?.binary}</code> on your
+              PATH, and turns on session recording for it. Run it again any time you add another
+              agent.
+            </p>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/src/components/integrations/McpServers.tsx
+++ b/frontend/src/components/integrations/McpServers.tsx
@@ -43,7 +43,7 @@ export default function AddServerForm({ onAdded }: { onAdded: () => void }) {
       });
       onAdded();
     } catch (e) {
-      toast.error(e instanceof ApiError || e instanceof Error ? e.message : "Failed to add server");
+      toast.error(e instanceof ApiError || e instanceof Error ? e.message : "Failed to connect the server");
     } finally {
       setSaving(false);
     }
@@ -107,7 +107,7 @@ export default function AddServerForm({ onAdded }: { onAdded: () => void }) {
       )}
       <Button type="submit" disabled={saving || !name.trim() || targetMissing} className="self-start">
         <Plus className="h-4 w-4" />
-        Add server
+        Connect server
       </Button>
     </form>
   );

--- a/frontend/src/components/integrations/McpServers.tsx
+++ b/frontend/src/components/integrations/McpServers.tsx
@@ -1,26 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { Globe, Plus, SquareTerminal } from "lucide-react";
+import { useState } from "react";
+import { Plus } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
-  ApiError,
-  createMcpServer,
-  deleteMcpServer,
-  listMcpServers,
-  type McpServer,
-} from "@/lib/api";
+import { ApiError, createMcpServer } from "@/lib/api";
 
 // One "KEY=VALUE" line per header, parsed at submit time.
 function parseHeaderLines(raw: string): Record<string, string> {
@@ -35,7 +22,9 @@ function parseHeaderLines(raw: string): Record<string, string> {
   return headers;
 }
 
-function AddServerForm({ onAdded }: { onAdded: () => void }) {
+/** The add-a-server form, shown in the dialog behind the "Custom MCP server"
+ *  box. Registering one hands it to your cloud agent before every turn. */
+export default function AddServerForm({ onAdded }: { onAdded: () => void }) {
   const [name, setName] = useState("");
   const [transport, setTransport] = useState<"stdio" | "http">("http");
   const [command, setCommand] = useState("");
@@ -121,108 +110,5 @@ function AddServerForm({ onAdded }: { onAdded: () => void }) {
         Add server
       </Button>
     </form>
-  );
-}
-
-/** A registered server, in the same card shape as every other integration. */
-function ServerCard({ server, onRemoved }: { server: McpServer; onRemoved: () => void }) {
-  const [removing, setRemoving] = useState(false);
-  const Icon = server.transport === "stdio" ? SquareTerminal : Globe;
-  const headerKeys = Object.keys(server.headers);
-
-  async function remove() {
-    setRemoving(true);
-    try {
-      await deleteMcpServer(server.id);
-      onRemoved();
-    } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Failed to remove server");
-      setRemoving(false);
-    }
-  }
-
-  return (
-    <div className="flex flex-col gap-2.5 rounded-xl border border-border bg-surface p-4">
-      <div className="flex items-center gap-2.5">
-        <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-raised">
-          <Icon className="h-4 w-4 text-dim" />
-        </span>
-        <span className="truncate text-[14px] font-medium text-foreground">{server.name}</span>
-      </div>
-
-      <p className="min-h-[34px] break-all font-mono text-[11.5px] leading-snug text-muted-foreground">
-        {server.transport === "stdio" ? server.command : server.url}
-        {headerKeys.length > 0 && ` · headers: ${headerKeys.join(", ")}`}
-      </p>
-
-      <Button
-        variant="ghost"
-        size="sm"
-        className="self-start px-2"
-        onClick={() => void remove()}
-        disabled={removing}
-      >
-        {removing ? "Removing…" : "Remove"}
-      </Button>
-    </div>
-  );
-}
-
-/** The MCP-server registry: servers your cloud agent can call. Cards like
- *  everything else on the page, including the one that adds a new one — the
- *  form lives in its dialog rather than sitting open at the bottom of a grid. */
-export default function McpServers({ onCountChange }: { onCountChange: (n: number) => void }) {
-  const [servers, setServers] = useState<McpServer[] | null>(null);
-  const [adding, setAdding] = useState(false);
-
-  const refresh = useCallback(async () => {
-    try {
-      const rows = await listMcpServers();
-      setServers(rows);
-      onCountChange(rows.length);
-    } catch (e) {
-      toast.error(e instanceof ApiError ? e.message : "Failed to load MCP servers");
-    }
-  }, [onCountChange]);
-
-  useEffect(() => {
-    void refresh();
-  }, [refresh]);
-
-  return (
-    <>
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {servers?.map((s) => (
-          <ServerCard key={s.id} server={s} onRemoved={() => void refresh()} />
-        ))}
-
-        <button
-          type="button"
-          onClick={() => setAdding(true)}
-          className="flex min-h-[124px] flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-border bg-surface/50 p-4 text-muted-foreground transition-colors hover:border-brand-300 hover:text-foreground"
-        >
-          <Plus className="h-5 w-5" />
-          <span className="text-[13px] font-medium">Add a custom server</span>
-        </button>
-      </div>
-
-      <Dialog open={adding} onOpenChange={setAdding}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Add an MCP server</DialogTitle>
-            <DialogDescription>
-              Your cloud agent gets it before every turn, alongside the tools Stash gives it
-              natively.
-            </DialogDescription>
-          </DialogHeader>
-          <AddServerForm
-            onAdded={() => {
-              setAdding(false);
-              void refresh();
-            }}
-          />
-        </DialogContent>
-      </Dialog>
-    </>
   );
 }

--- a/frontend/src/components/integrations/McpServers.tsx
+++ b/frontend/src/components/integrations/McpServers.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Globe, Plus, Terminal } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  ApiError,
+  createMcpServer,
+  deleteMcpServer,
+  listMcpServers,
+  type McpServer,
+} from "@/lib/api";
+
+// One "KEY=VALUE" line per header, parsed at submit time.
+function parseHeaderLines(raw: string): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) throw new Error(`Headers must be KEY=VALUE lines; got "${trimmed}"`);
+    headers[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+  }
+  return headers;
+}
+
+function AddServerForm({ onAdded }: { onAdded: () => void }) {
+  const [name, setName] = useState("");
+  const [transport, setTransport] = useState<"stdio" | "http">("http");
+  const [command, setCommand] = useState("");
+  const [url, setUrl] = useState("");
+  const [headerLines, setHeaderLines] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  async function submit() {
+    setSaving(true);
+    try {
+      const headers = transport === "http" ? parseHeaderLines(headerLines) : {};
+      await createMcpServer({
+        name: name.trim(),
+        transport,
+        ...(transport === "stdio" ? { command: command.trim() } : { url: url.trim(), headers }),
+      });
+      setName("");
+      setCommand("");
+      setUrl("");
+      setHeaderLines("");
+      onAdded();
+    } catch (e) {
+      toast.error(e instanceof ApiError || e instanceof Error ? e.message : "Failed to add server");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const targetMissing = transport === "stdio" ? !command.trim() : !url.trim();
+
+  return (
+    <form
+      className="rounded-lg border border-border bg-surface p-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        void submit();
+      }}
+    >
+      <h2 className="text-sm font-semibold">Add an MCP server</h2>
+      <div className="mt-3 flex flex-col gap-3">
+        <Input
+          aria-label="Server name"
+          placeholder="Name (e.g. linear)"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <div className="flex gap-1 rounded-md bg-muted p-1 self-start" role="radiogroup">
+          {(["http", "stdio"] as const).map((t) => (
+            <button
+              key={t}
+              type="button"
+              role="radio"
+              aria-checked={transport === t}
+              onClick={() => setTransport(t)}
+              className={`rounded px-3 py-1 text-xs font-medium ${
+                transport === t
+                  ? "bg-surface text-foreground shadow-sm"
+                  : "text-muted-foreground"
+              }`}
+            >
+              {t === "http" ? "Remote (HTTP)" : "Local (stdio)"}
+            </button>
+          ))}
+        </div>
+        {transport === "stdio" ? (
+          <Input
+            aria-label="Command"
+            placeholder="Command (e.g. npx -y linear-mcp)"
+            value={command}
+            onChange={(e) => setCommand(e.target.value)}
+          />
+        ) : (
+          <>
+            <Input
+              aria-label="URL"
+              placeholder="URL (e.g. https://mcp.example.com/mcp)"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+            />
+            <Textarea
+              aria-label="Headers"
+              placeholder={"Optional headers, one per line:\nAuthorization=Bearer …"}
+              rows={2}
+              value={headerLines}
+              onChange={(e) => setHeaderLines(e.target.value)}
+            />
+          </>
+        )}
+        <Button type="submit" disabled={saving || !name.trim() || targetMissing} className="self-start">
+          <Plus className="h-4 w-4" />
+          Add server
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function ServerRow({ server, onRemoved }: { server: McpServer; onRemoved: () => void }) {
+  const [removing, setRemoving] = useState(false);
+
+  async function remove() {
+    setRemoving(true);
+    try {
+      await deleteMcpServer(server.id);
+      onRemoved();
+    } catch (e) {
+      toast.error(e instanceof ApiError ? e.message : "Failed to remove server");
+      setRemoving(false);
+    }
+  }
+
+  const headerKeys = Object.keys(server.headers);
+  return (
+    <li className="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3">
+      {server.transport === "stdio" ? (
+        <Terminal className="h-4 w-4 shrink-0 text-muted-foreground" />
+      ) : (
+        <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium">{server.name}</div>
+        <div className="truncate text-xs text-muted-foreground">
+          {server.transport === "stdio" ? server.command : server.url}
+          {headerKeys.length > 0 && `, headers: ${headerKeys.join(", ")}`}
+        </div>
+      </div>
+      <Button variant="ghost" size="sm" onClick={() => void remove()} disabled={removing}>
+        Remove
+      </Button>
+    </li>
+  );
+}
+
+/** The MCP-server registry: servers your cloud agent can call, and the form
+ *  that adds one. Owns its own loading so the Integrations page doesn't have
+ *  to thread the list through. */
+export default function McpServers({ onCountChange }: { onCountChange: (n: number) => void }) {
+  const [servers, setServers] = useState<McpServer[] | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const rows = await listMcpServers();
+      setServers(rows);
+      onCountChange(rows.length);
+    } catch (e) {
+      toast.error(e instanceof ApiError ? e.message : "Failed to load MCP servers");
+    }
+  }, [onCountChange]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      {servers !== null && servers.length === 0 && (
+        <p className="text-[13px] text-muted-foreground">
+          No MCP servers yet — add one below.
+        </p>
+      )}
+      {servers !== null && servers.length > 0 && (
+        <ul className="flex flex-col gap-2">
+          {servers.map((s) => (
+            <ServerRow key={s.id} server={s} onRemoved={() => void refresh()} />
+          ))}
+        </ul>
+      )}
+      <AddServerForm onAdded={() => void refresh()} />
+    </div>
+  );
+}

--- a/frontend/src/components/integrations/McpServers.tsx
+++ b/frontend/src/components/integrations/McpServers.tsx
@@ -1,12 +1,19 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Globe, Plus, Terminal } from "lucide-react";
+import { Globe, Plus, SquareTerminal } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   ApiError,
   createMcpServer,
@@ -45,10 +52,6 @@ function AddServerForm({ onAdded }: { onAdded: () => void }) {
         transport,
         ...(transport === "stdio" ? { command: command.trim() } : { url: url.trim(), headers }),
       });
-      setName("");
-      setCommand("");
-      setUrl("");
-      setHeaderLines("");
       onAdded();
     } catch (e) {
       toast.error(e instanceof ApiError || e instanceof Error ? e.message : "Failed to add server");
@@ -61,73 +64,71 @@ function AddServerForm({ onAdded }: { onAdded: () => void }) {
 
   return (
     <form
-      className="rounded-lg border border-border bg-surface p-4"
+      className="flex min-w-0 flex-col gap-3"
       onSubmit={(e) => {
         e.preventDefault();
         void submit();
       }}
     >
-      <h2 className="text-sm font-semibold">Add an MCP server</h2>
-      <div className="mt-3 flex flex-col gap-3">
-        <Input
-          aria-label="Server name"
-          placeholder="Name (e.g. linear)"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <div className="flex gap-1 rounded-md bg-muted p-1 self-start" role="radiogroup">
-          {(["http", "stdio"] as const).map((t) => (
-            <button
-              key={t}
-              type="button"
-              role="radio"
-              aria-checked={transport === t}
-              onClick={() => setTransport(t)}
-              className={`rounded px-3 py-1 text-xs font-medium ${
-                transport === t
-                  ? "bg-surface text-foreground shadow-sm"
-                  : "text-muted-foreground"
-              }`}
-            >
-              {t === "http" ? "Remote (HTTP)" : "Local (stdio)"}
-            </button>
-          ))}
-        </div>
-        {transport === "stdio" ? (
-          <Input
-            aria-label="Command"
-            placeholder="Command (e.g. npx -y linear-mcp)"
-            value={command}
-            onChange={(e) => setCommand(e.target.value)}
-          />
-        ) : (
-          <>
-            <Input
-              aria-label="URL"
-              placeholder="URL (e.g. https://mcp.example.com/mcp)"
-              value={url}
-              onChange={(e) => setUrl(e.target.value)}
-            />
-            <Textarea
-              aria-label="Headers"
-              placeholder={"Optional headers, one per line:\nAuthorization=Bearer …"}
-              rows={2}
-              value={headerLines}
-              onChange={(e) => setHeaderLines(e.target.value)}
-            />
-          </>
-        )}
-        <Button type="submit" disabled={saving || !name.trim() || targetMissing} className="self-start">
-          <Plus className="h-4 w-4" />
-          Add server
-        </Button>
+      <Input
+        aria-label="Server name"
+        placeholder="Name (e.g. linear)"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <div className="flex gap-1 self-start rounded-md bg-muted p-1" role="radiogroup">
+        {(["http", "stdio"] as const).map((t) => (
+          <button
+            key={t}
+            type="button"
+            role="radio"
+            aria-checked={transport === t}
+            onClick={() => setTransport(t)}
+            className={`rounded px-3 py-1 text-xs font-medium ${
+              transport === t ? "bg-surface text-foreground shadow-sm" : "text-muted-foreground"
+            }`}
+          >
+            {t === "http" ? "Remote (HTTP)" : "Local (stdio)"}
+          </button>
+        ))}
       </div>
+      {transport === "stdio" ? (
+        <Input
+          aria-label="Command"
+          placeholder="Command (e.g. npx -y linear-mcp)"
+          value={command}
+          onChange={(e) => setCommand(e.target.value)}
+        />
+      ) : (
+        <>
+          <Input
+            aria-label="URL"
+            placeholder="URL (e.g. https://mcp.example.com/mcp)"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+          />
+          <Textarea
+            aria-label="Headers"
+            placeholder={"Optional headers, one per line:\nAuthorization=Bearer …"}
+            rows={2}
+            value={headerLines}
+            onChange={(e) => setHeaderLines(e.target.value)}
+          />
+        </>
+      )}
+      <Button type="submit" disabled={saving || !name.trim() || targetMissing} className="self-start">
+        <Plus className="h-4 w-4" />
+        Add server
+      </Button>
     </form>
   );
 }
 
-function ServerRow({ server, onRemoved }: { server: McpServer; onRemoved: () => void }) {
+/** A registered server, in the same card shape as every other integration. */
+function ServerCard({ server, onRemoved }: { server: McpServer; onRemoved: () => void }) {
   const [removing, setRemoving] = useState(false);
+  const Icon = server.transport === "stdio" ? SquareTerminal : Globe;
+  const headerKeys = Object.keys(server.headers);
 
   async function remove() {
     setRemoving(true);
@@ -140,33 +141,39 @@ function ServerRow({ server, onRemoved }: { server: McpServer; onRemoved: () => 
     }
   }
 
-  const headerKeys = Object.keys(server.headers);
   return (
-    <li className="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3">
-      {server.transport === "stdio" ? (
-        <Terminal className="h-4 w-4 shrink-0 text-muted-foreground" />
-      ) : (
-        <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
-      )}
-      <div className="min-w-0 flex-1">
-        <div className="text-sm font-medium">{server.name}</div>
-        <div className="truncate text-xs text-muted-foreground">
-          {server.transport === "stdio" ? server.command : server.url}
-          {headerKeys.length > 0 && `, headers: ${headerKeys.join(", ")}`}
-        </div>
+    <div className="flex flex-col gap-2.5 rounded-xl border border-border bg-surface p-4">
+      <div className="flex items-center gap-2.5">
+        <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-raised">
+          <Icon className="h-4 w-4 text-dim" />
+        </span>
+        <span className="truncate text-[14px] font-medium text-foreground">{server.name}</span>
       </div>
-      <Button variant="ghost" size="sm" onClick={() => void remove()} disabled={removing}>
-        Remove
+
+      <p className="min-h-[34px] break-all font-mono text-[11.5px] leading-snug text-muted-foreground">
+        {server.transport === "stdio" ? server.command : server.url}
+        {headerKeys.length > 0 && ` · headers: ${headerKeys.join(", ")}`}
+      </p>
+
+      <Button
+        variant="ghost"
+        size="sm"
+        className="self-start px-2"
+        onClick={() => void remove()}
+        disabled={removing}
+      >
+        {removing ? "Removing…" : "Remove"}
       </Button>
-    </li>
+    </div>
   );
 }
 
-/** The MCP-server registry: servers your cloud agent can call, and the form
- *  that adds one. Owns its own loading so the Integrations page doesn't have
- *  to thread the list through. */
+/** The MCP-server registry: servers your cloud agent can call. Cards like
+ *  everything else on the page, including the one that adds a new one — the
+ *  form lives in its dialog rather than sitting open at the bottom of a grid. */
 export default function McpServers({ onCountChange }: { onCountChange: (n: number) => void }) {
   const [servers, setServers] = useState<McpServer[] | null>(null);
+  const [adding, setAdding] = useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -183,20 +190,39 @@ export default function McpServers({ onCountChange }: { onCountChange: (n: numbe
   }, [refresh]);
 
   return (
-    <div className="flex flex-col gap-3">
-      {servers !== null && servers.length === 0 && (
-        <p className="text-[13px] text-muted-foreground">
-          No MCP servers yet — add one below.
-        </p>
-      )}
-      {servers !== null && servers.length > 0 && (
-        <ul className="flex flex-col gap-2">
-          {servers.map((s) => (
-            <ServerRow key={s.id} server={s} onRemoved={() => void refresh()} />
-          ))}
-        </ul>
-      )}
-      <AddServerForm onAdded={() => void refresh()} />
-    </div>
+    <>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {servers?.map((s) => (
+          <ServerCard key={s.id} server={s} onRemoved={() => void refresh()} />
+        ))}
+
+        <button
+          type="button"
+          onClick={() => setAdding(true)}
+          className="flex min-h-[124px] flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-border bg-surface/50 p-4 text-muted-foreground transition-colors hover:border-brand-300 hover:text-foreground"
+        >
+          <Plus className="h-5 w-5" />
+          <span className="text-[13px] font-medium">Add a custom server</span>
+        </button>
+      </div>
+
+      <Dialog open={adding} onOpenChange={setAdding}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add an MCP server</DialogTitle>
+            <DialogDescription>
+              Your cloud agent gets it before every turn, alongside the tools Stash gives it
+              natively.
+            </DialogDescription>
+          </DialogHeader>
+          <AddServerForm
+            onAdded={() => {
+              setAdding(false);
+              void refresh();
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/frontend/src/components/integrations/OutputSurfaces.tsx
+++ b/frontend/src/components/integrations/OutputSurfaces.tsx
@@ -5,96 +5,28 @@ import { useEffect, useState, type ReactNode } from "react";
 import { Braces, SquareTerminal, Waypoints } from "lucide-react";
 
 import CopyableCommandBlock from "@/components/CopyableCommandBlock";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 
 // `stash-mcp` is a console script (pyproject.toml: stash-mcp =
 // "cli.mcp_server:main"), speaking stdio and reading the CLI's stored config —
 // so a client needs no key of its own, only a machine where `stash signin` has
 // run. Deliberately no tool count anywhere here: it drifts every time
 // cli/mcp_server.py gains a tool, and a stale number is worse than no number.
-const MCP_CLIENT_CONFIG = `{
+export const MCP_CLIENT_CONFIG = `{
   "mcpServers": {
     "stash": { "command": "stash-mcp" }
   }
 }`;
 
-const CLI_SETUP = `uv tool install stashai\nstash signin`;
+export const CLI_SETUP = `uv tool install stashai\nstash signin`;
 
 const CLI_USAGE = `stash search "org isolation"\nstash vfs "ls /"\nstash vfs "cat '/files/spec.md'"`;
 
-type Surface = {
-  key: string;
-  label: string;
-  icon: typeof Waypoints;
-  blurb: string;
-  /** What the dialog shows once you pick this way out. */
-  steps: ReactNode;
-};
-
-function Step({ n, children }: { n: number; children: ReactNode }) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <div className="text-[12px] font-medium text-dim">
-        {n}. {children}
-      </div>
-    </div>
-  );
+export function Step({ n, children }: { n: number; children: ReactNode }) {
+  return <div className="text-[12px] font-medium text-dim">{n}. {children}</div>;
 }
 
-export const OUTPUT_SURFACES: Surface[] = [
-  {
-    key: "mcp",
-    label: "MCP server",
-    icon: Waypoints,
-    blurb: "Point any MCP client at your stash — Claude Desktop, Cursor, anything that speaks MCP.",
-    steps: (
-      <div className="flex min-w-0 flex-col gap-3">
-        <Step n={1}>Install the CLI and sign in</Step>
-        <CopyableCommandBlock commands={CLI_SETUP} />
-        <Step n={2}>Add it to your client&apos;s MCP config</Step>
-        <CopyableCommandBlock commands={MCP_CLIENT_CONFIG} />
-        <p className="text-[12.5px] text-muted-foreground">
-          The server reads the CLI&apos;s stored credentials, so the client needs no key of its own.
-          It exposes search, the VFS, your sources, sessions, and the Memory wiki as tools.
-        </p>
-      </div>
-    ),
-  },
-  {
-    key: "cli",
-    label: "CLI",
-    icon: SquareTerminal,
-    blurb: "Read and write your stash from any terminal or script — the same commands your agents use.",
-    steps: (
-      <div className="flex min-w-0 flex-col gap-3">
-        <Step n={1}>Install and sign in</Step>
-        <CopyableCommandBlock commands={CLI_SETUP} />
-        <Step n={2}>Read anything</Step>
-        <CopyableCommandBlock commands={CLI_USAGE} />
-        <p className="text-[12.5px] text-muted-foreground">
-          <code className="font-mono">stash --help</code> lists the rest.
-        </p>
-      </div>
-    ),
-  },
-  {
-    key: "api",
-    label: "HTTP API",
-    icon: Braces,
-    blurb: "Everything the app can do, over HTTP, authenticated with an API key.",
-    steps: null,
-  },
-];
-
-/** The API card's steps depend on where the app is served from, so they're
- *  built at render rather than baked into the constant above. */
+/** The API steps depend on where the app is served from, so they're a
+ *  component rather than a constant. */
 function ApiSteps() {
   // The app proxies /api/v1 to the backend, so its own origin is the correct
   // base for every deployment — hardcoding api.joinstash.ai would hand
@@ -116,57 +48,61 @@ function ApiSteps() {
   );
 }
 
-/** One way out, as a card that matches the source cards on the inputs side.
- *  The setup lives behind the click instead of unfurled on the page — the
- *  inputs side doesn't print an OAuth flow inline either. */
-function SurfaceCard({ surface, onOpen }: { surface: Surface; onOpen: () => void }) {
-  const Icon = surface.icon;
-  return (
-    <div className="flex flex-col gap-2.5 rounded-xl border border-border bg-surface p-4">
-      <div className="flex items-center gap-2.5">
-        <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-raised">
-          <Icon className="h-4 w-4 text-dim" />
-        </span>
-        <button
-          type="button"
-          onClick={onOpen}
-          className="truncate text-left text-[14px] font-medium text-foreground hover:underline"
-        >
-          {surface.label}
-        </button>
+export type OutputSurface = {
+  key: string;
+  name: string;
+  icon: typeof Waypoints;
+  blurb: string;
+  keywords: string;
+  body: ReactNode;
+};
+
+/** The ways an agent or a script reads a stash. Each is one box on the
+ *  Integrations grid; the setup lives in its dialog. */
+export const OUTPUT_SURFACES: OutputSurface[] = [
+  {
+    key: "mcp",
+    name: "MCP server",
+    icon: Waypoints,
+    blurb: "Point any MCP client at your stash — Claude Desktop, Cursor, anything that speaks MCP.",
+    keywords: "mcp model context protocol claude desktop cursor stash-mcp",
+    body: (
+      <div className="flex min-w-0 flex-col gap-3">
+        <Step n={1}>Install the CLI and sign in</Step>
+        <CopyableCommandBlock commands={CLI_SETUP} />
+        <Step n={2}>Add it to your client&apos;s MCP config</Step>
+        <CopyableCommandBlock commands={MCP_CLIENT_CONFIG} />
+        <p className="text-[12.5px] text-muted-foreground">
+          The server reads the CLI&apos;s stored credentials, so the client needs no key of its own.
+          It exposes search, the VFS, your sources, sessions, and the Memory wiki as tools.
+        </p>
       </div>
-
-      <p className="min-h-[34px] text-[12.5px] leading-snug text-muted-foreground">
-        {surface.blurb}
-      </p>
-
-      <Button size="sm" variant="secondary" className="self-start" onClick={onOpen}>
-        Set up
-      </Button>
-    </div>
-  );
-}
-
-export default function OutputSurfaces() {
-  const [open, setOpen] = useState<Surface | null>(null);
-
-  return (
-    <>
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {OUTPUT_SURFACES.map((s) => (
-          <SurfaceCard key={s.key} surface={s} onOpen={() => setOpen(s)} />
-        ))}
+    ),
+  },
+  {
+    key: "cli",
+    name: "CLI",
+    icon: SquareTerminal,
+    blurb: "Read and write your stash from any terminal or script — the same commands your agents use.",
+    keywords: "cli terminal shell command line stash search vfs",
+    body: (
+      <div className="flex min-w-0 flex-col gap-3">
+        <Step n={1}>Install and sign in</Step>
+        <CopyableCommandBlock commands={CLI_SETUP} />
+        <Step n={2}>Read anything</Step>
+        <CopyableCommandBlock commands={CLI_USAGE} />
+        <p className="text-[12.5px] text-muted-foreground">
+          <code className="font-mono">stash --help</code> lists the rest.
+        </p>
       </div>
-
-      <Dialog open={open !== null} onOpenChange={(v) => !v && setOpen(null)}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{open?.label}</DialogTitle>
-            <DialogDescription>{open?.blurb}</DialogDescription>
-          </DialogHeader>
-          {open?.key === "api" ? <ApiSteps /> : open?.steps}
-        </DialogContent>
-      </Dialog>
-    </>
-  );
-}
+    ),
+  },
+  {
+    key: "api",
+    name: "HTTP API",
+    icon: Braces,
+    blurb: "Everything the app can do, over HTTP, authenticated with an API key.",
+    keywords: "api http rest curl key token",
+    body: <ApiSteps />,
+  },
+];

--- a/frontend/src/components/integrations/OutputSurfaces.tsx
+++ b/frontend/src/components/integrations/OutputSurfaces.tsx
@@ -1,15 +1,24 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
+import { Braces, SquareTerminal, Waypoints } from "lucide-react";
 
 import CopyableCommandBlock from "@/components/CopyableCommandBlock";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 // `stash-mcp` is a console script (pyproject.toml: stash-mcp =
 // "cli.mcp_server:main"), speaking stdio and reading the CLI's stored config —
 // so a client needs no key of its own, only a machine where `stash signin` has
-// run. Deliberately no tool count here: it drifts every time cli/mcp_server.py
-// gains a tool, and a stale number in the UI is worse than no number.
+// run. Deliberately no tool count anywhere here: it drifts every time
+// cli/mcp_server.py gains a tool, and a stale number is worse than no number.
 const MCP_CLIENT_CONFIG = `{
   "mcpServers": {
     "stash": { "command": "stash-mcp" }
@@ -20,33 +29,73 @@ const CLI_SETUP = `uv tool install stashai\nstash signin`;
 
 const CLI_USAGE = `stash search "org isolation"\nstash vfs "ls /"\nstash vfs "cat '/files/spec.md'"`;
 
-function OutputCard({
-  title,
-  blurb,
-  children,
-  footer,
-}: {
-  title: string;
+type Surface = {
+  key: string;
+  label: string;
+  icon: typeof Waypoints;
   blurb: string;
-  children: React.ReactNode;
-  footer?: React.ReactNode;
-}) {
+  /** What the dialog shows once you pick this way out. */
+  steps: ReactNode;
+};
+
+function Step({ n, children }: { n: number; children: ReactNode }) {
   return (
-    <div className="flex flex-col gap-3 rounded-xl border border-border bg-surface p-5">
-      <div>
-        <h3 className="text-[14px] font-semibold text-foreground">{title}</h3>
-        <p className="mt-1 max-w-2xl text-[13px] text-muted-foreground">{blurb}</p>
+    <div className="flex flex-col gap-1.5">
+      <div className="text-[12px] font-medium text-dim">
+        {n}. {children}
       </div>
-      {children}
-      {footer}
     </div>
   );
 }
 
-/** The ways an agent reads a stash: MCP, the CLI, and the HTTP API. These are
- *  setup instructions rather than connect buttons — the thing being configured
- *  lives on the user's machine, not on our side. */
-export default function OutputSurfaces() {
+export const OUTPUT_SURFACES: Surface[] = [
+  {
+    key: "mcp",
+    label: "MCP server",
+    icon: Waypoints,
+    blurb: "Point any MCP client at your stash — Claude Desktop, Cursor, anything that speaks MCP.",
+    steps: (
+      <div className="flex min-w-0 flex-col gap-3">
+        <Step n={1}>Install the CLI and sign in</Step>
+        <CopyableCommandBlock commands={CLI_SETUP} />
+        <Step n={2}>Add it to your client&apos;s MCP config</Step>
+        <CopyableCommandBlock commands={MCP_CLIENT_CONFIG} />
+        <p className="text-[12.5px] text-muted-foreground">
+          The server reads the CLI&apos;s stored credentials, so the client needs no key of its own.
+          It exposes search, the VFS, your sources, sessions, and the Memory wiki as tools.
+        </p>
+      </div>
+    ),
+  },
+  {
+    key: "cli",
+    label: "CLI",
+    icon: SquareTerminal,
+    blurb: "Read and write your stash from any terminal or script — the same commands your agents use.",
+    steps: (
+      <div className="flex min-w-0 flex-col gap-3">
+        <Step n={1}>Install and sign in</Step>
+        <CopyableCommandBlock commands={CLI_SETUP} />
+        <Step n={2}>Read anything</Step>
+        <CopyableCommandBlock commands={CLI_USAGE} />
+        <p className="text-[12.5px] text-muted-foreground">
+          <code className="font-mono">stash --help</code> lists the rest.
+        </p>
+      </div>
+    ),
+  },
+  {
+    key: "api",
+    label: "HTTP API",
+    icon: Braces,
+    blurb: "Everything the app can do, over HTTP, authenticated with an API key.",
+    steps: null,
+  },
+];
+
+/** The API card's steps depend on where the app is served from, so they're
+ *  built at render rather than baked into the constant above. */
+function ApiSteps() {
   // The app proxies /api/v1 to the backend, so its own origin is the correct
   // base for every deployment — hardcoding api.joinstash.ai would hand
   // self-hosters a URL that isn't theirs.
@@ -54,45 +103,70 @@ export default function OutputSurfaces() {
   useEffect(() => setOrigin(window.location.origin), []);
 
   return (
-    <div className="flex flex-col gap-3">
-      <OutputCard
-        title="MCP server"
-        blurb="Point any MCP client at your stash — Claude Desktop, Cursor, anything that speaks MCP. It exposes search, the VFS, your sources, sessions, and the Memory wiki as tools."
-      >
-        <div className="flex flex-col gap-2">
-          <div className="text-[12px] font-medium text-dim">1. Install the CLI and sign in</div>
-          <CopyableCommandBlock commands={CLI_SETUP} />
-          <div className="mt-1 text-[12px] font-medium text-dim">
-            2. Add it to your client&apos;s MCP config
-          </div>
-          <CopyableCommandBlock commands={MCP_CLIENT_CONFIG} />
-          <p className="text-[12px] text-muted-foreground">
-            The server reads the CLI&apos;s stored credentials, so the client needs no key of its
-            own.
-          </p>
-        </div>
-      </OutputCard>
-
-      <OutputCard
-        title="CLI"
-        blurb="Read and write your stash from any terminal or script. The same commands your coding agents use."
-      >
-        <CopyableCommandBlock commands={CLI_USAGE} />
-      </OutputCard>
-
-      <OutputCard
-        title="HTTP API"
-        blurb="Everything the app can do, over HTTP, authenticated with an API key."
-        footer={
-          <Link href="/settings" className="text-[12.5px] font-medium text-brand-600 hover:underline">
-            Manage API keys in Settings →
-          </Link>
-        }
-      >
-        <CopyableCommandBlock
-          commands={`curl -H "Authorization: Bearer <your-key>" \\\n  ${origin || "https://your-stash"}/api/v1/me/vitals`}
-        />
-      </OutputCard>
+    <div className="flex min-w-0 flex-col gap-3">
+      <Step n={1}>Mint a key</Step>
+      <Link href="/settings" className="text-[12.5px] font-medium text-brand-600 hover:underline">
+        Settings → API keys &amp; sessions →
+      </Link>
+      <Step n={2}>Call it</Step>
+      <CopyableCommandBlock
+        commands={`curl -H "Authorization: Bearer <your-key>" \\\n  ${origin || "https://your-stash"}/api/v1/me/vitals`}
+      />
     </div>
+  );
+}
+
+/** One way out, as a card that matches the source cards on the inputs side.
+ *  The setup lives behind the click instead of unfurled on the page — the
+ *  inputs side doesn't print an OAuth flow inline either. */
+function SurfaceCard({ surface, onOpen }: { surface: Surface; onOpen: () => void }) {
+  const Icon = surface.icon;
+  return (
+    <div className="flex flex-col gap-2.5 rounded-xl border border-border bg-surface p-4">
+      <div className="flex items-center gap-2.5">
+        <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-raised">
+          <Icon className="h-4 w-4 text-dim" />
+        </span>
+        <button
+          type="button"
+          onClick={onOpen}
+          className="truncate text-left text-[14px] font-medium text-foreground hover:underline"
+        >
+          {surface.label}
+        </button>
+      </div>
+
+      <p className="min-h-[34px] text-[12.5px] leading-snug text-muted-foreground">
+        {surface.blurb}
+      </p>
+
+      <Button size="sm" variant="secondary" className="self-start" onClick={onOpen}>
+        Set up
+      </Button>
+    </div>
+  );
+}
+
+export default function OutputSurfaces() {
+  const [open, setOpen] = useState<Surface | null>(null);
+
+  return (
+    <>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {OUTPUT_SURFACES.map((s) => (
+          <SurfaceCard key={s.key} surface={s} onOpen={() => setOpen(s)} />
+        ))}
+      </div>
+
+      <Dialog open={open !== null} onOpenChange={(v) => !v && setOpen(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{open?.label}</DialogTitle>
+            <DialogDescription>{open?.blurb}</DialogDescription>
+          </DialogHeader>
+          {open?.key === "api" ? <ApiSteps /> : open?.steps}
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/frontend/src/components/integrations/OutputSurfaces.tsx
+++ b/frontend/src/components/integrations/OutputSurfaces.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import CopyableCommandBlock from "@/components/CopyableCommandBlock";
+
+// `stash-mcp` is a console script (pyproject.toml: stash-mcp =
+// "cli.mcp_server:main"), speaking stdio and reading the CLI's stored config —
+// so a client needs no key of its own, only a machine where `stash signin` has
+// run. Deliberately no tool count here: it drifts every time cli/mcp_server.py
+// gains a tool, and a stale number in the UI is worse than no number.
+const MCP_CLIENT_CONFIG = `{
+  "mcpServers": {
+    "stash": { "command": "stash-mcp" }
+  }
+}`;
+
+const CLI_SETUP = `uv tool install stashai\nstash signin`;
+
+const CLI_USAGE = `stash search "org isolation"\nstash vfs "ls /"\nstash vfs "cat '/files/spec.md'"`;
+
+function OutputCard({
+  title,
+  blurb,
+  children,
+  footer,
+}: {
+  title: string;
+  blurb: string;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-border bg-surface p-5">
+      <div>
+        <h3 className="text-[14px] font-semibold text-foreground">{title}</h3>
+        <p className="mt-1 max-w-2xl text-[13px] text-muted-foreground">{blurb}</p>
+      </div>
+      {children}
+      {footer}
+    </div>
+  );
+}
+
+/** The ways an agent reads a stash: MCP, the CLI, and the HTTP API. These are
+ *  setup instructions rather than connect buttons — the thing being configured
+ *  lives on the user's machine, not on our side. */
+export default function OutputSurfaces() {
+  // The app proxies /api/v1 to the backend, so its own origin is the correct
+  // base for every deployment — hardcoding api.joinstash.ai would hand
+  // self-hosters a URL that isn't theirs.
+  const [origin, setOrigin] = useState("");
+  useEffect(() => setOrigin(window.location.origin), []);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <OutputCard
+        title="MCP server"
+        blurb="Point any MCP client at your stash — Claude Desktop, Cursor, anything that speaks MCP. It exposes search, the VFS, your sources, sessions, and the Memory wiki as tools."
+      >
+        <div className="flex flex-col gap-2">
+          <div className="text-[12px] font-medium text-dim">1. Install the CLI and sign in</div>
+          <CopyableCommandBlock commands={CLI_SETUP} />
+          <div className="mt-1 text-[12px] font-medium text-dim">
+            2. Add it to your client&apos;s MCP config
+          </div>
+          <CopyableCommandBlock commands={MCP_CLIENT_CONFIG} />
+          <p className="text-[12px] text-muted-foreground">
+            The server reads the CLI&apos;s stored credentials, so the client needs no key of its
+            own.
+          </p>
+        </div>
+      </OutputCard>
+
+      <OutputCard
+        title="CLI"
+        blurb="Read and write your stash from any terminal or script. The same commands your coding agents use."
+      >
+        <CopyableCommandBlock commands={CLI_USAGE} />
+      </OutputCard>
+
+      <OutputCard
+        title="HTTP API"
+        blurb="Everything the app can do, over HTTP, authenticated with an API key."
+        footer={
+          <Link href="/settings" className="text-[12.5px] font-medium text-brand-600 hover:underline">
+            Manage API keys in Settings →
+          </Link>
+        }
+      >
+        <CopyableCommandBlock
+          commands={`curl -H "Authorization: Bearer <your-key>" \\\n  ${origin || "https://your-stash"}/api/v1/me/vitals`}
+        />
+      </OutputCard>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -107,7 +107,9 @@ function DialogFooter({
     <div
       data-slot="dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        // `border-t` alone resolves to currentColor under Tailwind v4, which
+        // painted this divider near-black instead of a hairline.
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t border-border bg-muted/50 p-4 sm:flex-row sm:justify-end",
         className
       )}
       {...props}


### PR DESCRIPTION
Stacked on #1047 (`stash-revamp-3`) — it edits the page that PR renames, so it targets that branch rather than `main`.

Integrations becomes **one flat grid of boxes with a search field**, where every box looks the same, behaves the same, and says which way the data moves.

## The finding that shaped this

The page owned **two of the four ways anything reaches Stash**, and had **no outputs on it at all** — including the section that read most like one.

There are two different MCPs in this product:

| | direction | where it was |
|---|---|---|
| `mcp_server_service.py` — servers **you register**, which Stash's cloud agent calls | **in** | on this page, labelled "MCP servers" |
| `stash-mcp` — **Stash as a server**, for any MCP client | **out** | a console script in `pyproject.toml`, surfaced nowhere |

Same acronym, opposite directions, one page. Neither is called just "MCP" now: the registry is **Custom MCP server**, and Stash-as-a-server is **MCP server** under Outputs.

Three ways out existed in the codebase with no UI at all — `stash-mcp`, the CLI, and the HTTP API. All three are boxes now. The API example is built from `window.location.origin`, so a self-hoster gets their own URL rather than `api.joinstash.ai`.

## The interface

One grid, ~32 boxes, all the same shape: icon, name, one line, one button.

- **Inputs / Outputs** are an exclusive choice — one direction on screen at a time, with counts on each pill.
- **Search** matches beyond visible text (`curl`, `rest`, `bookmarks` all find the right box). Because only one direction shows, a query that matches nothing here counts the other side and offers to switch, carrying the query: *"1 match in Outputs →"*.
- **Connected boxes are tinted and sort first.** Below them, the order follows how a team adopts Stash: coding agents, then work tools, then personal accounts.
- **Every box opens a dialog.** Connectors get one holding what connecting does, the Connect button, and a link to the full settings page — which still owns choosing what syncs.
- **Two verbs, total:** `Connect` if it isn't set up, `Manage` if it is. Earlier drafts had `Set up`, `Add`, and `Remove` as well; each encoded something about our implementation (who performs the work, whether a row is being created) rather than what the user wants.

Deleted along the way: a direction segmented control, category pills, five section headings, five section blurbs, and a per-box direction badge.

## Coding agents appear twice, on purpose

An agent writes transcripts **in** and reads the stash back **out**, so it gets a box per direction — *"Claude Code transcripts"* and *"Claude Code access"* — rather than one box wearing a `⇄ BOTH` badge, which named the ambiguity instead of resolving it.

**No per-agent connected state, deliberately.** The uploaded `agent_name` comes from the user's own config (`cli.get("username")`), not from which harness ran, so "Claude Code: connected" would be a guess dressed as a fact.

The agent list tracks `_SUPPORTED_AGENTS` in `cli/main.py`; an agent listed here that the CLI can't wire is a promise the product doesn't keep.

## Manage and remove, everywhere

Registered MCP servers used to show a bare `Remove` that deleted the row on one click, with no confirmation, sitting in the same slot where every other box had a harmless navigation. Removal now lives inside the Manage dialog, alongside the server's transport, target, and header **key names** (values stay secret). Connected sources already worked this way — their provider page holds Disconnect.

Editing a registered server still isn't possible: there's no PATCH on `/me/mcp-servers`, only list/create/delete, so Manage shows the config read-only rather than pretending otherwise.

## Bugs found and fixed on the way

- **Copy buttons failed silently.** `writeText` rejects for reasons the page can't prevent; unhandled, the button just did nothing. It now says so.
- **`DialogFooter` painted a black bar.** A bare `border-t` resolves to `currentColor` under Tailwind v4. Fixed at the source, so the files-explorer dialog gets the hairline too.
- **Code blocks overflowed dialogs by 13px** — `DialogContent` is a grid, and a grid item's automatic `min-width` grew the track. Measured, not guessed.
- **Long commands scrolled under the copy button**, hiding half the install URL. They wrap now.
- **`disabled_reason` was never shown anywhere.** A self-hosted server without `INTEGRATIONS_ENCRYPTION_KEY` offered twelve Connect buttons that could only 503, with the explanation sitting unused in the API response. The connector dialog now says so and offers no button it can't honour.

## Verified

`tsc --noEmit` clean · 318 vitest tests pass · `npm run lint` reports no errors · `next build` succeeds.

Driven in a browser against a seeded stash throughout: added and removed an MCP server end to end, opened all 17 setup dialogs in both directions, exercised search and the cross-direction jump, and checked dark mode.

Test coverage moved with the UI rather than being deleted: the remove test now asserts the grid has **no** one-click Remove, and a new test opens Manage to prove header names appear while header values never do.

## Known, not addressed here

- The command-block wrap fix touches the shared `CopyableCommandBlock`, so onboarding, the sessions page, and Home's empty state get wrapping blocks too.
- `tables/[tableId]/page.test.tsx` has a flaky command-z undo test — failed twice across dozens of runs, passes 4/4 in isolation. Pre-existing; this branch doesn't touch that file.
- Unrelated, found while testing: the knowledge-density labeler surfaces UUID fragments as topics, because it tokenizes page bodies and memory pages contain `/p/<id>` wiki links. Prod hits this too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
