### PR TITLE
The CLI keeps itself current, instead of hoping a hook does

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -38,6 +38,8 @@ COPY docs/skills/ ./docs/skills/
 COPY stashvfs/ ./stashvfs/
 COPY backend/entrypoint.sh ./entrypoint.sh
 COPY alembic.ini ./alembic.ini
+# The CLI release number clients are told to upgrade to (backend/cli_release.py).
+COPY pyproject.toml ./pyproject.toml
 
 RUN mkdir -p /app/.secrets && \
     chmod 700 /app/.secrets && \

--- a/backend/cli_release.py
+++ b/backend/cli_release.py
@@ -1,0 +1,21 @@
+"""The stash CLI release clients should be running.
+
+Sourced from the repo's pyproject version — the same number publish.yml pushes
+to PyPI — so cutting a release stays a one-line edit. Served on every response
+as X-Stash-Cli-Latest; a CLI that finds itself older upgrades in the background
+(see stashai/self_upgrade.py).
+
+Missing pyproject.toml raises at import: a backend that can't name the current
+release would silently stop upgrading every client on the fleet, which is the
+failure this whole path exists to end.
+"""
+
+import tomllib
+from pathlib import Path
+
+LATEST_VERSION_HEADER = "X-Stash-Cli-Latest"
+
+_PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+with _PYPROJECT.open("rb") as _f:
+    LATEST_CLI_VERSION: str = tomllib.load(_f)["project"]["version"]

--- a/backend/cli_release.py
+++ b/backend/cli_release.py
@@ -5,11 +5,12 @@ to PyPI — so cutting a release stays a one-line edit. Served on every response
 as X-Stash-Cli-Latest; a CLI that finds itself older upgrades in the background
 (see stashai/self_upgrade.py).
 
-Missing pyproject.toml raises at import: a backend that can't name the current
-release would silently stop upgrading every client on the fleet, which is the
-failure this whole path exists to end.
+A missing or malformed version raises at import: a backend that can't name a
+release clients can compare would silently stop upgrading every client on the
+fleet, which is the failure this whole path exists to end.
 """
 
+import re
 import tomllib
 from pathlib import Path
 
@@ -17,5 +18,19 @@ LATEST_VERSION_HEADER = "X-Stash-Cli-Latest"
 
 _PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
-with _PYPROJECT.open("rb") as _f:
-    LATEST_CLI_VERSION: str = tomllib.load(_f)["project"]["version"]
+
+def _read_release(pyproject: Path) -> str:
+    with pyproject.open("rb") as f:
+        release = tomllib.load(f)["project"]["version"]
+    # A pre-release ("0.1.365rc1") is PEP-440-valid and would publish fine,
+    # but clients compare plain dotted numbers and would read it as *older* —
+    # silently freezing every install until the next plain release.
+    if not re.fullmatch(r"\d+(\.\d+)*", release):
+        raise ValueError(
+            f"pyproject version {release!r} is not a plain dotted release; "
+            "clients cannot compare it and would stop upgrading."
+        )
+    return release
+
+
+LATEST_CLI_VERSION: str = _read_release(_PYPROJECT)

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,7 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from starlette.responses import JSONResponse
 
+from . import cli_release
 from . import exports as _exports  # noqa: F401 — registers exporter Celery tasks
 from . import integrations as _integrations  # noqa: F401 — registers providers + importers
 from .config import settings
@@ -186,6 +187,9 @@ async def add_security_headers(request: Request, call_next):
     for key, value in SECURITY_HEADERS.items():
         if key not in response.headers:
             response.headers[key] = value
+    # Every client learns the current release from the traffic it already
+    # makes, so staying current costs no extra request and needs no hook.
+    response.headers[cli_release.LATEST_VERSION_HEADER] = cli_release.LATEST_CLI_VERSION
     return response
 
 

--- a/backend/tests/test_cli_release_header.py
+++ b/backend/tests/test_cli_release_header.py
@@ -36,3 +36,13 @@ def test_release_is_the_published_version():
     diverge, clients chase a release that does not exist."""
     with (REPO_ROOT / "pyproject.toml").open("rb") as f:
         assert cli_release.LATEST_CLI_VERSION == tomllib.load(f)["project"]["version"]
