### PR TITLE
Files is a flat searchable table, not a filesystem

### DIFF
--- a/backend/routers/user_knowledge.py
+++ b/backend/routers/user_knowledge.py
@@ -29,7 +29,7 @@ from ..services import (
 
 router = APIRouter(prefix="/api/v1/me", tags=["me"])
 
-SIDEBAR_ETAG_VERSION = "sidebar-skill-folders-v4"
+SIDEBAR_ETAG_VERSION = "sidebar-page-agent-v5"
 
 
 # ---------------------------------------------------------------------------
@@ -84,7 +84,8 @@ async def _files_tree(owner_user_id: UUID, user_id: UUID) -> dict:
             user_id,
         ),
         pool.fetch(
-            "SELECT p.id, p.name, p.content_type, p.folder_id, p.created_at, p.updated_at "
+            "SELECT p.id, p.name, p.content_type, p.folder_id, p.created_at, p.updated_at, "
+            "       p.last_edit_agent_name "
             "FROM pages p "
             f"WHERE p.owner_user_id = $1 AND p.deleted_at IS NULL AND {readable_page} "
             "ORDER BY p.name",
@@ -129,6 +130,7 @@ async def _files_tree(owner_user_id: UUID, user_id: UUID) -> dict:
                 "folder_id": str(r["folder_id"]) if r["folder_id"] else None,
                 "created_at": r["created_at"],
                 "updated_at": r["updated_at"],
+                "last_edit_agent_name": r["last_edit_agent_name"],
             }
             for r in page_rows
         ],