+
+
+def test_a_prerelease_version_is_refused_at_import(tmp_path):
+    """Clients compare plain dotted numbers, so '0.1.365rc1' would read as
+    *older* than what they run and silently freeze every install on the fleet.
+    The backend must refuse to serve it rather than serve it quietly."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nversion = "0.1.365rc1"\n')
+    with pytest.raises(ValueError, match="not a plain dotted release"):
+        cli_release._read_release(pyproject)

--- a/backend/tests/test_cli_release_header.py
+++ b/backend/tests/test_cli_release_header.py
@@ -1,0 +1,38 @@
+"""The backend names the CLI release every client should be on.
+
+This header is the only thing that tells a stale install to upgrade — without
+it the CLI has no idea it is behind, which is exactly how installs sat 30
+releases back for weeks. It rides on responses clients already make, so it must
+be present unconditionally, including on requests that carry no auth.
+"""
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from backend import cli_release
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.asyncio
+async def test_every_response_names_the_current_release(client):
+    response = await client.get("/health")
+    assert response.headers["X-Stash-Cli-Latest"] == cli_release.LATEST_CLI_VERSION
+
+
+@pytest.mark.asyncio
+async def test_error_responses_carry_it_too(client):
+    """A CLI whose token expired still gets 401s — and still deserves to learn
+    it is stale, since an upgrade may be what fixes it."""
+    response = await client.get("/api/v1/me/files")
+    assert response.status_code in (401, 403)
+    assert response.headers["X-Stash-Cli-Latest"] == cli_release.LATEST_CLI_VERSION
+
+
+def test_release_is_the_published_version():
+    """One source of truth: the number publish.yml ships to PyPI. If these ever
+    diverge, clients chase a release that does not exist."""
+    with (REPO_ROOT / "pyproject.toml").open("rb") as f:
+        assert cli_release.LATEST_CLI_VERSION == tomllib.load(f)["project"]["version"]

--- a/cli/client.py
+++ b/cli/client.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import httpx
 
+from stashai import self_upgrade
 from stashvfs import VfsClientError
 
 
@@ -101,6 +102,7 @@ class StashClient:
         headers = kwargs.pop("headers", {})
         headers.update(self._headers())
         resp = self._http.request(method, path, headers=headers, **kwargs)
+        self_upgrade.note_latest(resp.headers.get(self_upgrade.LATEST_VERSION_HEADER, ""))
         if not resp.is_success:
             detail = ""
             try:

--- a/cli/config.py
+++ b/cli/config.py
@@ -176,11 +176,6 @@ def save_enabled_agents(agents: list[str]) -> None:
     _write_to(USER_CONFIG_FILE, {"enabled_agents": agents})
 
 
-def set_codex_auto_update(enabled: bool) -> None:
-    """Persist whether Stash may auto-update itself at Codex session start."""
-    _write_to(USER_CONFIG_FILE, {"codex_auto_update": enabled})
-
-
 def clear_config() -> None:
     """Remove stored config."""
     if USER_CONFIG_FILE.exists():

--- a/cli/main.py
+++ b/cli/main.py
@@ -38,7 +38,6 @@ from .config import (
     save_recorded_paths,
     save_scope,
     session_link_enabled,
-    set_codex_auto_update,
     set_session_link,
     start_streaming,
     stop_streaming,
@@ -857,16 +856,6 @@ def hook_run(agent: str = typer.Argument(...), event: str = typer.Argument(...))
     script = _assets_dir(agent) / "scripts" / f"{event}.py"
     sys.path.insert(0, str(script.parent))
     runpy.run_path(str(script), run_name="__main__")
-
-
-@hook_app.command("auto-update")
-def hook_auto_update(choice: str = typer.Argument(..., help="'on' or 'off'")) -> None:
-    """Record whether Stash may auto-update at Codex session start."""
-    if choice not in ("on", "off"):
-        typer.echo("Pass 'on' or 'off'.", err=True)
-        raise typer.Exit(1)
-    set_codex_auto_update(choice == "on")
-    console.print(f"Codex auto-update {choice}.")
 
 
 def _plugin_installed(agent: str) -> bool:

--- a/cli/main.py
+++ b/cli/main.py
@@ -81,21 +81,23 @@ def root(
 @app.command()
 def upgrade() -> None:
     """Upgrade the stash CLI to the latest version on PyPI."""
-    import shutil
     import subprocess
 
-    if not shutil.which("uv"):
+    from stashai import self_upgrade
+
+    if self_upgrade.is_editable():
+        typer.echo("This is an editable checkout — `git pull` to update it.", err=True)
+        raise typer.Exit(1)
+    command = self_upgrade.upgrade_command()
+    if command is None:
         typer.echo(
-            "uv is not on PATH. Re-run the installer: "
-            'bash -c "$(curl -fsSL https://joinstash.ai/install)"',
+            "This install has no working upgrader (no uv, no pip). "
+            'Re-run the installer: bash -c "$(curl -fsSL https://joinstash.ai/install)"',
             err=True,
         )
         raise typer.Exit(1)
     typer.echo(f"Upgrading stashai from {__version__}…")
-    result = subprocess.run(
-        ["uv", "tool", "install", "--force", "--reinstall", "--refresh", "stashai"]
-    )
-    raise typer.Exit(result.returncode)
+    raise typer.Exit(subprocess.run(command).returncode)
 
 
 def _client(auto: bool = False) -> StashClient:
@@ -3068,6 +3070,11 @@ def agent_chat(
     """Start (or continue) a cloud agent chat and stream the turn live.
 
     Ctrl-C disconnects the stream, which stops the turn on the box."""
+    from stashai import self_upgrade
+
+    # Streams for as long as the turn runs; swapping the package under a live
+    # interpreter breaks its lazy imports (see stashai/self_upgrade.disable).
+    self_upgrade.disable()
     with _client() as c:
         try:
             agent_id = _resolve_agent_id(c, agent) if agent else None
@@ -3088,6 +3095,10 @@ def agent_run(
     agent: str = typer.Argument(..., help="Scheduled agent name or id."),
 ):
     """Run a prompt-scheduled agent now and stream the run live."""
+    from stashai import self_upgrade
+
+    # Streams for as long as the run takes; see agent_chat.
+    self_upgrade.disable()
     with _client() as c:
         try:
             agent_id = _resolve_agent_id(c, agent)
@@ -3121,6 +3132,10 @@ def agent_watch(
 ):
     """Follow a chat session live — works for turns started anywhere
     (web, Slack, a schedule, or another terminal). Exits when the turn ends."""
+    from stashai import self_upgrade
+
+    # Polls indefinitely; see agent_chat.
+    self_upgrade.disable()
     role_style = {"user": "[bold]you:[/bold] ", "assistant": "", "tool": "[dim]", "": ""}
     with _client() as c:
         seen = 0

--- a/cli/mcp_server.py
+++ b/cli/mcp_server.py
@@ -824,6 +824,12 @@ def stash_assign_session(session_row_id: str, folder_id: str = "") -> str:
 
 
 def main():
+    # This server holds one interpreter open for a whole editor session;
+    # swapping the package under it would break the next lazy import hours in
+    # (see stashai/self_upgrade.disable).
+    from stashai import self_upgrade
+
+    self_upgrade.disable()
     mcp.run(transport="stdio")
 
 

--- a/cli/telemetry.py
+++ b/cli/telemetry.py
@@ -12,6 +12,8 @@ import threading
 
 import httpx
 
+from stashai import self_upgrade
+
 from .config import load_config
 
 
@@ -30,7 +32,13 @@ def _post(base_url: str, api_key: str, command: str) -> None:
                         {
                             "surface": "cli",
                             "event_name": "cli.command_invoked",
-                            "properties": {"command": command},
+                            # The version makes fleet staleness a query instead
+                            # of an investigation: without it, "how many users
+                            # are running months-old code?" is unanswerable.
+                            "properties": {
+                                "command": command,
+                                "version": self_upgrade.current_version(),
+                            },
                         }
                     ]
                 },

--- a/cli/tests/test_hook_cli.py
+++ b/cli/tests/test_hook_cli.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 
@@ -36,19 +35,6 @@ def test_hook_events_table_matches_script_files() -> None:
         scripts_dir = REPO_ROOT / "stashai" / "plugin" / "assets" / agent / "scripts"
         on_disk = {p.stem for p in scripts_dir.glob("on_*.py")}
         assert set(events) == on_disk, f"{agent}: table {sorted(events)} vs files {sorted(on_disk)}"
-
-
-def test_hook_auto_update_writes_preference(monkeypatch, tmp_path: Path) -> None:
-    cfg_file = tmp_path / "config.json"
-    monkeypatch.setattr("cli.config.USER_CONFIG_FILE", cfg_file)
-
-    assert runner.invoke(app, ["hook", "auto-update", "on"]).exit_code == 0
-    assert json.loads(cfg_file.read_text())["codex_auto_update"] is True
-
-    assert runner.invoke(app, ["hook", "auto-update", "off"]).exit_code == 0
-    assert json.loads(cfg_file.read_text())["codex_auto_update"] is False
-
-    assert runner.invoke(app, ["hook", "auto-update", "maybe"]).exit_code == 1
 
 
 def test_hook_run_codex_on_stop_executes(monkeypatch, tmp_path: Path) -> None:

--- a/cli/tests/test_release_header_wire.py
+++ b/cli/tests/test_release_header_wire.py
@@ -1,0 +1,62 @@
+"""Both HTTP clients must read the release header off every response.
+
+The upgrade logic is worthless if nothing feeds it. The CLI client covers
+`stash <command>`; the plugin client covers hook traffic, which for an active
+user is thousands of requests a day and the fastest way a stale install hears
+about a new release.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from cli.client import StashClient
+from stashai import self_upgrade
+from stashai.plugin.stash_client import StashClient as PluginClient
+
+
+@pytest.fixture
+def seen(monkeypatch) -> list[str]:
+    latest: list[str] = []
+    monkeypatch.setattr(self_upgrade, "note_latest", latest.append)
+    return latest
+
+
+def _transport(headers: dict[str, str]) -> httpx.MockTransport:
+    return httpx.MockTransport(lambda request: httpx.Response(200, json={}, headers=headers))
+
+
+def test_cli_client_reads_the_header(monkeypatch, seen):
+    client = StashClient("https://example.test", api_key="k")
+    client._http = httpx.Client(
+        base_url="https://example.test",
+        transport=_transport({self_upgrade.LATEST_VERSION_HEADER: "0.1.364"}),
+    )
+
+    client._get("/api/v1/me/files")
+
+    assert seen == ["0.1.364"]
+
+
+def test_plugin_client_reads_the_header(monkeypatch, seen):
+    client = PluginClient("https://example.test", api_key="k")
+    client._http = httpx.Client(
+        base_url="https://example.test",
+        transport=_transport({self_upgrade.LATEST_VERSION_HEADER: "0.1.364"}),
+    )
+
+    client._get("/api/v1/me/whoami")
+
+    assert seen == ["0.1.364"]
+
+
+def test_a_backend_without_the_header_says_nothing(monkeypatch, seen):
+    """Self-hosters run their own backend; absence must read as 'no opinion',
+    not as a version to chase."""
+    client = StashClient("https://example.test", api_key="k")
+    client._http = httpx.Client(base_url="https://example.test", transport=_transport({}))
+
+    client._get("/api/v1/me/files")
+
+    assert seen == [""]

--- a/cli/tests/test_release_header_wire.py
+++ b/cli/tests/test_release_header_wire.py
@@ -16,6 +16,15 @@ from stashai import self_upgrade
 from stashai.plugin.stash_client import StashClient as PluginClient
 
 
+def test_the_header_name_is_the_wire_literal():
+    """The backend serves this exact string (backend/cli_release.py), and the
+    CLI ships separately so the two constants cannot import each other. Every
+    other test here builds its mocks from the constant itself, so without this
+    pin, renaming it would pass the whole suite while every deployed CLI
+    silently stopped seeing the header."""
+    assert self_upgrade.LATEST_VERSION_HEADER == "X-Stash-Cli-Latest"
+
+
 @pytest.fixture
 def seen(monkeypatch) -> list[str]:
     latest: list[str] = []

--- a/cli/tests/test_self_upgrade.py
+++ b/cli/tests/test_self_upgrade.py
@@ -24,6 +24,7 @@ def _isolate(monkeypatch, tmp_path: Path):
     disables. Nothing here may touch the developer's real ~/.stash."""
     monkeypatch.setattr(self_upgrade, "_STAMP_PATH", tmp_path / "upgrade_attempt.json")
     monkeypatch.setattr(self_upgrade, "_enabled", True)
+    monkeypatch.setattr(self_upgrade, "_warned_stamp_unwritable", False)
 
 
 @pytest.fixture
@@ -36,7 +37,7 @@ def spawned(monkeypatch) -> list[list[str]]:
 
 def _as_release(monkeypatch, current: str) -> None:
     monkeypatch.setattr(self_upgrade, "current_version", lambda: current)
-    monkeypatch.setattr(self_upgrade, "_is_editable", lambda: False)
+    monkeypatch.setattr(self_upgrade, "is_editable", lambda: False)
 
 
 def test_stale_install_upgrades_itself(monkeypatch, spawned, capsys):
@@ -73,6 +74,8 @@ def test_pip_install_is_upgraded_by_its_own_interpreter(monkeypatch, spawned):
     install that gets upgraded."""
     _as_release(monkeypatch, "0.1.334")
     monkeypatch.setattr(self_upgrade, "_is_uv_tool", lambda: False)
+    monkeypatch.setattr(self_upgrade, "_has_pip", lambda: True)
+    monkeypatch.setattr(self_upgrade, "_is_externally_managed", lambda: False)
     monkeypatch.setattr(self_upgrade.sys, "executable", "/pyenv/versions/3.12/bin/python")
 
     self_upgrade.note_latest("0.1.364")
@@ -94,7 +97,7 @@ def test_editable_checkout_is_never_touched(monkeypatch, spawned, capsys):
     """Upgrading a developer's `pip install -e .` would overwrite the code they
     are working on. Tell them, change nothing."""
     monkeypatch.setattr(self_upgrade, "current_version", lambda: "0.1.334")
-    monkeypatch.setattr(self_upgrade, "_is_editable", lambda: True)
+    monkeypatch.setattr(self_upgrade, "is_editable", lambda: True)
 
     self_upgrade.note_latest("0.1.364")
 
@@ -113,8 +116,8 @@ def test_missing_uv_is_reported_not_swallowed(monkeypatch, spawned, capsys):
 
     assert spawned == []
     err = capsys.readouterr().err
-    assert "uv is not installed" in err
-    assert "joinstash.ai/install.sh" in err
+    assert "no working upgrader" in err
+    assert "joinstash.ai/install" in err
 
 
 def test_one_attempt_per_hour_per_release(monkeypatch, spawned):
@@ -156,6 +159,81 @@ def test_stale_stamp_expires(monkeypatch, spawned):
     self_upgrade.note_latest("0.1.364")
 
     assert len(spawned) == 1
+
+
+def test_a_rolling_deploy_does_not_reset_the_throttle(monkeypatch, spawned):
+    """During a zero-downtime deploy, old and new backend instances alternate
+    headers for minutes. Each flip must read as 'already attempted', not as a
+    fresh release, or every stale client storms for the whole window."""
+    _as_release(monkeypatch, "0.1.334")
+    monkeypatch.setattr(self_upgrade, "_is_uv_tool", lambda: True)
+    monkeypatch.setattr(self_upgrade, "_find_uv", lambda: "/usr/local/bin/uv")
+
+    self_upgrade.note_latest("0.1.365")
+    self_upgrade.note_latest("0.1.364")
+    self_upgrade.note_latest("0.1.365")
+
+    assert len(spawned) == 1
+
+
+def test_an_unwritable_stamp_dir_never_crashes_the_request(monkeypatch, spawned, capsys, tmp_path):
+    """note_latest rides on every API response; a ~/.stash we cannot write to
+    (root-owned install, full disk) must not turn successful requests into
+    crashes. No stamp means no throttle, so it must also not attempt."""
+    _as_release(monkeypatch, "0.1.334")
+    monkeypatch.setattr(self_upgrade, "_is_uv_tool", lambda: True)
+    monkeypatch.setattr(self_upgrade, "_find_uv", lambda: "/usr/local/bin/uv")
+    blocker = tmp_path / "blocker"
+    blocker.write_text("")
+    monkeypatch.setattr(self_upgrade, "_STAMP_PATH", blocker / "stamp.json")
+
+    self_upgrade.note_latest("0.1.364")
+    self_upgrade.note_latest("0.1.364")
+
+    assert spawned == []
+    # Said once, not once per response.
+    assert capsys.readouterr().err.count("not writable") == 1
+
+
+def test_a_corrupt_stamp_reads_as_never_attempted(monkeypatch, spawned):
+    """A stamp holding valid-but-wrong JSON (external corruption) must not
+    crash the request path; never-attempted is the state we want to act on."""
+    _as_release(monkeypatch, "0.1.334")
+    monkeypatch.setattr(self_upgrade, "_is_uv_tool", lambda: True)
+    monkeypatch.setattr(self_upgrade, "_find_uv", lambda: "/usr/local/bin/uv")
+    self_upgrade._STAMP_PATH.parent.mkdir(parents=True, exist_ok=True)
+    self_upgrade._STAMP_PATH.write_text("null")
+
+    self_upgrade.note_latest("0.1.364")
+
+    assert len(spawned) == 1
+
+
+def test_a_python_without_pip_is_reported_not_swallowed(monkeypatch, spawned, capsys):
+    """uv venvs ship without pip; `python -m pip` there dies unseen in the
+    detached child. Say the install can't upgrade instead of claiming it is."""
+    _as_release(monkeypatch, "0.1.334")
+    monkeypatch.setattr(self_upgrade, "_is_uv_tool", lambda: False)
+    monkeypatch.setattr(self_upgrade, "_has_pip", lambda: False)
+
+    self_upgrade.note_latest("0.1.364")
+
+    assert spawned == []
+    assert "no working upgrader" in capsys.readouterr().err
+
+
+def test_pep668_pythons_get_the_flags_they_require(monkeypatch, spawned):
+    """An externally-managed python (Debian's, the Fly Sprites we provision)
+    refuses a plain `pip install` — into DEVNULL, in a detached child, forever.
+    The same flags our sprite setup installs with make it land."""
+    _as_release(monkeypatch, "0.1.334")
+    monkeypatch.setattr(self_upgrade, "_is_uv_tool", lambda: False)
+    monkeypatch.setattr(self_upgrade, "_has_pip", lambda: True)
+    monkeypatch.setattr(self_upgrade, "_is_externally_managed", lambda: True)
+
+    self_upgrade.note_latest("0.1.364")
+
+    assert spawned[0][-2:] == ["--user", "--break-system-packages"]
 
 
 def test_disable_stops_long_lived_processes_from_upgrading(monkeypatch, spawned):