--- a/frontend/src/app/(app)/f/[fileId]/FileClient.tsx
+++ b/frontend/src/app/(app)/f/[fileId]/FileClient.tsx
@@ -246,7 +246,6 @@ function FileViewerPageInner({ fileId }: { fileId: string }) {
         <FileViewerHeader
           icon={<KindGlyph contentType={file?.content_type ?? ""} name={file?.name ?? ""} />}
           iconColor={kindIconColor(file?.content_type ?? "")}
-          breadcrumbs={ancestorCrumbs}
           title={file?.name ?? "File"}
           onRenameTitle={
             file

--- a/frontend/src/app/(app)/files/page.tsx
+++ b/frontend/src/app/(app)/files/page.tsx
@@ -4,14 +4,14 @@ import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
 import { FileBrowserSkeleton } from "@/components/SkeletonStates";
-import FilesOverview from "@/components/content/files-overview/FilesOverview";
+import FlatFilesPage from "@/components/content/flat-files/FlatFilesPage";
 import { useAuth } from "@/hooks/useAuth";
 
 export default function FilesPage() {
   const router = useRouter();
   const { user, loading } = useAuth();
 
-  useBreadcrumbs([{ label: "VFS" }], "files");
+  useBreadcrumbs([{ label: "Files" }], "files");
 
   useEffect(() => {
     if (!loading && !user) router.push("/login");
@@ -20,5 +20,5 @@ export default function FilesPage() {
   if (loading) return <FileBrowserSkeleton />;
   if (!user) return null;
 
-  return <FilesOverview />;
+  return <FlatFilesPage />;
 }

--- a/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
+++ b/frontend/src/app/(app)/p/[pageId]/PageClient.tsx
@@ -622,7 +622,6 @@ export default function SkillPageView({ pageId }: { pageId: string }) {
       <FileViewerHeader
         icon={isHtml ? <HtmlGlyph /> : <PageGlyph />}
         iconColor={isHtml ? "var(--color-brand-600)" : "var(--text-muted)"}
-        breadcrumbs={ancestorCrumbs}
         title={baseName}
         onRenameTitle={
           page

--- a/frontend/src/components/CommandPalette.test.tsx
+++ b/frontend/src/components/CommandPalette.test.tsx
@@ -57,6 +57,8 @@ const sidebar = {
         name: "Launch Roadmap.md",
         content_type: "markdown" as const,
         folder_id: null,
+        updated_at: "2026-01-01T00:00:00Z",
+        last_edit_agent_name: null,
       },
     ],
     files: [],

--- a/frontend/src/components/content/FileViewerHeader.tsx
+++ b/frontend/src/components/content/FileViewerHeader.tsx
@@ -13,11 +13,6 @@ interface BackLink {
   href: string;
 }
 
-interface Breadcrumb {
-  label: string;
-  href: string;
-}
-
 interface Tag {
   label: string;
   tone?: "brand" | "muted";
@@ -38,9 +33,6 @@ interface FileViewerHeaderProps {
   readOnlyLabel?: string;
   /** Back link rendered above the title (e.g. "← Demo Skill"). */
   backLink?: BackLink;
-  /** Ancestor trail rendered before the title in the compact bar
-   *  (e.g. Files / Research / — the title itself is the last crumb). */
-  breadcrumbs?: Breadcrumb[];
   /** Small label chips before the meta items. */
   tags?: Tag[];
   /**
@@ -74,7 +66,6 @@ export default function FileViewerHeader({
   readOnly,
   readOnlyLabel = "read-only",
   backLink,
-  breadcrumbs,
   tags,
   meta,
   saveStatus,
@@ -96,12 +87,6 @@ export default function FileViewerHeader({
           <span className="text-muted-foreground/50">/</span>
         </span>
       )}
-      {breadcrumbs?.map((crumb) => (
-        <span key={crumb.href} className="hidden shrink-0 items-center gap-2.5 text-[12.5px] text-muted-foreground sm:inline-flex">
-          <Link href={crumb.href} className="max-w-[160px] truncate hover:text-foreground">{crumb.label}</Link>
-          <span className="text-muted-foreground/50">/</span>
-        </span>
-      ))}
       <span className="min-w-0 shrink truncate text-[13.5px] font-semibold text-foreground">
         {readOnly || !onRenameTitle ? title : <EditableTitle value={title} onSave={onRenameTitle} />}
       </span>

--- a/frontend/src/components/content/files-overview/FilesOverview.test.tsx
+++ b/frontend/src/components/content/files-overview/FilesOverview.test.tsx
@@ -42,7 +42,7 @@ function sidebar() {
       // 12 pages inside Research: enough to trip the per-directory cap.
       pages: Array.from({ length: 12 }, (_, i) => ({
         id: `p${i}`, name: `Page ${String(i).padStart(2, "0")}`,
-        content_type: "markdown" as const, folder_id: "root-1",
+        content_type: "markdown" as const, folder_id: "root-1", updated_at: "2026-01-01T00:00:00Z", last_edit_agent_name: null,
       })),
       files: [],
     },

--- a/frontend/src/components/content/files-overview/build.test.ts
+++ b/frontend/src/components/content/files-overview/build.test.ts
@@ -25,8 +25,8 @@ const tree: FilesTree = {
     { id: "m1", name: "People", parent_folder_id: MEMORY_ID, page_count: 2, file_count: 0 },
   ],
   pages: [
-    { id: "p1", name: "Notes", content_type: "markdown", folder_id: "a" },
-    { id: "p2", name: "Root page", content_type: "markdown", folder_id: null },
+    { id: "p1", name: "Notes", content_type: "markdown", folder_id: "a", updated_at: "2026-01-01T00:00:00Z", last_edit_agent_name: null },
+    { id: "p2", name: "Root page", content_type: "markdown", folder_id: null, updated_at: "2026-01-01T00:00:00Z", last_edit_agent_name: null },
   ],
   files: [
     {

--- a/frontend/src/components/content/flat-files/FlatFilesPage.tsx
+++ b/frontend/src/components/content/flat-files/FlatFilesPage.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+// Experimental full-screen VFS: no tree, no folders — one reverse-chron table
+// of everything in the stash. The search input is the topbar's search bar
+// (topbar.tsx renders it on /files and writes to the shared store); this page
+// renders the filtered results. Arrows move, Enter opens.
+
+import Link from "next/link";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowUpRight } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { timeAgo } from "@/components/content/files-overview/build";
+import { useFilesSearch } from "./search-store";
+import { FlatItemIcon, filterItems, useFlatItems, type FlatItem, type FlatKind } from "./useFlatItems";
+
+const PAGE_SIZE = 100;
+
+const KINDS: { kind: FlatKind; label: string }[] = [
+  { kind: "page", label: "Pages" },
+  { kind: "file", label: "Files" },
+  { kind: "table", label: "Tables" },
+  { kind: "session", label: "Sessions" },
+  { kind: "skill", label: "Skills" },
+];
+
+// One shared grid so the header and every row line up as table columns.
+const COLUMNS =
+  "grid grid-cols-[minmax(0,3fr)_80px_minmax(0,1.2fr)_minmax(0,1fr)_80px] items-center gap-x-4";
+
+const KIND_NAME: Record<FlatKind, string> = {
+  page: "Page",
+  file: "File",
+  table: "Table",
+  session: "Session",
+  skill: "Skill",
+};
+
+type SortKey = "name" | "type" | "folder" | "agent" | "modified";
+type Sort = { key: SortKey; dir: "asc" | "desc" };
+
+// Modified-desc is what the list already arrives in, and doubles as "default":
+// while searching under the default sort, relevance ranking wins instead.
+const DEFAULT_SORT: Sort = { key: "modified", dir: "desc" };
+
+function compareBy(key: SortKey, a: FlatItem, b: FlatItem): number {
+  if (key === "modified") return +new Date(a.updatedAt) - +new Date(b.updatedAt);
+  if (key === "name") return a.name.localeCompare(b.name);
+  if (key === "type") return KIND_NAME[a.kind].localeCompare(KIND_NAME[b.kind]);
+  if (key === "folder") return (a.context ?? "").localeCompare(b.context ?? "");
+  return (a.agent ?? "").localeCompare(b.agent ?? "");
+}
+
+function HeaderCell({
+  label,
+  sortKey,
+  sort,
+  onSort,
+  right,
+}: {
+  label: string;
+  sortKey: SortKey;
+  sort: Sort;
+  onSort: (key: SortKey) => void;
+  right?: boolean;
+}) {
+  const active = sort.key === sortKey;
+  return (
+    <button
+      type="button"
+      onClick={() => onSort(sortKey)}
+      className={cn(
+        "flex items-center gap-1 font-mono text-[10.5px] uppercase tracking-wide",
+        right && "justify-end",
+        active ? "text-foreground" : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {label}
+      <span className={cn("w-2", !active && "invisible")}>{sort.dir === "asc" ? "↑" : "↓"}</span>
+    </button>
+  );
+}
+
+function Chip({ active, label, onClick }: { active: boolean; label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-full border px-2.5 py-0.5 text-[12px]",
+        active
+          ? "border-brand-500/40 bg-brand-500/10 text-brand-700"
+          : "border-border text-muted-foreground hover:bg-raised",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+export default function FlatFilesPage() {
+  const router = useRouter();
+  const { items, loaded, error } = useFlatItems();
+  const query = useFilesSearch((s) => s.query);
+  const [kind, setKind] = useState<FlatKind | "all">("all");
+  const [sort, setSort] = useState<Sort>(DEFAULT_SORT);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const [limit, setLimit] = useState(PAGE_SIZE);
+  // Only keyboard moves scroll the active row into view; mouse and initial
+  // renders must not yank the page around.
+  const keyed = useRef(false);
+
+  const ofKind = useMemo(
+    () => (kind === "all" ? items : items.filter((i) => i.kind === kind)),
+    [items, kind],
+  );
+  const searching = query.trim().length > 0;
+  const matches = useMemo(() => {
+    const filtered = filterItems(ofKind, query);
+    const isDefault = sort.key === DEFAULT_SORT.key && sort.dir === DEFAULT_SORT.dir;
+    // Relevance order survives only under the default sort; an explicit sort
+    // is a stronger statement than the ranker.
+    if (searching && isDefault) return filtered;
+    const sign = sort.dir === "asc" ? 1 : -1;
+    return [...filtered].sort((a, b) => sign * compareBy(sort.key, a, b));
+  }, [ofKind, query, searching, sort]);
+  const visible = matches.slice(0, limit);
+
+  function onSort(key: SortKey) {
+    setActiveIdx(0);
+    setSort((s) =>
+      s.key === key
+        ? { key, dir: s.dir === "asc" ? "desc" : "asc" }
+        : { key, dir: key === "modified" ? "desc" : "asc" },
+    );
+  }
+
+  // The topbar owns the input; leaving the page clears the shared query so a
+  // return visit starts with the full list.
+  useEffect(() => () => useFilesSearch.getState().setQuery(""), []);
+
+  useEffect(() => {
+    setActiveIdx(0);
+    setLimit(PAGE_SIZE);
+  }, [query]);
+
+  // Keyboard driving happens at window level: focus sits in the topbar input
+  // while the results live here.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (!searching || e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        keyed.current = true;
+        setActiveIdx((i) => Math.min(i + 1, visible.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        keyed.current = true;
+        setActiveIdx((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter" && visible[activeIdx]) {
+        router.push(visible[activeIdx].href);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [searching, visible, activeIdx, router]);
+
+  if (error) {
+    return <div className="p-6 font-mono text-[12px] text-error">✗ couldn&apos;t read the stash: {error}</div>;
+  }
+
+  return (
+    <div className="h-full overflow-y-auto bg-base">
+      <div className="mx-auto w-full max-w-5xl px-6 py-8">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Chip
+            active={kind === "all"}
+            label={`All ${items.length}`}
+            onClick={() => { setKind("all"); setActiveIdx(0); }}
+          />
+          {KINDS.map(({ kind: k, label }) => {
+            const count = items.filter((i) => i.kind === k).length;
+            if (count === 0) return null;
+            return (
+              <Chip
+                key={k}
+                active={kind === k}
+                label={`${label} ${count}`}
+                onClick={() => { setKind(k); setActiveIdx(0); }}
+              />
+            );
+          })}
+        </div>
+
+        <div className="mt-4">
+          {!loaded && (
+            <div className="space-y-3 py-2">
+              {Array.from({ length: 10 }, (_, i) => (
+                <Skeleton key={i} className="h-5" style={{ width: `${55 + (i % 4) * 12}%` }} />
+              ))}
+            </div>
+          )}
+
+          {loaded && matches.length === 0 && (
+            <div className="py-8 text-center font-mono text-[12px] text-muted-foreground">
+              {searching ? <>no matches for &ldquo;{query.trim()}&rdquo;</> : "nothing here yet"}
+            </div>
+          )}
+
+          {loaded && matches.length > 0 && (
+            <div className={cn("border-b border-border px-3 pb-1.5", COLUMNS)}>
+              <HeaderCell label="Name" sortKey="name" sort={sort} onSort={onSort} />
+              <HeaderCell label="Type" sortKey="type" sort={sort} onSort={onSort} />
+              <HeaderCell label="Folder" sortKey="folder" sort={sort} onSort={onSort} />
+              <HeaderCell label="Agent" sortKey="agent" sort={sort} onSort={onSort} />
+              <HeaderCell label="Modified" sortKey="modified" sort={sort} onSort={onSort} right />
+            </div>
+          )}
+
+          {visible.map((item, idx) => (
+            <Link
+              key={item.key}
+              href={item.href}
+              ref={
+                searching && idx === activeIdx
+                  ? (el) => {
+                      if (el && keyed.current) {
+                        keyed.current = false;
+                        el.scrollIntoView({ block: "nearest" });
+                      }
+                    }
+                  : undefined
+              }
+              onMouseMove={() => { if (searching) setActiveIdx(idx); }}
+              className={cn(
+                "rounded-md px-3 py-2",
+                COLUMNS,
+                searching && idx === activeIdx ? "bg-brand-500/10" : "hover:bg-raised",
+              )}
+            >
+              <span className="flex min-w-0 items-center gap-2">
+                <FlatItemIcon kind={item.kind} />
+                <span className="min-w-0 truncate text-[13.5px] text-foreground">{item.name}</span>
+                {item.annotation && (
+                  <span className="shrink-0 font-mono text-[10.5px] text-muted-foreground">{item.annotation}</span>
+                )}
+              </span>
+              <span className="truncate text-[12px] text-muted-foreground">{KIND_NAME[item.kind]}</span>
+              <span className="truncate text-[12px] text-muted-foreground">{item.context ?? "—"}</span>
+              <span className="truncate font-mono text-[11px] text-muted-foreground">{item.agent ?? "—"}</span>
+              <span className="text-right font-mono text-[11px] text-muted-foreground">{timeAgo(item.updatedAt)}</span>
+            </Link>
+          ))}
+
+          {matches.length > visible.length && (
+            <button
+              type="button"
+              onClick={() => setLimit((l) => l + 500)}
+              className="mt-1 flex w-full items-center gap-1 rounded-md px-3 py-1.5 text-left font-mono text-[11.5px] text-dim hover:bg-raised hover:text-brand-700"
+            >
+              … +{matches.length - visible.length} more
+            </button>
+          )}
+
+          {searching && (
+            <Link
+              href={`/search?q=${encodeURIComponent(query.trim())}`}
+              className="mt-2 flex items-center gap-1 rounded-md px-3 py-1.5 font-mono text-[11.5px] text-dim hover:bg-raised hover:text-brand-700"
+            >
+              search connected sources too <ArrowUpRight className="h-3 w-3" />
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/content/flat-files/search-store.ts
+++ b/frontend/src/components/content/flat-files/search-store.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+// The /files search query lives here because the input is the topbar's search
+// bar while the results render in the page below — one search, two components.
+interface FilesSearchState {
+  query: string;
+  setQuery: (query: string) => void;
+}
+
+export const useFilesSearch = create<FilesSearchState>((set) => ({
+  query: "",
+  setQuery: (query) => set({ query }),
+}));

--- a/frontend/src/components/content/flat-files/useFlatItems.tsx
+++ b/frontend/src/components/content/flat-files/useFlatItems.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+// The flat-list VFS experiment: the whole stash as one searchable,
+// reverse-chronological list — no hierarchy. Folder location survives only as
+// a dim context label on each row. Agents still get the real filesystem
+// through the CLI VFS; this is the human lens.
+
+import { useEffect, useState } from "react";
+import { GraduationCap, MessagesSquare } from "lucide-react";
+import {
+  getMemoryFolder,
+  getSidebar,
+  listSkills,
+  listTables,
+  type Sidebar,
+  type Skill,
+  type TreeFolder,
+} from "@/lib/api";
+import type { Table } from "@/lib/types";
+import { FileIcon, PageIcon, TableIcon } from "@/components/SkillIcons";
+import { humanSize } from "@/components/content/files-overview/build";
+
+export type FlatKind = "page" | "file" | "table" | "session" | "skill";
+
+export interface FlatItem {
+  key: string;
+  kind: FlatKind;
+  name: string;
+  href: string;
+  /** Where it lives, in words: the folder path. */
+  context?: string;
+  /** Agent it came from — the session's agent, or a page's last agent editor. */
+  agent?: string;
+  /** Dim mono note — "12 KB", "8 rows", "4 files". */
+  annotation?: string;
+  updatedAt: string;
+}
+
+export function FlatItemIcon({ kind }: { kind: FlatKind }) {
+  if (kind === "page") return <span className="shrink-0 text-muted-foreground"><PageIcon /></span>;
+  if (kind === "table") return <span className="shrink-0 text-muted-foreground"><TableIcon /></span>;
+  if (kind === "session") return <MessagesSquare className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />;
+  if (kind === "skill") return <GraduationCap className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />;
+  return <span className="shrink-0 text-muted-foreground"><FileIcon /></span>;
+}
+
+/** Full "A / B / C" location for every folder, in one pass. */
+function folderPaths(folders: TreeFolder[]): Map<string, string> {
+  const byId = new Map(folders.map((f) => [f.id, f]));
+  const paths = new Map<string, string>();
+  function pathOf(id: string): string {
+    const cached = paths.get(id);
+    if (cached) return cached;
+    const folder = byId.get(id);
+    // Parents can be invisible (skill subtrees, unreadable folders); the
+    // path then starts at the first visible ancestor.
+    if (!folder) return "";
+    const parent = folder.parent_folder_id ? pathOf(folder.parent_folder_id) : "";
+    const path = parent ? `${parent} / ${folder.name}` : folder.name;
+    paths.set(id, path);
+    return path;
+  }
+  folders.forEach((f) => pathOf(f.id));
+  return paths;
+}
+
+/** The memory folder and every folder under it. */
+function memorySubtree(folders: TreeFolder[], memoryFolderId: string): Set<string> {
+  const ids = new Set([memoryFolderId]);
+  let grew = true;
+  while (grew) {
+    grew = false;
+    for (const f of folders) {
+      if (f.parent_folder_id && ids.has(f.parent_folder_id) && !ids.has(f.id)) {
+        ids.add(f.id);
+        grew = true;
+      }
+    }
+  }
+  return ids;
+}
+
+function buildFlatItems(
+  sidebar: Sidebar,
+  tables: Table[],
+  skills: Skill[],
+  memoryFolderId: string,
+): FlatItem[] {
+  // Memory is a derived layer over the stash, not ground truth — the whole
+  // subtree is invisible here (part of the never-show-memory experiment).
+  const memoryIds = memorySubtree(sidebar.files.folders, memoryFolderId);
+  const inMemory = (folderId: string | null) => folderId !== null && memoryIds.has(folderId);
+
+  const paths = folderPaths(sidebar.files.folders);
+  const context = (folderId: string | null) => (folderId ? paths.get(folderId) : undefined);
+
+  const pages = sidebar.files.pages.filter((p) => !inMemory(p.folder_id)).map<FlatItem>((p) => ({
+    key: `page:${p.id}`,
+    kind: "page",
+    name: p.name,
+    href: `/p/${p.id}`,
+    context: context(p.folder_id),
+    agent: p.last_edit_agent_name ?? undefined,
+    updatedAt: p.updated_at,
+  }));
+  const files = sidebar.files.files.filter((f) => !inMemory(f.folder_id)).map<FlatItem>((f) => ({
+    key: `file:${f.id}`,
+    kind: "file",
+    name: f.name,
+    href: `/f/${f.id}`,
+    context: context(f.folder_id),
+    annotation: humanSize(f.size_bytes),
+    updatedAt: f.created_at,
+  }));
+  const tableItems = tables.filter((t) => !inMemory(t.folder_id)).map<FlatItem>((t) => ({
+    key: `table:${t.id}`,
+    kind: "table",
+    name: t.name,
+    href: `/tables/${t.id}`,
+    context: context(t.folder_id),
+    annotation: `${t.row_count ?? 0} row${t.row_count === 1 ? "" : "s"}`,
+    updatedAt: t.updated_at,
+  }));
+  const sessions = sidebar.sessions.map<FlatItem>((s) => ({
+    key: `session:${s.session_id}`,
+    kind: "session",
+    name: s.title || s.agent_name || "session",
+    href: `/sessions/${s.session_id}`,
+    agent: s.agent_name || undefined,
+    updatedAt: s.last_at,
+  }));
+  const skillItems = skills.map<FlatItem>((s) => ({
+    key: `skill:${s.folder_id}`,
+    kind: "skill",
+    name: s.name,
+    href: `/skills/folder/${s.folder_id}`,
+    annotation: `${s.file_count} file${s.file_count === 1 ? "" : "s"}`,
+    updatedAt: s.updated_at,
+  }));
+
+  return [...pages, ...files, ...tableItems, ...sessions, ...skillItems].sort(
+    (a, b) => +new Date(b.updatedAt) - +new Date(a.updatedAt),
+  );
+}
+
+/** Rank matches: name prefix, then name substring, then location/agent
+ *  substring. Within a rank the list keeps its recency order (Array.sort is
+ *  stable). */
+export function filterItems(items: FlatItem[], query: string): FlatItem[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return items;
+  const scored: { item: FlatItem; score: number }[] = [];
+  for (const item of items) {
+    const name = item.name.toLowerCase();
+    const rest = `${item.context ?? ""} ${item.agent ?? ""}`.toLowerCase();
+    if (name.startsWith(q)) scored.push({ item, score: 0 });
+    else if (name.includes(q)) scored.push({ item, score: 1 });
+    else if (rest.includes(q)) scored.push({ item, score: 2 });
+  }
+  return scored.sort((a, b) => a.score - b.score).map((s) => s.item);
+}
+
+export function useFlatItems(): { items: FlatItem[]; loaded: boolean; error: string | null } {
+  const [items, setItems] = useState<FlatItem[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([getSidebar(), listTables(), listSkills(), getMemoryFolder()])
+      .then(([sidebar, tables, skills, memoryFolder]) => {
+        if (cancelled) return;
+        setItems(buildFlatItems(sidebar, tables.tables, skills, memoryFolder.id));
+      })
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : String(e)); });
+    return () => { cancelled = true; };
+  }, []);
+
+  return { items: items ?? [], loaded: items !== null, error };
+}

--- a/frontend/src/components/workspace/explorer.tsx
+++ b/frontend/src/components/workspace/explorer.tsx
@@ -12,7 +12,6 @@ import { CONNECTORS, connectorIcon, providerForSourceType } from "@/components/i
 import { INTEGRATIONS_CHANGED_EVENT, listIntegrations } from "@/lib/integrations";
 import { opensNewTab } from "@/lib/tab-nav";
 import FilesExplorer, { type Item } from "./files-explorer";
-import VfsTree from "./vfs-tree";
 
 export type ExplorerSection = "files" | "sessions" | "skills" | "agents" | "integrations" | "computer";
 
@@ -344,9 +343,6 @@ export default function Explorer({ section }: { section: ExplorerSection }) {
   const createSessionFolderItem = useCallback(async () => { await createSessionFolder("New folder"); }, []);
 
   if (section === "agents") return <AgentsExplorer />;
-
-  // The VFS section docks the same tree the /files lens shows full-screen.
-  if (section === "files") return <VfsTree />;
 
   // Skills & Sessions are file managers (own breadcrumb/toolbar).
   if ((section === "skills" || section === "sessions") && !atRoot) {

--- a/frontend/src/components/workspace/rail.test.tsx
+++ b/frontend/src/components/workspace/rail.test.tsx
@@ -56,18 +56,18 @@ describe("Rail", () => {
     const labels = Array.from(document.querySelectorAll("[aria-label]")).map((el) =>
       el.getAttribute("aria-label"),
     );
-    expect(labels).toEqual(["Integrations", "Home", "Viz", "VFS", "Chat", "Settings"]);
+    expect(labels).toEqual(["Integrations", "Home", "Viz", "Files", "Chat", "Settings"]);
   });
 
-  it("shows sessions as part of the VFS, not a section of their own", () => {
+  it("shows sessions as part of Files, not a section of their own", () => {
     renderAt("/sessions/abc");
-    expect(currentSection()).toBe("VFS");
+    expect(currentSection()).toBe("Files");
     expect(screen.queryByLabelText("Sessions")).toBeNull();
   });
 
-  it("shows an opened skill as part of the VFS", () => {
+  it("shows an opened skill as part of Files", () => {
     renderAt("/skills/folder/abc");
-    expect(currentSection()).toBe("VFS");
+    expect(currentSection()).toBe("Files");
     expect(screen.queryByLabelText("Skills")).toBeNull();
   });
 

--- a/frontend/src/components/workspace/rail.tsx
+++ b/frontend/src/components/workspace/rail.tsx
@@ -3,7 +3,7 @@
 import { Fragment, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Bot, FolderTree, Home, Network, Plug, Settings } from "lucide-react";
+import { Bot, Files, Home, Network, Plug, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import { useWorkspace, type RailSection } from "@/lib/workspace-store";
@@ -17,7 +17,7 @@ const PRIMARY: RailItem[] = [
   { key: "integrations", label: "Integrations", icon: Plug, match: (p) => p.startsWith("/integrations") },
   { key: "home", label: "Home", icon: Home, match: (p) => p === "/" },
   { key: "viz", label: "Viz", icon: Network, match: (p) => p.startsWith("/viz") },
-  { key: "files", label: "VFS", icon: FolderTree, match: (p) => p === "/files" || p.startsWith("/f/") || p.startsWith("/p/") || p.startsWith("/folders/") || p.startsWith("/tables/") || p.startsWith("/sessions") || p.startsWith("/session-folders") || p.startsWith("/skills") },
+  { key: "files", label: "Files", icon: Files, match: (p) => p === "/files" || p.startsWith("/f/") || p.startsWith("/p/") || p.startsWith("/folders/") || p.startsWith("/tables/") || p.startsWith("/sessions") || p.startsWith("/session-folders") || p.startsWith("/skills") },
   { key: "agents", label: "Chat", icon: Bot, match: (p) => p.startsWith("/agents") },
 ];
 

--- a/frontend/src/components/workspace/topbar.tsx
+++ b/frontend/src/components/workspace/topbar.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { Search } from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
+import { ArrowLeft, ArrowRight, Search } from "lucide-react";
 import CommandPalette from "@/components/CommandPalette";
 import { StashIcon } from "@/components/SkillIcons";
 import { useFilesSearch } from "@/components/content/flat-files/search-store";
@@ -15,6 +15,7 @@ import ScopeSwitcher from "./scope-switcher";
  *  live instead of opening the palette. */
 export default function Topbar() {
   const pathname = usePathname();
+  const router = useRouter();
   const [cmdkOpen, setCmdkOpen] = useState(false);
   const searchBarRef = useRef<HTMLDivElement>(null);
   const filesInputRef = useRef<HTMLInputElement>(null);
@@ -43,6 +44,28 @@ export default function Topbar() {
           <span className="text-[15px] font-semibold tracking-tight text-foreground">Stash</span>
         </Link>
         <ScopeSwitcher />
+        {/* IDE-style history nav: back is "wherever I just was", not "up a
+            level" — the same arrows VS Code keeps beside its command center. */}
+        <div className="flex items-center">
+          <button
+            type="button"
+            onClick={() => router.back()}
+            aria-label="Go back"
+            title="Go back"
+            className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-raised hover:text-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={() => router.forward()}
+            aria-label="Go forward"
+            title="Go forward"
+            className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-raised hover:text-foreground"
+          >
+            <ArrowRight className="h-4 w-4" />
+          </button>
+        </div>
       </div>
       <div className="flex min-w-0 flex-1 justify-center">
         <div ref={searchBarRef} className="w-full max-w-2xl">

--- a/frontend/src/components/workspace/topbar.tsx
+++ b/frontend/src/components/workspace/topbar.tsx
@@ -6,26 +6,34 @@ import { usePathname } from "next/navigation";
 import { Search } from "lucide-react";
 import CommandPalette from "@/components/CommandPalette";
 import { StashIcon } from "@/components/SkillIcons";
+import { useFilesSearch } from "@/components/content/flat-files/search-store";
 import ScopeSwitcher from "./scope-switcher";
 
 /** Full-width top bar: octopus logo + breadcrumb (left), ⌘K search (center),
- *  share action (right). Account actions live on the rail's bottom avatar. */
+ *  share action (right). Account actions live on the rail's bottom avatar.
+ *  On /files the search bar IS the page's search: it filters the flat list
+ *  live instead of opening the palette. */
 export default function Topbar() {
   const pathname = usePathname();
   const [cmdkOpen, setCmdkOpen] = useState(false);
   const searchBarRef = useRef<HTMLDivElement>(null);
+  const filesInputRef = useRef<HTMLInputElement>(null);
   const isSearchPage = pathname === "/search";
+  const isFilesPage = pathname === "/files";
+  const filesQuery = useFilesSearch((s) => s.query);
+  const setFilesQuery = useFilesSearch((s) => s.setQuery);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && e.key === "k" && !isSearchPage) {
         e.preventDefault();
-        setCmdkOpen((o) => !o);
+        if (isFilesPage) filesInputRef.current?.focus();
+        else setCmdkOpen((o) => !o);
       }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [isSearchPage]);
+  }, [isSearchPage, isFilesPage]);
 
   return (
     <header className="flex h-12 shrink-0 items-center gap-3 bg-rail px-3">
@@ -38,14 +46,29 @@ export default function Topbar() {
       </div>
       <div className="flex min-w-0 flex-1 justify-center">
         <div ref={searchBarRef} className="w-full max-w-2xl">
-          <button
-            onClick={() => setCmdkOpen(true)}
-            className="flex h-9 w-full items-center gap-2.5 rounded-full border border-border bg-surface px-4 text-left text-[13px] text-muted-foreground shadow-sm transition-colors hover:border-brand-300 hover:bg-raised hover:text-foreground"
-          >
-            <Search className="h-4 w-4 shrink-0" />
-            <span className="min-w-0 flex-1 truncate">Search</span>
-            <span className="rounded bg-base px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground ring-1 ring-border">⌘K</span>
-          </button>
+          {isFilesPage ? (
+            <div className="flex h-9 w-full items-center gap-2.5 rounded-full border border-border bg-surface px-4 text-[13px] shadow-sm transition-colors focus-within:border-brand-300">
+              <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <input
+                ref={filesInputRef}
+                autoFocus
+                value={filesQuery}
+                onChange={(e) => setFilesQuery(e.target.value)}
+                placeholder="Search everything in your stash…"
+                className="min-w-0 flex-1 bg-transparent text-foreground outline-none placeholder:text-muted-foreground"
+              />
+              <span className="rounded bg-base px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground ring-1 ring-border">⌘K</span>
+            </div>
+          ) : (
+            <button
+              onClick={() => setCmdkOpen(true)}
+              className="flex h-9 w-full items-center gap-2.5 rounded-full border border-border bg-surface px-4 text-left text-[13px] text-muted-foreground shadow-sm transition-colors hover:border-brand-300 hover:bg-raised hover:text-foreground"
+            >
+              <Search className="h-4 w-4 shrink-0" />
+              <span className="min-w-0 flex-1 truncate">Search</span>
+              <span className="rounded bg-base px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground ring-1 ring-border">⌘K</span>
+            </button>
+          )}
         </div>
       </div>
       <div className="w-[120px] shrink-0" />

--- a/frontend/src/components/workspace/workbench.tsx
+++ b/frontend/src/components/workspace/workbench.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useEffect } from "react";
-import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { ArrowLeft, X, SplitSquareHorizontal, PanelRightClose, Plus, Bot, Plug, FileText } from "lucide-react";
+import { X, SplitSquareHorizontal, PanelRightClose, Plus, Bot, Plug, FileText } from "lucide-react";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
@@ -15,19 +14,6 @@ import { PageIcon, FileIcon, TableIcon, SessionsIcon, SkillIcon, FolderIcon } fr
 import TabBody from "./tab-body";
 
 const TAB_DND = "application/x-wb-tab";
-
-// Tab kinds opened from the flat Files list — every one gets the "← Files"
-// back button in the action bar (there are no breadcrumbs; the list is the
-// only way things are found). Tool and agent tabs belong to other sections.
-const FILES_BACK_KINDS: WorkbenchTab["kind"][] = [
-  "page",
-  "file",
-  "table",
-  "session",
-  "sessions-home",
-  "skill",
-  "folder",
-];
 
 function TabIcon({ kind }: { kind: WorkbenchTab["kind"] }) {
   const cls = "text-[13px]";
@@ -95,8 +81,6 @@ function TabPane({ pane }: { pane: 0 | 1 }) {
   const paneTabs = tabs.filter((t) => (paneOf[t.id] ?? 0) === pane);
   const activeId = pane === 0 ? activeTabId : activeTab1;
   const { shareAction } = useShellChromeValue(activeId ?? undefined);
-  const activePaneTab = paneTabs.find((t) => t.id === activeId);
-  const showFilesBack = pane === 0 && !!activePaneTab && FILES_BACK_KINDS.includes(activePaneTab.kind);
 
   // Keep ?section= when refocusing a tab — the explorer sidebar's section is
   // derived from the URL, and switching tabs must never move the sidebar.
@@ -178,21 +162,9 @@ function TabPane({ pane }: { pane: 0 | 1 }) {
           )}
         </div>
       </div>
-      {(shareAction || showFilesBack) && (
-        <div className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-border bg-base px-3">
-          {showFilesBack ? (
-            <Link
-              href="/files"
-              className="flex items-center gap-1.5 rounded-md px-1.5 py-1 text-[13px] text-muted-foreground hover:bg-raised hover:text-foreground"
-              title="Back to all files"
-            >
-              <ArrowLeft className="h-3.5 w-3.5" />
-              Files
-            </Link>
-          ) : (
-            <span />
-          )}
-          <div className="flex items-center gap-2">{shareAction}</div>
+      {shareAction && (
+        <div className="flex h-10 shrink-0 items-center justify-end gap-2 border-b border-border bg-base px-3">
+          {shareAction}
         </div>
       )}
       <div className="min-h-0 flex-1 overflow-hidden">

--- a/frontend/src/components/workspace/workbench.tsx
+++ b/frontend/src/components/workspace/workbench.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect } from "react";
+import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { X, SplitSquareHorizontal, PanelRightClose, Plus, Bot, Plug, FileText } from "lucide-react";
+import { ArrowLeft, X, SplitSquareHorizontal, PanelRightClose, Plus, Bot, Plug, FileText } from "lucide-react";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
@@ -14,6 +15,19 @@ import { PageIcon, FileIcon, TableIcon, SessionsIcon, SkillIcon, FolderIcon } fr
 import TabBody from "./tab-body";
 
 const TAB_DND = "application/x-wb-tab";
+
+// Tab kinds opened from the flat Files list — every one gets the "← Files"
+// back button in the action bar (there are no breadcrumbs; the list is the
+// only way things are found). Tool and agent tabs belong to other sections.
+const FILES_BACK_KINDS: WorkbenchTab["kind"][] = [
+  "page",
+  "file",
+  "table",
+  "session",
+  "sessions-home",
+  "skill",
+  "folder",
+];
 
 function TabIcon({ kind }: { kind: WorkbenchTab["kind"] }) {
   const cls = "text-[13px]";
@@ -81,6 +95,8 @@ function TabPane({ pane }: { pane: 0 | 1 }) {
   const paneTabs = tabs.filter((t) => (paneOf[t.id] ?? 0) === pane);
   const activeId = pane === 0 ? activeTabId : activeTab1;
   const { shareAction } = useShellChromeValue(activeId ?? undefined);
+  const activePaneTab = paneTabs.find((t) => t.id === activeId);
+  const showFilesBack = pane === 0 && !!activePaneTab && FILES_BACK_KINDS.includes(activePaneTab.kind);
 
   // Keep ?section= when refocusing a tab — the explorer sidebar's section is
   // derived from the URL, and switching tabs must never move the sidebar.
@@ -162,9 +178,21 @@ function TabPane({ pane }: { pane: 0 | 1 }) {
           )}
         </div>
       </div>
-      {shareAction && (
-        <div className="flex h-10 shrink-0 items-center justify-end gap-2 border-b border-border bg-base px-3">
-          {shareAction}
+      {(shareAction || showFilesBack) && (
+        <div className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-border bg-base px-3">
+          {showFilesBack ? (
+            <Link
+              href="/files"
+              className="flex items-center gap-1.5 rounded-md px-1.5 py-1 text-[13px] text-muted-foreground hover:bg-raised hover:text-foreground"
+              title="Back to all files"
+            >
+              <ArrowLeft className="h-3.5 w-3.5" />
+              Files
+            </Link>
+          ) : (
+            <span />
+          )}
+          <div className="flex items-center gap-2">{shareAction}</div>
         </div>
       )}
       <div className="min-h-0 flex-1 overflow-hidden">

--- a/frontend/src/components/workspace/workspace-shell.tsx
+++ b/frontend/src/components/workspace/workspace-shell.tsx
@@ -16,12 +16,11 @@ const MIN_W = 220;
 const MAX_W = 600;
 const EXPLORER_SECTIONS: ExplorerSection[] = ["files", "agents", "integrations", "computer"];
 
-// Only the VFS keeps the tree sidebar. Integrations and Agents render
-// full-width — the explorers were a second nav axis over the same content as
-// the rail, and the two looked independent. Agents brings its own
-// ChatGPT-style chat list; the VM (browser) keeps its panel because that
-// content lives nowhere else.
-const PANELLED_SECTIONS: ExplorerSection[] = ["files", "computer"];
+// Only the VM (browser) keeps a docked panel — that content lives nowhere
+// else. Files is a flat searchable list at /files with full-width detail
+// views; Integrations and Agents render full-width for the same reason the
+// explorers were dropped: a second nav axis over the rail's content.
+const PANELLED_SECTIONS: ExplorerSection[] = ["computer"];
 
 /** Resizable explorer panel — drag the right edge to set width (persisted). */
 function ExplorerPanel({ section }: { section: ExplorerSection }) {
@@ -139,10 +138,10 @@ export default function WorkspaceShell({
     setLastVfsUrl(query ? `${pathname}?${query}` : pathname);
   }, [section, pathname, searchParams, setLastVfsUrl]);
 
-  // /files IS a file tree — showing the explorer's tree beside it would be
-  // the same thing twice. An explicit ?section= still summons the panel.
+  // /files is the flat list itself; it renders as a plain full page, not
+  // inside the workbench chrome.
   const isFilesHome = pathname === "/files" && !selectedSection;
-  const showExplorer = section !== null && PANELLED_SECTIONS.includes(section) && !isFilesHome;
+  const showExplorer = section !== null && PANELLED_SECTIONS.includes(section);
 
   return (
     // Chrome surface — the content panel floats on top of it.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1883,6 +1883,9 @@ export interface TreePage {
   name: string;
   content_type: "markdown" | "html";
   folder_id: string | null;
+  updated_at: string;
+  /** Agent that made the last edit; null when a human edited last. */
+  last_edit_agent_name: string | null;
 }
 export interface TreeFile {
   id: string;


### PR DESCRIPTION
## What this is

An experiment against the theory that users don't think in filesystems. The VFS tree UI is gone; **/files is now one reverse-chronological table of everything in the stash** — pages, files, tables, sessions, skills — and search is the primary way to find things.

## Changes

- **Flat table at /files**: columns Name / Type / Folder / Agent / Modified, all sortable (click to sort, click again to flip). Filter chips with live counts per kind. Built from the existing flat `sidebar` payload + tables + skills — no new list endpoints, so filtering is instant and local.
- **One search bar**: on /files the topbar search becomes the table's live filter (shared store; ⌘K focuses it there instead of opening the palette). Relevance ranks name-prefix > name > folder/agent matches; arrows + Enter navigate; a "search connected sources too" row hands off to /search for remote/semantic results.
- **No sidebar, no breadcrumbs**: the docked explorer panel is removed for the whole files section and detail views render full width. Breadcrumb trails are removed from page/file headers.
- **IDE-style navigation**: back/forward history arrows in the topbar beside the logo (VS Code-style), driving location history — no dedicated back row anywhere.
- **Agent column**: pages already track `last_edit_agent_name` in the DB; it's now included in the `/me/sidebar` payload (ETag version bumped). Sessions show their `agent_name`. Null (human-edited / uploads) renders as "–".
- **Memory hidden**: the Memory folder subtree is filtered out of the list entirely — part of the experiment of treating memory as a derived layer, never shown as content. Only this view filters it; /search, the palette, and the CLI still see it.
- **VFS → Files**: rail label and icon (stacked documents instead of a tree).
- **Agents unaffected**: the CLI VFS and all backend filesystem semantics are untouched — folders still exist as organization, humans just stop navigating them.

## Testing

- frontend: `tsc` clean, `npm run lint` clean, all 318 vitest tests pass (rail label tests and sidebar-payload fixtures updated)
- backend: `ruff` clean, sidebar/files-tree/overview pytest suite passes
- manually QA'd in the running dev stack: search/sort/chips, Enter-to-open, history arrows from pages/sessions, topbar reverting to ⌘K off /files, query reset on return

🤖 Generated with [Claude Code](https://claude.com/claude-code)