--- a/cli/tests/test_self_upgrade.py
+++ b/cli/tests/test_self_upgrade.py
@@ -1,0 +1,201 @@
+"""Cover the CLI's own upgrade path.
+
+The bug this replaces: freshness lived entirely in agent-plugin hooks, every
+failure was silent, and an install ran 30 releases behind for two weeks while
+its hooks fired thousands of times a day. So the properties worth pinning are
+the ones that failed then — that a stale install actually acts, that it
+upgrades *the copy that is running*, and that when it can't, it says so.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from stashai import self_upgrade
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path: Path):
+    """Point the attempt stamp at a temp dir and re-enable after any test that
+    disables. Nothing here may touch the developer's real ~/.stash."""
+    monkeypatch.setattr(self_upgrade, "_STAMP_PATH", tmp_path / "upgrade_attempt.json")
+    monkeypatch.setattr(self_upgrade, "_enabled", True)
+
+
+@pytest.fixture
+def spawned(monkeypatch) -> list[list[str]]:
+    """Record every process the upgrade would start."""
+    calls: list[list[str]] = []
+    monkeypatch.setattr(self_upgrade.subprocess, "Popen", lambda cmd, **kw: calls.append(cmd))
+    return calls
+
+
+def _as_release(monkeypatch, current: str) -> None:
+    monkeypatch.setattr(self_upgrade, "current_version", lambda: current)
+    monkeypatch.setattr(self_upgrade, "_is_editable", lambda: False)
+
+
+def test_stale_install_upgrades_itself(monkeypatch, spawned, capsys):
+    """The whole point: nobody had to run anything for this to happen."""
+    _as_release(monkeypatch, "0.1.334")
+    monkeypatch.setattr(self_upgrade, "_is_uv_tool", lambda: True)
+    monkeypatch.setattr(self_upgrade, "_find_uv", lambda: "/opt/homebrew/bin/uv")
+
+    self_upgrade.note_latest("0.1.364")
+
+    assert spawned == [["/opt/homebrew/bin/uv", "tool", "install", "--quiet", "stashai@latest"]]
+    # The user is told which version their command actually ran on, because it
+    # is not the one they are about to get.
+    assert "0.1.334 → 0.1.364" in capsys.readouterr().err
+
+
+def test_current_install_does_nothing(monkeypatch, spawned):
+    _as_release(monkeypatch, "0.1.364")
+    self_upgrade.note_latest("0.1.364")
+    assert spawned == []
+
+
+def test_missing_header_does_nothing(monkeypatch, spawned):
+    """Self-hosted and older backends send no header; that is not a signal to
+    upgrade toward an unknown release."""
+    _as_release(monkeypatch, "0.1.334")
+    self_upgrade.note_latest("")
+    assert spawned == []
+
+
+def test_pip_install_is_upgraded_by_its_own_interpreter(monkeypatch, spawned):
+    """Sam's failure mode: uv dutifully upgraded a copy that was not the copy
+    on PATH, so the version never moved. The install that is running is the
+    install that gets upgraded."""
+    _as_release(monkeypatch, "0.1.334")
+    monkeypatch.setattr(self_upgrade, "_is_uv_tool", lambda: False)
+    monkeypatch.setattr(self_upgrade.sys, "executable", "/pyenv/versions/3.12/bin/python")
+
+    self_upgrade.note_latest("0.1.364")
+
+    assert spawned == [
+        [
+            "/pyenv/versions/3.12/bin/python",
+            "-m",
+            "pip",
+            "install",
+            "--quiet",
+            "--upgrade",
+            "stashai",
+        ]
+    ]
+
+
+def test_editable_checkout_is_never_touched(monkeypatch, spawned, capsys):
+    """Upgrading a developer's `pip install -e .` would overwrite the code they
+    are working on. Tell them, change nothing."""
+    monkeypatch.setattr(self_upgrade, "current_version", lambda: "0.1.334")
+    monkeypatch.setattr(self_upgrade, "_is_editable", lambda: True)
+
+    self_upgrade.note_latest("0.1.364")
+
+    assert spawned == []
+    assert "checkout" in capsys.readouterr().err
+
+
+def test_missing_uv_is_reported_not_swallowed(monkeypatch, spawned, capsys):
+    """The old path returned silently when uv was absent, which is how an
+    install could sit stale for weeks with nothing on screen ever saying so."""
+    _as_release(monkeypatch, "0.1.334")
+    monkeypatch.setattr(self_upgrade, "_is_uv_tool", lambda: True)
+    monkeypatch.setattr(self_upgrade, "_find_uv", lambda: None)
+
+    self_upgrade.note_latest("0.1.364")
+
+    assert spawned == []
+    err = capsys.readouterr().err
+    assert "uv is not installed" in err
+    assert "joinstash.ai/install.sh" in err
+
+
+def test_one_attempt_per_hour_per_release(monkeypatch, spawned):
+    """A CLI makes many requests per command. Without the stamp, a machine that
+    cannot upgrade would spawn an installer on every single response."""
+    _as_release(monkeypatch, "0.1.334")
+    monkeypatch.setattr(self_upgrade, "_is_uv_tool", lambda: True)
+    monkeypatch.setattr(self_upgrade, "_find_uv", lambda: "/usr/local/bin/uv")
+
+    self_upgrade.note_latest("0.1.364")
+    self_upgrade.note_latest("0.1.364")
+    self_upgrade.note_latest("0.1.364")
+
+    assert len(spawned) == 1
+
+
+def test_a_newer_release_retries_immediately(monkeypatch, spawned):
+    """The throttle bounds failure, so it must not delay a release that just
+    shipped."""
+    _as_release(monkeypatch, "0.1.334")
+    monkeypatch.setattr(self_upgrade, "_is_uv_tool", lambda: True)
+    monkeypatch.setattr(self_upgrade, "_find_uv", lambda: "/usr/local/bin/uv")
+
+    self_upgrade.note_latest("0.1.364")
+    self_upgrade.note_latest("0.1.365")
+
+    assert len(spawned) == 2
+
+
+def test_stale_stamp_expires(monkeypatch, spawned):
+    _as_release(monkeypatch, "0.1.334")
+    monkeypatch.setattr(self_upgrade, "_is_uv_tool", lambda: True)
+    monkeypatch.setattr(self_upgrade, "_find_uv", lambda: "/usr/local/bin/uv")
+    self_upgrade._STAMP_PATH.parent.mkdir(parents=True, exist_ok=True)
+    self_upgrade._STAMP_PATH.write_text(
+        json.dumps({"version": "0.1.364", "at": time.time() - self_upgrade._THROTTLE_SECONDS - 1})
+    )
+
+    self_upgrade.note_latest("0.1.364")
+
+    assert len(spawned) == 1
+
+
+def test_disable_stops_long_lived_processes_from_upgrading(monkeypatch, spawned):
+    """The session watcher outlives the session it watches; swapping the
+    package under it is how you get an ImportError hours later."""
+    _as_release(monkeypatch, "0.1.334")
+    monkeypatch.setattr(self_upgrade, "_is_uv_tool", lambda: True)
+    monkeypatch.setattr(self_upgrade, "_find_uv", lambda: "/usr/local/bin/uv")
+
+    self_upgrade.disable()
+    self_upgrade.note_latest("0.1.364")
+
+    assert spawned == []
+
+
+def test_uv_environments_are_recognised_by_their_receipt(monkeypatch, tmp_path: Path):
+    """Recognising uv by the shape of sys.prefix (.../uv/tools/<name>) passes on
+    a default install and fails whenever UV_TOOL_DIR is set — which sends a uv
+    install down the pip branch, where a uv environment has no pip and the
+    upgrade dies unseen in a detached process. Caught end-to-end; pinned here."""
+    env = tmp_path / "somewhere" / "custom-tool-dir" / "stashai"
+    env.mkdir(parents=True)
+    monkeypatch.setattr(self_upgrade.sys, "prefix", str(env))
+    assert self_upgrade._is_uv_tool() is False
+
+    (env / "uv-receipt.toml").write_text("")
+    assert self_upgrade._is_uv_tool() is True
+
+
+@pytest.mark.parametrize(
+    ("have", "want", "older"),
+    [
+        ("0.1.334", "0.1.364", True),
+        ("0.1.364", "0.1.364", False),
+        ("0.1.365", "0.1.364", False),
+        ("0.2.0", "0.1.999", False),
+        # A locally built wheel carries a non-numeric trailer. It compares on
+        # its release numbers rather than raising inside a request.
+        ("0.1.334.dev0", "0.1.364", True),
+    ],
+)
+def test_version_comparison(have: str, want: str, older: bool):
+    assert self_upgrade._is_older(have, want) is older

--- a/plugins/claude-plugin/scripts/ensure_cli.sh
+++ b/plugins/claude-plugin/scripts/ensure_cli.sh
@@ -38,11 +38,16 @@ version_below() {
   }'
 }
 
-# Hooks run with a minimal PATH, so PATH alone is not enough to find uv.
-# install.sh puts it in ~/.local/bin.
+# Hooks run with a minimal PATH, so PATH alone is not enough to find uv. Checking
+# only ~/.local/bin (where install.sh puts it) missed every user who had already
+# installed uv another way — a Homebrew uv meant this script silently upgraded
+# nothing, forever, with no output to say so.
 find_uv() {
   command -v uv 2>/dev/null && return 0
-  [ -x "$HOME/.local/bin/uv" ] && echo "$HOME/.local/bin/uv" && return 0
+  for candidate in "$HOME/.local/bin/uv" "$HOME/.cargo/bin/uv" \
+                   /opt/homebrew/bin/uv /usr/local/bin/uv; do
+    [ -x "$candidate" ] && echo "$candidate" && return 0
+  done
   return 1
 }
 

--- a/plugins/claude-plugin/scripts/ensure_cli.sh
+++ b/plugins/claude-plugin/scripts/ensure_cli.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 # Keep the stash CLI current enough to run this plugin's hooks.
 #
-# This script is the only upgrade path that reaches a stale install. The hook
-# scripts themselves live inside the stashai package and run via
-# `stash hook run`, which rejects unknown agents before executing anything — so
-# an upgrade invoked from inside those scripts cannot run on exactly the
-# versions that need it. The plugin auto-updates through Claude Code's
-# marketplace, so CLI upgrades have to be driven from the plugin side of that
-# boundary. Every other agent's hook config is written by the CLI itself, so
-# their config and CLI always ship together and they have no such gap.
+# Since SELF_UPGRADE_VERSION the CLI keeps itself current: every API response
+# names the release the backend expects, and an older install upgrades itself
+# (stashai/self_upgrade.py). This script covers what that path cannot reach —
+# installs from before it existed — and enforces the version floor the hooks
+# depend on. It has to live on the plugin side of the marketplace boundary
+# because `stash hook run` rejects unknown agents before executing anything,
+# so nothing inside the package can run on exactly the versions that need it.
 #
 # This never blocks. The upgrade always runs detached, so a CLI below the floor
 # costs this one session and the next session start finds the new CLI. Holding
@@ -22,6 +21,12 @@ set -uo pipefail
 # The first release whose `stash hook run` accepts the `claude` agent. Raise
 # this only when hooks.json starts depending on a newer CLI contract.
 MIN_VERSION="0.1.318"
+
+# The first release that upgrades itself off the response header. Anything at
+# or past it manages its own freshness — upgrading it from here too would race
+# the CLI's own attempt, and would aim uv at machines whose stash is a pip
+# install, minting a second copy that shadows the real one.
+SELF_UPGRADE_VERSION="0.1.366"
 
 # True when $1 is an older dotted version than $2. An absent version reads as
 # 0.0.0, so a missing CLI counts as stale.
@@ -57,7 +62,7 @@ CURRENT="$(stash --version 2>/dev/null | awk '{print $2}')"
 # All three fds are detached: a background job that inherits the hook's stdout
 # holds that pipe open, and the agent waits on it for the whole upgrade — which
 # is the stall this backgrounding exists to avoid.
-if [ -n "$UV" ]; then
+if [ -n "$UV" ] && version_below "$CURRENT" "$SELF_UPGRADE_VERSION"; then
   "$UV" tool install --quiet stashai@latest </dev/null >/dev/null 2>&1 &
 fi
 
@@ -71,7 +76,7 @@ fi
 if [ -z "$UV" ]; then
   echo "stash: CLI ${CURRENT:-not found} is older than $MIN_VERSION and uv is not" \
        "installed, so it cannot upgrade itself. Session activity is not being" \
-       "recorded. Reinstall with: curl -LsSf https://joinstash.ai/install.sh | sh" >&2
+       'recorded. Reinstall with: bash -c "$(curl -fsSL https://joinstash.ai/install)"' >&2
 else
   echo "stash: CLI ${CURRENT:-not found} is older than $MIN_VERSION. An upgrade is" \
        "running in the background; this session is not recorded, the next one will be." >&2

--- a/plugins/codex-plugin/README.md
+++ b/plugins/codex-plugin/README.md
@@ -30,11 +30,11 @@ then.
 
 ## Auto-update
 
-On session start, if no preference is recorded, the plugin asks (via a
-`systemMessage` to the agent) whether Stash may update itself automatically.
-Record the choice with `stash hook auto-update on|off`; it is stored as
-`codex_auto_update` in `~/.stash/config.json`. Manual upgrades stay available
-via `stash upgrade`.
+The CLI keeps itself current: every API response names the release the backend
+expects, and an older install upgrades itself in the background (never mid-run —
+the upgrade is detached, so the running command finishes on the version it
+started with). Nothing to configure, here or anywhere else. `stash upgrade`
+still forces it immediately.
 
 ## Commands
 

--- a/plugins/codex-plugin/scripts/on_session_start.py
+++ b/plugins/codex-plugin/scripts/on_session_start.py
@@ -3,13 +3,10 @@
 
 import json
 import os
-import shutil
-import subprocess
 
 from adapt import adapt_session_start
 from config import DATA_DIR, get_client, get_config, get_stdin_data
 
-from stashai.plugin.agent_config import cli_config
 from stashai.plugin.hooks import (
     color_upload_health_warning,
     create_session_record,
@@ -19,30 +16,6 @@ from stashai.plugin.hooks import (
 )
 from stashai.plugin.session_upload import spawn_session_watcher, spawn_skills_sync
 from stashai.plugin.state import load_state, reset_stats, save_state
-
-_ASK_AUTO_UPDATE = (
-    "Stash: Codex auto-update isn't configured yet. Ask the user whether Stash "
-    "should update itself automatically at session start. Pros: the hook runtime "
-    "stays current with the Stash backend. Cons: the stash CLI can change under "
-    "you mid-project. Record the answer by running `stash hook auto-update on` "
-    "or `stash hook auto-update off`."
-)
-
-
-def _auto_update_message() -> str | None:
-    """Returns the ask-the-user prompt until a preference is recorded; when
-    auto-update is on, kicks off the background upgrade instead."""
-    pref = cli_config().get("codex_auto_update")
-    if pref is None:
-        return _ASK_AUTO_UPDATE
-    if pref and shutil.which("uv"):
-        subprocess.Popen(
-            ["uv", "tool", "install", "--quiet", "stashai@latest"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,
-        )
-    return None
 
 
 def main():
@@ -81,10 +54,6 @@ def main():
             session_row_id=state.get("session_row_id", ""),
             transcript_path=event.transcript_path,
         )
-
-    message = _auto_update_message()
-    if message:
-        print(json.dumps({"systemMessage": message}))
 
 
 if __name__ == "__main__":

--- a/plugins/cursor-plugin/scripts/on_session_start.py
+++ b/plugins/cursor-plugin/scripts/on_session_start.py
@@ -11,7 +11,6 @@ from stashai.plugin.hooks import (
     uploads_disabled_warning,
     uploads_enabled,
 )
-from stashai.plugin.session_upload import spawn_self_upgrade
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 
@@ -36,8 +35,6 @@ def main():
             create_session_record(client, cfg, state, event, DATA_DIR)
     except Exception:
         pass
-
-    spawn_self_upgrade()
 
 
 if __name__ == "__main__":

--- a/plugins/gemini-plugin/scripts/on_session_start.py
+++ b/plugins/gemini-plugin/scripts/on_session_start.py
@@ -11,7 +11,7 @@ from stashai.plugin.hooks import (
     uploads_disabled_warning,
     uploads_enabled,
 )
-from stashai.plugin.session_upload import spawn_self_upgrade, spawn_skills_sync
+from stashai.plugin.session_upload import spawn_skills_sync
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 
@@ -38,7 +38,6 @@ def main():
         pass
 
     spawn_skills_sync(cfg)
-    spawn_self_upgrade()
 
 
 if __name__ == "__main__":

--- a/plugins/hermes-plugin/scripts/on_session_start.py
+++ b/plugins/hermes-plugin/scripts/on_session_start.py
@@ -17,7 +17,7 @@ from stashai.plugin.hooks import (
     uploads_disabled_warning,
     uploads_enabled,
 )
-from stashai.plugin.session_upload import spawn_self_upgrade, spawn_skills_sync
+from stashai.plugin.session_upload import spawn_skills_sync
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 
@@ -44,7 +44,6 @@ def main():
         pass
 
     spawn_skills_sync(cfg)
-    spawn_self_upgrade()
 
 
 if __name__ == "__main__":

--- a/plugins/openclaw-plugin/scripts/on_session_start.py
+++ b/plugins/openclaw-plugin/scripts/on_session_start.py
@@ -11,7 +11,7 @@ from stashai.plugin.hooks import (
     uploads_disabled_warning,
     uploads_enabled,
 )
-from stashai.plugin.session_upload import spawn_self_upgrade, spawn_skills_sync
+from stashai.plugin.session_upload import spawn_skills_sync
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 
@@ -38,7 +38,6 @@ def main():
         pass
 
     spawn_skills_sync(cfg)
-    spawn_self_upgrade()
 
 
 if __name__ == "__main__":

--- a/plugins/opencode-plugin/scripts/on_session_start.py
+++ b/plugins/opencode-plugin/scripts/on_session_start.py
@@ -20,7 +20,7 @@ from stashai.plugin.hooks import (
     uploads_disabled_warning,
     uploads_enabled,
 )
-from stashai.plugin.session_upload import spawn_self_upgrade, spawn_skills_sync
+from stashai.plugin.session_upload import spawn_skills_sync
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 
@@ -63,7 +63,6 @@ def main():
         pass
 
     spawn_skills_sync(cfg)
-    spawn_self_upgrade()
 
 
 if __name__ == "__main__":

--- a/plugins/tests/test_event_queue.py
+++ b/plugins/tests/test_event_queue.py
@@ -44,6 +44,9 @@ class _Recorder:
             status_code = status
             is_success = status < 400
             text = "<!DOCTYPE html><title>Blocked</title>" if edge_blocked else "simulated error"
+            # Real responses carry the release header the client reads on
+            # every request (stashai/self_upgrade.py).
+            headers: dict[str, str] = {}
 
             def json(self_inner):
                 if edge_blocked:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.364"
+version = "0.1.366"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/stashai/plugin/_session_watcher.py
+++ b/stashai/plugin/_session_watcher.py
@@ -56,6 +56,13 @@ def _state_transcript_path(data_dir: str) -> str:
 
 
 def main() -> None:
+    # This process outlives the agent session it watches, so it must never
+    # swap the package out from under itself; short-lived commands and hooks
+    # carry the upgrade instead.
+    from stashai import self_upgrade
+
+    self_upgrade.disable()
+
     (
         _,
         agent_pid_str,

--- a/stashai/plugin/assets/codex/README.md
+++ b/stashai/plugin/assets/codex/README.md
@@ -30,11 +30,11 @@ then.
 
 ## Auto-update
 
-On session start, if no preference is recorded, the plugin asks (via a
-`systemMessage` to the agent) whether Stash may update itself automatically.
-Record the choice with `stash hook auto-update on|off`; it is stored as
-`codex_auto_update` in `~/.stash/config.json`. Manual upgrades stay available
-via `stash upgrade`.
+The CLI keeps itself current: every API response names the release the backend
+expects, and an older install upgrades itself in the background (never mid-run —
+the upgrade is detached, so the running command finishes on the version it
+started with). Nothing to configure, here or anywhere else. `stash upgrade`
+still forces it immediately.
 
 ## Commands
 

--- a/stashai/plugin/assets/codex/scripts/on_session_start.py
+++ b/stashai/plugin/assets/codex/scripts/on_session_start.py
@@ -3,13 +3,10 @@
 
 import json
 import os
-import shutil
-import subprocess
 
 from adapt import adapt_session_start
 from config import DATA_DIR, get_client, get_config, get_stdin_data
 
-from stashai.plugin.agent_config import cli_config
 from stashai.plugin.hooks import (
     color_upload_health_warning,
     create_session_record,
@@ -19,30 +16,6 @@ from stashai.plugin.hooks import (
 )
 from stashai.plugin.session_upload import spawn_session_watcher, spawn_skills_sync
 from stashai.plugin.state import load_state, reset_stats, save_state
-
-_ASK_AUTO_UPDATE = (
-    "Stash: Codex auto-update isn't configured yet. Ask the user whether Stash "
-    "should update itself automatically at session start. Pros: the hook runtime "
-    "stays current with the Stash backend. Cons: the stash CLI can change under "
-    "you mid-project. Record the answer by running `stash hook auto-update on` "
-    "or `stash hook auto-update off`."
-)
-
-
-def _auto_update_message() -> str | None:
-    """Returns the ask-the-user prompt until a preference is recorded; when
-    auto-update is on, kicks off the background upgrade instead."""
-    pref = cli_config().get("codex_auto_update")
-    if pref is None:
-        return _ASK_AUTO_UPDATE
-    if pref and shutil.which("uv"):
-        subprocess.Popen(
-            ["uv", "tool", "install", "--quiet", "stashai@latest"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,
-        )
-    return None
 
 
 def main():
@@ -81,10 +54,6 @@ def main():
             session_row_id=state.get("session_row_id", ""),
             transcript_path=event.transcript_path,
         )
-
-    message = _auto_update_message()
-    if message:
-        print(json.dumps({"systemMessage": message}))
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/cursor/scripts/on_session_start.py
+++ b/stashai/plugin/assets/cursor/scripts/on_session_start.py
@@ -11,7 +11,6 @@ from stashai.plugin.hooks import (
     uploads_disabled_warning,
     uploads_enabled,
 )
-from stashai.plugin.session_upload import spawn_self_upgrade
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 
@@ -36,8 +35,6 @@ def main():
             create_session_record(client, cfg, state, event, DATA_DIR)
     except Exception:
         pass
-
-    spawn_self_upgrade()
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/gemini/scripts/on_session_start.py
+++ b/stashai/plugin/assets/gemini/scripts/on_session_start.py
@@ -11,7 +11,7 @@ from stashai.plugin.hooks import (
     uploads_disabled_warning,
     uploads_enabled,
 )
-from stashai.plugin.session_upload import spawn_self_upgrade, spawn_skills_sync
+from stashai.plugin.session_upload import spawn_skills_sync
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 
@@ -38,7 +38,6 @@ def main():
         pass
 
     spawn_skills_sync(cfg)
-    spawn_self_upgrade()
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/hermes/scripts/on_session_start.py
+++ b/stashai/plugin/assets/hermes/scripts/on_session_start.py
@@ -17,7 +17,7 @@ from stashai.plugin.hooks import (
     uploads_disabled_warning,
     uploads_enabled,
 )
-from stashai.plugin.session_upload import spawn_self_upgrade, spawn_skills_sync
+from stashai.plugin.session_upload import spawn_skills_sync
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 
@@ -44,7 +44,6 @@ def main():
         pass
 
     spawn_skills_sync(cfg)
-    spawn_self_upgrade()
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/openclaw/scripts/on_session_start.py
+++ b/stashai/plugin/assets/openclaw/scripts/on_session_start.py
@@ -11,7 +11,7 @@ from stashai.plugin.hooks import (
     uploads_disabled_warning,
     uploads_enabled,
 )
-from stashai.plugin.session_upload import spawn_self_upgrade, spawn_skills_sync
+from stashai.plugin.session_upload import spawn_skills_sync
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 
@@ -38,7 +38,6 @@ def main():
         pass
 
     spawn_skills_sync(cfg)
-    spawn_self_upgrade()
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/opencode/scripts/on_session_start.py
+++ b/stashai/plugin/assets/opencode/scripts/on_session_start.py
@@ -20,7 +20,7 @@ from stashai.plugin.hooks import (
     uploads_disabled_warning,
     uploads_enabled,
 )
-from stashai.plugin.session_upload import spawn_self_upgrade, spawn_skills_sync
+from stashai.plugin.session_upload import spawn_skills_sync
 from stashai.plugin.state import load_state, reset_stats, save_state
 
 
@@ -63,7 +63,6 @@ def main():
         pass
 
     spawn_skills_sync(cfg)
-    spawn_self_upgrade()
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/session_upload.py
+++ b/stashai/plugin/session_upload.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -55,23 +54,6 @@ def spawn_skills_sync(cfg: dict) -> None:
         )
     except Exception:
         pass
-
-
-def spawn_self_upgrade() -> None:
-    """Background-upgrade the stashai install at session start. The hook
-    scripts ship inside the package (`stash hook run` executes them), so
-    upgrading the package keeps library and scripts current in lockstep.
-    Detached and silent — an upgrade must never block or break a session."""
-    if not shutil.which("uv"):
-        return
-    subprocess.Popen(
-        ["uv", "tool", "install", "--quiet", "stashai@latest"],
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
-        close_fds=True,
-    )
 
 
 def spawn_session_watcher(

--- a/stashai/plugin/stash_client.py
+++ b/stashai/plugin/stash_client.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import httpx
 from filelock import FileLock
 
+from stashai import self_upgrade
 from stashai.plugin.upload_status import (
     record_upload_attempt,
     record_upload_failure,
@@ -117,6 +118,7 @@ class StashClient:
         headers = kwargs.pop("headers", {})
         headers.update(self._headers())
         resp = self._http.request(method, path, headers=headers, **kwargs)
+        self_upgrade.note_latest(resp.headers.get(self_upgrade.LATEST_VERSION_HEADER, ""))
         if not resp.is_success:
             try:
                 payload = resp.json()

--- a/stashai/self_upgrade.py
+++ b/stashai/self_upgrade.py
@@ -1,0 +1,201 @@
+"""Keep the running `stash` install current without the user thinking about it.
+
+Freshness used to depend entirely on a chain outside the CLI: an agent plugin
+had to be installed, its session-start hook had to fire, uv had to be findable
+from that hook's PATH, and the copy uv upgraded had to be the copy the user
+actually runs. Every link failed silently, and the CLI itself had no idea what
+version it was supposed to be — so an install could sit 30 releases behind for
+weeks while its hooks fired thousands of times a day, and the user hit bugs
+fixed a fortnight earlier.
+
+Now the CLI settles it itself. Every API response carries the release the
+backend expects (X-Stash-Cli-Latest); when the running install is older, we
+upgrade *that* install — resolved from sys.executable rather than assumed to be
+uv's — in a detached process, and say so in one line. That covers a bare
+terminal, every agent harness, and the case where PATH resolves to a different
+copy than the one uv manages.
+
+An editable checkout (`uv pip install -e .`) is never upgraded: its version is
+the developer's business, and clobbering it would delete their work. It gets
+the notice and nothing else.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from functools import lru_cache
+from importlib.metadata import distribution, version
+from pathlib import Path
+
+LATEST_VERSION_HEADER = "X-Stash-Cli-Latest"
+
+_STAMP_PATH = Path.home() / ".stash" / "upgrade_attempt.json"
+
+# One attempt per hour per release. The normal case needs no throttle at all —
+# the upgrade lands and the next run is current — so this only bounds the
+# broken case (no uv, no network, read-only install) to something that can't
+# storm. A newly published release retries immediately regardless of the clock.
+_THROTTLE_SECONDS = 3600
+
+_INSTALLER = "curl -LsSf https://joinstash.ai/install.sh | sh"
+
+_enabled = True
+
+
+def disable() -> None:
+    """Turn self-upgrade off for this process. For long-lived processes only
+    (the session watcher): replacing the environment under an interpreter that
+    imports lazily for the next several hours is how you get an ImportError
+    halfway through someone's session."""
+    global _enabled
+    _enabled = False
+
+
+@lru_cache(maxsize=1)
+def current_version() -> str:
+    """Cached: this runs on every API response, and a process cannot change the
+    version it is running."""
+    return version("stashai")
+
+
+def note_latest(latest: str) -> None:
+    """Handle the release header from an API response. Cheap and silent in the
+    common case: a current install compares two strings and returns."""
+    if not _enabled or not latest:
+        return
+    current = current_version()
+    if not _is_older(current, latest):
+        return
+    if not _claim_attempt(latest):
+        return
+    _upgrade(current, latest)
+
+
+def _is_older(have: str, want: str) -> bool:
+    return _parts(have) < _parts(want)
+
+
+def _parts(release: str) -> tuple[int, ...]:
+    """Dotted release as a comparable tuple. Non-numeric trailers ('.dev0',
+    '+local') drop out, so a locally built wheel compares on its release
+    numbers instead of raising mid-request."""
+    return tuple(int(part) for part in release.split(".") if part.isdigit())
+
+
+def _claim_attempt(latest: str) -> bool:
+    """True when this process should attempt the upgrade now. Writing the stamp
+    before spawning means a failed attempt still counts — the throttle exists to
+    bound failure, not success."""
+    stamp = _read_stamp()
+    attempted_at = stamp.get("at", 0) if stamp.get("version") == latest else 0
+    if time.time() - attempted_at < _THROTTLE_SECONDS:
+        return False
+    _STAMP_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _STAMP_PATH.write_text(json.dumps({"version": latest, "at": time.time()}))
+    return True
+
+
+def _read_stamp() -> dict:
+    """The last attempt we made. A missing or unreadable file means we have
+    never attempted this release, which is the state we want to act on."""
+    if not _STAMP_PATH.is_file():
+        return {}
+    try:
+        return json.loads(_STAMP_PATH.read_text())
+    except (OSError, ValueError):
+        return {}
+
+
+def _upgrade(current: str, latest: str) -> None:
+    if _is_editable():
+        _say(
+            f"this checkout is {current}; the current release is {latest}. "
+            "Editable installs are left alone — `git pull` when you want the fix."
+        )
+        return
+
+    command = _upgrade_command()
+    if command is None:
+        _say(
+            f"{current} is behind {latest}, but uv is not installed so the "
+            f"upgrade can't run. Reinstall with: {_INSTALLER}"
+        )
+        return
+
+    # All three fds are detached: a background process holding the hook's
+    # stdout keeps the agent waiting on that pipe for the whole upgrade.
+    try:
+        subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except OSError as e:
+        # Spawning can genuinely fail on a user's machine (binary removed
+        # mid-flight, noexec mount). Say so rather than leave them wondering
+        # why the version never moves.
+        _say(f"{current} is behind {latest} and the upgrade could not start ({e}).")
+        return
+    _say(f"upgrading {current} → {latest} in the background; this run used {current}.")
+
+
+def _upgrade_command() -> list[str] | None:
+    """How to upgrade *this* install. The kind is decided by where the running
+    interpreter lives, so a pip install under pyenv is upgraded by that pip
+    instead of by uv quietly refreshing a copy nobody runs."""
+    if _is_uv_tool():
+        uv = _find_uv()
+        return [uv, "tool", "install", "--quiet", "stashai@latest"] if uv else None
+    return [sys.executable, "-m", "pip", "install", "--quiet", "--upgrade", "stashai"]
+
+
+def _is_uv_tool() -> bool:
+    """uv drops a receipt in every tool environment it creates.
+
+    Recognising the environment by its path shape instead looks fine on a
+    default install and breaks the moment UV_TOOL_DIR is set — sending a uv
+    install down the pip branch, where a uv environment has no pip and the
+    upgrade fails in a detached process nobody can see. The receipt is a fact
+    about this install rather than a guess about its layout."""
+    return (Path(sys.prefix) / "uv-receipt.toml").is_file()
+
+
+def _is_editable() -> bool:
+    """PEP 610 records how a distribution was installed; `pip install -e .`
+    writes dir_info.editable."""
+    raw = distribution("stashai").read_text("direct_url.json")
+    if raw is None:
+        return False
+    return bool(json.loads(raw).get("dir_info", {}).get("editable"))
+
+
+def _find_uv() -> str | None:
+    """uv, whether or not it is on this process's PATH. Agent hooks run with a
+    minimal PATH, which is how the previous upgrade path silently did nothing
+    for anyone whose uv came from Homebrew."""
+    found = shutil.which("uv")
+    if found:
+        return found
+    candidates = [
+        Path.home() / ".local/bin/uv",
+        Path.home() / ".cargo/bin/uv",
+        Path("/opt/homebrew/bin/uv"),
+        Path("/usr/local/bin/uv"),
+    ]
+    for candidate in candidates:
+        if os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
+
+
+def _say(message: str) -> None:
+    """stderr, always: hook stdout carries the JSON payload the agent parses."""
+    print(f"stash: {message}", file=sys.stderr)

--- a/stashai/self_upgrade.py
+++ b/stashai/self_upgrade.py
@@ -22,15 +22,19 @@ the notice and nothing else.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import shutil
 import subprocess
 import sys
+import sysconfig
 import time
 from functools import lru_cache
 from importlib.metadata import distribution, version
 from pathlib import Path
+
+from filelock import FileLock, Timeout
 
 LATEST_VERSION_HEADER = "X-Stash-Cli-Latest"
 
@@ -42,9 +46,11 @@ _STAMP_PATH = Path.home() / ".stash" / "upgrade_attempt.json"
 # storm. A newly published release retries immediately regardless of the clock.
 _THROTTLE_SECONDS = 3600
 
-_INSTALLER = "curl -LsSf https://joinstash.ai/install.sh | sh"
+_INSTALLER = 'bash -c "$(curl -fsSL https://joinstash.ai/install)"'
 
 _enabled = True
+
+_warned_stamp_unwritable = False
 
 
 def disable() -> None:
@@ -90,40 +96,65 @@ def _parts(release: str) -> tuple[int, ...]:
 def _claim_attempt(latest: str) -> bool:
     """True when this process should attempt the upgrade now. Writing the stamp
     before spawning means a failed attempt still counts — the throttle exists to
-    bound failure, not success."""
-    stamp = _read_stamp()
-    attempted_at = stamp.get("at", 0) if stamp.get("version") == latest else 0
-    if time.time() - attempted_at < _THROTTLE_SECONDS:
-        return False
-    _STAMP_PATH.parent.mkdir(parents=True, exist_ok=True)
-    _STAMP_PATH.write_text(json.dumps({"version": latest, "at": time.time()}))
-    return True
-
-
-def _read_stamp() -> dict:
-    """The last attempt we made. A missing or unreadable file means we have
-    never attempted this release, which is the state we want to act on."""
-    if not _STAMP_PATH.is_file():
-        return {}
+    bound failure, not success. The lock keeps a burst of concurrent hook
+    processes from all claiming the same release at once."""
     try:
-        return json.loads(_STAMP_PATH.read_text())
-    except (OSError, ValueError):
-        return {}
+        _STAMP_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with FileLock(str(_STAMP_PATH) + ".lock", timeout=1):
+            stamped_version, attempted_at = _read_stamp()
+            # Only a release *newer* than the stamped one retries immediately.
+            # Merely different is not enough: a rolling deploy alternates old
+            # and new headers for minutes, and treating each flip as a fresh
+            # release would defeat the throttle for the whole window.
+            if _is_older(stamped_version, latest):
+                attempted_at = 0.0
+            if time.time() - attempted_at < _THROTTLE_SECONDS:
+                return False
+            _STAMP_PATH.write_text(json.dumps({"version": latest, "at": time.time()}))
+            return True
+    except Timeout:
+        # A sibling process holds the lock, so it is making this attempt.
+        return False
+    except OSError:
+        # This rides on every API response, so an unwritable ~/.stash
+        # (root-owned install, full disk) must not turn successful requests
+        # into crashes. Without the stamp the throttle can't engage, so the
+        # only storm-proof move is to not attempt — and say so once.
+        global _warned_stamp_unwritable
+        if not _warned_stamp_unwritable:
+            _warned_stamp_unwritable = True
+            _say(
+                f"a newer release exists but {_STAMP_PATH.parent} is not "
+                "writable, so self-upgrade is off. Fix its permissions to resume."
+            )
+        return False
+
+
+def _read_stamp() -> tuple[str, float]:
+    """The last attempt we made, as (version, at). A missing, unreadable, or
+    corrupt file reads as never-attempted — the state we want to act on."""
+    if not _STAMP_PATH.is_file():
+        return "", 0.0
+    try:
+        stamp = json.loads(_STAMP_PATH.read_text())
+        return str(stamp.get("version", "")), float(stamp.get("at", 0))
+    except (OSError, ValueError, AttributeError, TypeError):
+        return "", 0.0
 
 
 def _upgrade(current: str, latest: str) -> None:
-    if _is_editable():
+    if is_editable():
         _say(
             f"this checkout is {current}; the current release is {latest}. "
             "Editable installs are left alone — `git pull` when you want the fix."
         )
         return
 
-    command = _upgrade_command()
+    command = upgrade_command()
     if command is None:
         _say(
-            f"{current} is behind {latest}, but uv is not installed so the "
-            f"upgrade can't run. Reinstall with: {_INSTALLER}"
+            f"{current} is behind {latest}, but this install has no working "
+            f"upgrader (no uv, no pip). Reinstall with: {_INSTALLER}"
         )
         return
 
@@ -147,14 +178,36 @@ def _upgrade(current: str, latest: str) -> None:
     _say(f"upgrading {current} → {latest} in the background; this run used {current}.")
 
 
-def _upgrade_command() -> list[str] | None:
-    """How to upgrade *this* install. The kind is decided by where the running
-    interpreter lives, so a pip install under pyenv is upgraded by that pip
-    instead of by uv quietly refreshing a copy nobody runs."""
+def upgrade_command() -> list[str] | None:
+    """How to upgrade *this* install, or None when it has no working upgrader.
+    The kind is decided by where the running interpreter lives, so a pip
+    install under pyenv is upgraded by that pip instead of by uv quietly
+    refreshing a copy nobody runs. Also `stash upgrade`'s command, so the
+    manual and automatic paths cannot drift apart."""
     if _is_uv_tool():
         uv = _find_uv()
         return [uv, "tool", "install", "--quiet", "stashai@latest"] if uv else None
-    return [sys.executable, "-m", "pip", "install", "--quiet", "--upgrade", "stashai"]
+    if not _has_pip():
+        # uv venvs ship without pip; `python -m pip` there dies unseen in the
+        # detached child while the notice claims the upgrade is running.
+        return None
+    command = [sys.executable, "-m", "pip", "install", "--quiet", "--upgrade", "stashai"]
+    if _is_externally_managed():
+        # PEP 668 pythons (Debian's, the Fly Sprites we provision) refuse
+        # plain installs; these are the flags our own sprite setup uses
+        # (backend/services/sprite_service.py).
+        command += ["--user", "--break-system-packages"]
+    return command
+
+
+def _has_pip() -> bool:
+    return importlib.util.find_spec("pip") is not None
+
+
+def _is_externally_managed() -> bool:
+    """The PEP 668 marker: this python's distributor forbids installing into
+    it without an explicit override."""
+    return (Path(sysconfig.get_path("stdlib")) / "EXTERNALLY-MANAGED").is_file()
 
 
 def _is_uv_tool() -> bool:
@@ -168,7 +221,7 @@ def _is_uv_tool() -> bool:
     return (Path(sys.prefix) / "uv-receipt.toml").is_file()
 
 
-def _is_editable() -> bool:
+def is_editable() -> bool:
     """PEP 610 records how a distribution was installed; `pip install -e .`
     writes dir_info.editable."""
     raw = distribution("stashai").read_text("direct_url.json")


### PR DESCRIPTION
Sam ran `stash upload` on a two-week-old CLI and hit a directory-upload bug they had personally fixed 30 releases earlier — `.html` inside a folder upload posted as markdown, so the deck rendered as escaped source. The fix shipped to PyPI on July 27. Their machine never got it.

Not for want of trying: ~4,900 sessions in 14 days means the Claude plugin's SessionStart hook spawned `uv tool install stashai@latest` thousands of times. Freshness depended on a chain entirely outside the CLI — plugin installed → hook fires → uv findable from the hook's minimal PATH → the copy uv upgrades is the copy on PATH — where every link fails silently. And the CLI had no idea what version it was supposed to be: `__version__` was printed, never compared, never reported to the server. Nobody could see the problem, us included.

## What changes

**The CLI settles it itself.** Every API response carries the release the backend expects (`X-Stash-Cli-Latest`, read from the repo's pyproject version — the same number `publish.yml` ships to PyPI). A CLI that finds itself behind upgrades in the background and says so in one line. It rides on traffic clients already make: no extra request, no PyPI dependency, no hook required, works in a bare terminal and in every harness — including ones we haven't written a plugin for.

**Which install gets upgraded is a fact, not an assumption.** The kind is read off the running interpreter: a uv tool environment by the receipt uv leaves in it, anything else by `sys.executable`. A pip install under pyenv is upgraded by its own pip instead of uv refreshing a copy nobody runs — the likeliest reason Sam's upgrades landed nowhere. An editable checkout is never touched; it gets the notice and keeps its code.

Upgrades are always detached and always at process start, so a running command finishes on the version it started with.

**Same failure, also closed:**

- Codex's auto-update was opt-in behind a question the agent had to ask and a `stash hook auto-update` command nobody ran, while every other harness upgraded automatically. Nothing to configure anywhere now; the config key, command, and prompt are gone.
- `ensure_cli.sh` searched for uv on the hook's PATH and `~/.local/bin` only — a Homebrew uv meant it silently upgraded nothing. It now checks the usual locations, and stays as the bootstrap for CLIs too old to have this change.
- `spawn_self_upgrade()` and its five call sites are deleted. The CLI covers those harnesses now, and two upgrade paths is one too many.
- The session watcher opts out: it outlives the session it watches, and swapping the package under a process that imports lazily for hours is an ImportError waiting to happen.

**Visibility.** CLI telemetry reports the running version, so "how many users are on stale code?" is a SQL query instead of a two-hour investigation.

## Testing

- `cli/tests/test_self_upgrade.py` — stale acts, current doesn't, pip installs are upgraded by their own interpreter, editable checkouts are left alone, a missing uv is reported rather than swallowed, one attempt per hour per release, a new release retries immediately.
- `cli/tests/test_release_header_wire.py` — both HTTP clients read the header; a backend that sends none says nothing.
- `backend/tests/test_cli_release_header.py` — the header rides every response including 401s, and matches the published version.
- Full suites green: 417 CLI + plugin, 1367 backend, ruff clean.

**End-to-end against a stub backend claiming release 99.9.9**: a real uv tool install spawns `uv tool install --quiet stashai@latest` and prints the notice; an editable checkout prints and spawns nothing. That run is what caught the first version of the install-kind check, which recognised uv by the shape of `sys.prefix` and broke the moment `UV_TOOL_DIR` was set — sending uv installs down the pip branch, where a uv environment has no pip and the upgrade would have died unseen. Exactly the class of silent failure this replaces.

## Note for deploy

`backend/Dockerfile` now copies `pyproject.toml`; `backend/cli_release.py` raises at import without it, so a backend that can't name the current release fails loudly at boot rather than silently stranding the fleet.

## Still worth doing separately

Server-side routing so a page named `*.html` is an HTML page — the same rule `detect_page_kind` already applies at ingest. Old clients exist in the wild regardless of how good the upgrade path gets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every API response header and runs detached package upgrades on client machines; misconfigured pyproject version or header logic could strand or over-upgrade the fleet, though import-time validation and throttling mitigate this.
> 
> **Overview**
> Adds **fleet-wide CLI freshness** without relying on agent hooks. The backend reads `pyproject.toml` at import (`backend/cli_release.py`), rejects non–plain-dotted versions, and sets **`X-Stash-Cli-Latest`** on every HTTP response (including errors). The Docker image now copies `pyproject.toml` so that value is available in production.
> 
> Introduces **`stashai/self_upgrade.py`**: both HTTP clients call `note_latest` on each response; when the running install is older, it spawns a **detached** uv or pip upgrade of *this* interpreter (uv receipt detection, PEP 668 flags, editable skip, hourly throttle). Long-lived entry points call **`self_upgrade.disable()`** so upgrades do not run mid-stream (MCP, agent chat/watch/run, session watcher). **`stash upgrade`** and telemetry now use the same upgrade logic and report **`version`**.
> 
> **Removes** Codex `hook auto-update`, `codex_auto_update` config, **`spawn_self_upgrade()`** from session-start hooks, and narrows Claude **`ensure_cli.sh`** to pre–self-upgrade CLIs only (broader uv discovery). Package version bumps to **0.1.366** with focused backend/CLI tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fba034850d452edd9a2075a095b16c3f7592687f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->