### PR TITLE
Multiplier: consent-gated team memory (wiki + skills) on workspaces

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -109,7 +109,7 @@ async def _get_user_from_api_key(token: str, *, managed_auth_enabled: bool) -> d
     row = await pool.fetchrow(
         "SELECT u.id, u.name, u.display_name, u.email, u.description, "
         "       u.created_at, u.last_seen, u.role, u.referral_source, u.use_case, "
-        "       u.plan, u.plan_intent, "
+        "       u.plan, u.plan_intent, u.session_uploads_enabled, "
         "       k.id AS key_id, k.key_type, k.access AS key_access "
         "FROM user_api_keys k JOIN users u ON u.id = k.user_id "
         "WHERE k.key_hash = $1 AND k.revoked_at IS NULL",
@@ -142,7 +142,7 @@ async def _get_user_from_jwt(token: str) -> dict:
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT id, name, display_name, email, description, created_at, last_seen, "
-        "       role, referral_source, use_case, plan, plan_intent "
+        "       role, referral_source, use_case, plan, plan_intent, session_uploads_enabled "
         "FROM users WHERE auth0_sub = $1",
         claims["sub"],
     )
@@ -234,6 +234,18 @@ async def get_current_user(
     _enforce_key_access(user, request)
     _set_request_via(request, user)
     return user
+
+
+async def require_session_uploads(current_user: dict = Depends(get_current_user)) -> dict:
+    """`get_current_user`, but 403s when the caller's master upload switch is
+    off. Session-upload endpoints use this so a disabled account rejects
+    loudly instead of silently dropping events."""
+    if not current_user["session_uploads_enabled"]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Session uploads are disabled for this account (Settings → Session uploads)",
+        )
+    return current_user
 
 
 async def get_scope(

--- a/backend/main.py
+++ b/backend/main.py
@@ -49,6 +49,7 @@ from .routers import (
     sql,
     tables,
     tasks,
+    team,
     telegram,
     transcripts,
     trash,
@@ -141,6 +142,7 @@ app.include_router(analytics.router)
 app.include_router(marketing.router)
 app.include_router(pastes.router)
 app.include_router(sessions.router)
+app.include_router(team.router)
 app.include_router(trash.router)
 app.include_router(pins.router)
 app.include_router(mcp_servers.router)

--- a/backend/migrations/versions/0185_multiplier_switches.py
+++ b/backend/migrations/versions/0185_multiplier_switches.py
@@ -1,0 +1,43 @@
+"""Multiplier: the two consent switches for team sharing.
+
+Internal multiplayer ("Multiplier") is built on explicit contribution:
+nothing a person does reaches teammates unless they chose it. Two booleans
+carry that choice:
+
+- `users.session_uploads_enabled` — the master switch. Off means the
+  account accepts no new session transcripts at all; upload endpoints
+  reject with an explicit 403 rather than silently dropping events.
+- `sessions.team_visible` — the per-session choice. On means workspace
+  co-members may read this session (and the team curator may learn from
+  it). Off — the default — keeps it private to its owner, always.
+
+Visibility on sessions is otherwise computed from shares at read time;
+this flag is stored because "shared with my team" is a standing property
+of the session, not a per-principal grant.
+
+Revision ID: 0185
+Revises: 0184
+"""
+
+from alembic import op
+
+revision = "0185"
+down_revision = "0184"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE users ADD COLUMN session_uploads_enabled BOOLEAN NOT NULL DEFAULT true")
+    op.execute("ALTER TABLE sessions ADD COLUMN team_visible BOOLEAN NOT NULL DEFAULT false")
+    # Team views list co-members' shared sessions, newest first.
+    op.execute(
+        "CREATE INDEX sessions_team_visible_idx ON sessions(owner_user_id, started_at DESC) "
+        "WHERE team_visible AND deleted_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS sessions_team_visible_idx")
+    op.execute("ALTER TABLE sessions DROP COLUMN team_visible")
+    op.execute("ALTER TABLE users DROP COLUMN session_uploads_enabled")

--- a/backend/migrations/versions/0186_workspace_curators.py
+++ b/backend/migrations/versions/0186_workspace_curators.py
@@ -1,0 +1,61 @@
+"""Every workspace scope gets a Memory curator.
+
+New workspaces create theirs in `create_workspace`; this backfills the
+workspaces that already exist. Mirrors `agent_service.get_or_create_curator`:
+scheduled nightly (staggered off the scope user's id), with the cron baseline
+and delta watermark seeded to a bounded backfill point so the first run is
+due immediately and bootstraps the team wiki from real history.
+
+Revision ID: 0186
+Revises: 0185
+"""
+
+from uuid import UUID
+
+from alembic import op
+
+revision = "0186"
+down_revision = "0185"
+branch_labels = None
+depends_on = None
+
+# Copied from agent_service (migrations don't import app code); the exact
+# stagger only spreads load inside the nightly window, so drift is harmless.
+_BACKFILL_DAYS = 90
+_WINDOW_START_HOUR_UTC = 8
+_WINDOW_HOURS = 4
+
+
+def _staggered_nightly_cron(user_id: UUID) -> str:
+    n = int.from_bytes(user_id.bytes, "big")
+    hour = _WINDOW_START_HOUR_UTC + (n // 60) % _WINDOW_HOURS
+    return f"{n % 60} {hour} * * *"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    rows = bind.exec_driver_sql(
+        "SELECT w.scope_user_id FROM workspaces w "
+        "WHERE NOT EXISTS (SELECT 1 FROM agents a "
+        "                  WHERE a.user_id = w.scope_user_id AND a.is_curator)"
+    ).fetchall()
+    for (scope_user_id,) in rows:
+        bind.exec_driver_sql(
+            "INSERT INTO agents (user_id, name, run_mode, schedule_cron, is_curator, "
+            "                    last_run_at, curated_through) "
+            "SELECT u.id, 'Memory curator', 'scheduled', %(cron)s, true, "
+            "       greatest(u.created_at, now() - make_interval(days => %(days)s)), "
+            "       greatest(u.created_at, now() - make_interval(days => %(days)s)) "
+            "FROM users u WHERE u.id = %(scope_user_id)s",
+            {
+                "cron": _staggered_nightly_cron(UUID(str(scope_user_id))),
+                "days": _BACKFILL_DAYS,
+                "scope_user_id": scope_user_id,
+            },
+        )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DELETE FROM agents WHERE is_curator AND user_id IN (SELECT scope_user_id FROM workspaces)"
+    )

--- a/backend/migrations/versions/0187_team_memory_opt_out.py
+++ b/backend/migrations/versions/0187_team_memory_opt_out.py
@@ -1,0 +1,39 @@
+"""Team learning flips from opt-in to opt-out.
+
+The spec settled on input-side consent: every uploaded session feeds the
+team's collective distillation BY DEFAULT, and the per-session control is an
+exclusion ("keep this one out of team memory"), not a share. Raw traces are
+never team-readable either way — teammates see a transcript only via an
+explicit per-person share. So `team_visible` (opt-in read grant + curator
+input) is replaced by `team_memory_excluded` (curator input filter only).
+
+No data carried forward: the flag shipped hours ago on a dev branch and the
+old opt-in rows mean nothing under opt-out semantics.
+
+Revision ID: 0187
+Revises: 0186
+"""
+
+from alembic import op
+
+revision = "0187"
+down_revision = "0186"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS sessions_team_visible_idx")
+    op.execute("ALTER TABLE sessions DROP COLUMN team_visible")
+    op.execute(
+        "ALTER TABLE sessions ADD COLUMN team_memory_excluded BOOLEAN NOT NULL DEFAULT false"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE sessions DROP COLUMN team_memory_excluded")
+    op.execute("ALTER TABLE sessions ADD COLUMN team_visible BOOLEAN NOT NULL DEFAULT false")
+    op.execute(
+        "CREATE INDEX sessions_team_visible_idx ON sessions(owner_user_id, started_at DESC) "
+        "WHERE team_visible AND deleted_at IS NULL"
+    )

--- a/backend/migrations/versions/0188_page_provenance.py
+++ b/backend/migrations/versions/0188_page_provenance.py
@@ -1,0 +1,46 @@
+"""Pages remember which sessions they were built from.
+
+Provenance is the mechanism behind two spec obligations that were previously
+prompt-only hopes:
+
+- **Honest opt-out.** Excluding a session from team memory must reach content
+  already derived from it. `page_sources` finds those pages;
+  `pages.needs_recuration` marks them for the curator's next run.
+- **Enforced promotion.** A Team Skills page requires >=2 distinct authors'
+  sessions behind it. With sources recorded, that bar is checked at write
+  time instead of trusted to the curator's prompt.
+
+Revision ID: 0188
+Revises: 0187
+"""
+
+from alembic import op
+
+revision = "0188"
+down_revision = "0187"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE page_sources (
+            page_id UUID NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+            session_owner_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            session_id TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            PRIMARY KEY (page_id, session_owner_user_id, session_id)
+        )
+        """
+    )
+    # Exclusion flips look up "which pages used this session".
+    op.execute(
+        "CREATE INDEX page_sources_session_idx ON page_sources (session_owner_user_id, session_id)"
+    )
+    op.execute("ALTER TABLE pages ADD COLUMN needs_recuration BOOLEAN NOT NULL DEFAULT false")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE pages DROP COLUMN needs_recuration")
+    op.execute("DROP TABLE page_sources")

--- a/backend/models.py
+++ b/backend/models.py
@@ -45,6 +45,7 @@ class UserProfile(BaseModel):
     use_case: str | None = None
     plan: str = "free"
     plan_intent: str | None = None
+    session_uploads_enabled: bool = True
 
 
 class UserUpdateRequest(BaseModel):
@@ -61,6 +62,8 @@ class UserUpdateRequest(BaseModel):
     # The plan the user picked during onboarding — a sales signal, not the
     # billing entitlement (that's `users.plan`, set by admins).
     plan_intent: str | None = Field(None, max_length=64)
+    # Master consent switch: off means upload endpoints reject new sessions.
+    session_uploads_enabled: bool | None = None
 
 
 class LoginRequest(BaseModel):
@@ -183,6 +186,13 @@ class FolderListResponse(BaseModel):
     folders: list[FolderResponse]
 
 
+class SourceSessionRef(BaseModel):
+    """A session a page was built from — provenance for curated pages."""
+
+    owner_user_id: UUID
+    session_id: str = Field(..., min_length=1, max_length=64)
+
+
 class PageCreateRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
     folder_id: UUID | None = None
@@ -190,6 +200,7 @@ class PageCreateRequest(BaseModel):
     content_type: str = Field("markdown", pattern=r"^(markdown|html)$")
     content_html: str = ""
     html_layout: str = Field("responsive", pattern=r"^(responsive|fixed-aspect|full-width)$")
+    source_sessions: list[SourceSessionRef] | None = None
 
 
 class PageUpdateRequest(BaseModel):
@@ -204,6 +215,9 @@ class PageUpdateRequest(BaseModel):
     content_html: str | None = None
     html_layout: str | None = Field(None, pattern=r"^(responsive|fixed-aspect|full-width)$")
     move_to_root: bool = False
+    # Given, replaces the page's recorded provenance and clears its
+    # recuration flag — stating fresh sources IS the rebuild.
+    source_sessions: list[SourceSessionRef] | None = None
 
 
 class CopyRequest(BaseModel):

--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -33,6 +33,7 @@ from ..services import (
     comment_service,
     files_tree_service,
     page_events,
+    page_provenance_service,
     permission_service,
     prompts,
     security_audit_service,
@@ -243,15 +244,11 @@ async def recompute_memory(
     from ..services import agent_auth, agent_service, curation_service
     from ..tasks.agent_schedules import run_curator_now
 
-    # A workspace's curator runs on the workspace's own credentials and
-    # schedule; a member's recompute button must not silently rebuild their
-    # personal memory instead.
-    if scope_user_id != current_user["id"]:
-        raise HTTPException(
-            status_code=403,
-            detail="Workspace memory recomputes on the workspace's own schedule.",
-        )
-    user_id = current_user["id"]
+    # In a workspace scope this targets the TEAM's curator (get_scope has
+    # already verified membership); the personal scope targets your own. The
+    # workspace curator runs on the workspace's credentials, so a member's
+    # recompute never rebuilds their personal memory by accident.
+    user_id = scope_user_id
     curator = await agent_service.get_or_create_curator(user_id)
     if not await curation_service.has_changes_since(user_id, user_id, curator["curated_through"]):
         raise HTTPException(status_code=409, detail="Nothing new to curate since the last run.")
@@ -601,6 +598,11 @@ async def create_page(
             current_user["id"],
             require="write",
         )
+    sources = [(s.owner_user_id, s.session_id) for s in req.source_sessions or []]
+    try:
+        await page_provenance_service.enforce_team_skills_bar(req.folder_id, sources)
+    except page_provenance_service.SkillsBarNotMet as e:
+        raise HTTPException(status_code=422, detail=str(e))
     page = await files_tree_service.create_page_unique(
         owner_user_id,
         req.name,
@@ -611,6 +613,8 @@ async def create_page(
         content_html=req.content_html,
         html_layout=req.html_layout,
     )
+    if sources:
+        await page_provenance_service.set_sources(page["id"], sources)
     # The creator just wrote it; the response must not demote the editor.
     return PageResponse(**{**page, "can_write": True})
 
@@ -790,6 +794,29 @@ async def update_page(
             require="write",
         )
 
+    # The skills bar applies when a write moves a page into the Team Skills
+    # folder or restates its sources — not on content-only edits, whose
+    # provenance (and bar) were settled when the page got there.
+    if req.folder_id is not None or req.source_sessions is not None:
+        effective_folder = req.folder_id
+        if effective_folder is None and not req.move_to_root:
+            effective_folder = await get_pool().fetchval(
+                "SELECT folder_id FROM pages WHERE id = $1", page_id
+            )
+        if req.source_sessions is not None:
+            sources = [(s.owner_user_id, s.session_id) for s in req.source_sessions]
+        else:
+            # A move without restated sources is judged on what's recorded.
+            rows = await get_pool().fetch(
+                "SELECT session_owner_user_id, session_id FROM page_sources WHERE page_id = $1",
+                page_id,
+            )
+            sources = [(r["session_owner_user_id"], r["session_id"]) for r in rows]
+        try:
+            await page_provenance_service.enforce_team_skills_bar(effective_folder, sources)
+        except page_provenance_service.SkillsBarNotMet as e:
+            raise HTTPException(status_code=422, detail=str(e))
+
     try:
         page = await files_tree_service.update_page(
             page_id,
@@ -815,6 +842,10 @@ async def update_page(
         )
     if not page:
         raise HTTPException(status_code=404, detail="Page not found")
+    if req.source_sessions is not None:
+        await page_provenance_service.set_sources(
+            page_id, [(s.owner_user_id, s.session_id) for s in req.source_sessions]
+        )
     # Write access was checked above; a save response must not flip the
     # editor read-only by omitting the flag.
     return PageResponse(**{**page, "can_write": True})

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from ..auth import get_current_user, get_scope
+from ..auth import get_current_user, get_scope, require_session_uploads
 from ..config import settings
 from ..models import (
     HistoryEventBatchRequest,
@@ -44,7 +44,7 @@ async def _check_write(owner_user_id: UUID, user_id: UUID) -> None:
 @me_router.post("/events", response_model=HistoryEventResponse, status_code=201)
 async def push_event(
     req: HistoryEventCreateRequest,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_session_uploads),
     scope_user_id: UUID = Depends(get_scope),
 ):
     # Events land in the active scope, same as session rows: personal by
@@ -73,7 +73,7 @@ async def push_event(
 @me_router.post("/events/batch", response_model=list[HistoryEventResponse], status_code=201)
 async def push_events_batch(
     req: HistoryEventBatchRequest,
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_session_uploads),
     scope_user_id: UUID = Depends(get_scope),
 ):
     owner_user_id = scope_user_id

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -20,6 +20,7 @@ from ..services import (
     files_tree_service,
     linear_ticket_service,
     memory_service,
+    page_provenance_service,
     permission_service,
     security_audit_service,
     session_folder_service,
@@ -68,6 +69,7 @@ def _session_response(row: dict, title: str | None = None) -> dict:
         "started_at": row.get("started_at"),
         "finished_at": row.get("finished_at"),
         "created_by": str(row["created_by"]) if row.get("created_by") else None,
+        "team_memory_excluded": bool(row.get("team_memory_excluded")),
     }
 
 
@@ -166,6 +168,7 @@ async def list_my_sessions(
           he.session_id,
           s.id AS id,
           s.session_folder_id,
+          s.team_memory_excluded,
           sf.name AS session_folder_name,
           he.owner_user_id,
           owner.display_name AS owner_name,
@@ -188,7 +191,7 @@ async def list_my_sessions(
         LEFT JOIN session_folders sf ON sf.id = s.session_folder_id
         WHERE {" AND ".join(where)}
         GROUP BY he.session_id, he.owner_user_id, owner.display_name, s.id, s.session_folder_id,
-          sf.name, title_sources.title_source
+          s.team_memory_excluded, sf.name, title_sources.title_source
         ORDER BY last_event_at DESC, user_name ASC, session_id ASC
         LIMIT {int(limit)} OFFSET {int(offset)}
         """,
@@ -341,6 +344,40 @@ async def rename_my_session(
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc))
     return {"title": title}
+
+
+class SessionTeamMemoryRequest(BaseModel):
+    excluded: bool
+
+
+@router.patch("/me/sessions/{session_id}/team-memory")
+async def set_my_session_team_memory(
+    session_id: str,
+    body: SessionTeamMemoryRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Exclude one session from (or return it to) the team's collective
+    learning. Sessions participate by default; exclusion is the per-session
+    escape hatch. Consent is personal: only the owner may flip this, so the
+    lookup is pinned to the caller's personal scope."""
+    session = await session_service.get_session(current_user["id"], session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    pool = get_pool()
+    await pool.execute(
+        "UPDATE sessions SET team_memory_excluded = $1 WHERE id = $2",
+        body.excluded,
+        session["id"],
+    )
+    # Opt-out reaches the past: pages already built from this session get
+    # flagged, and the curator's next run rebuilds them without it. The count
+    # comes back so the consent surface can show the flip's consequences.
+    pages_flagged = 0
+    if body.excluded:
+        pages_flagged = await page_provenance_service.flag_pages_for_session(
+            current_user["id"], session_id
+        )
+    return {"team_memory_excluded": body.excluded, "pages_flagged": pages_flagged}
 
 
 async def _check_session_write(

--- a/backend/routers/team.py
+++ b/backend/routers/team.py
@@ -1,0 +1,105 @@
+"""Team endpoints: the member-facing view of a workspace.
+
+`/me/team` resolves "my team" from workspace membership. A caller in exactly
+one workspace never passes an id; a caller in several must say which — no
+guessing, no first-match fallback.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from ..auth import get_current_user
+from ..services import team_service, workspace_service
+
+router = APIRouter(prefix="/api/v1/me/team", tags=["team"])
+
+
+async def _resolve_workspace(current_user: dict, workspace_id: UUID | None) -> dict:
+    workspaces = await workspace_service.list_for_user(current_user["id"])
+    if not workspaces:
+        raise HTTPException(status_code=404, detail="You are not in a workspace")
+    if workspace_id is None:
+        if len(workspaces) > 1:
+            raise HTTPException(
+                status_code=400,
+                detail="You are in several workspaces; pass workspace_id",
+            )
+        return workspaces[0]
+    for workspace in workspaces:
+        if workspace["id"] == workspace_id:
+            return workspace
+    raise HTTPException(status_code=404, detail="You are not in that workspace")
+
+
+@router.get("")
+async def get_my_team(
+    workspace_id: UUID | None = Query(None),
+    current_user: dict = Depends(get_current_user),
+):
+    workspace = await _resolve_workspace(current_user, workspace_id)
+    members = await team_service.list_members(workspace["id"])
+    return {
+        "id": str(workspace["id"]),
+        "name": workspace["name"],
+        "domain": workspace["domain"],
+        "scope_user_id": str(workspace["scope_user_id"]),
+        "members": [
+            {
+                "id": str(member["id"]),
+                "name": member["name"],
+                "display_name": member["display_name"],
+                "email": member["email"],
+            }
+            for member in members
+        ],
+    }
+
+
+@router.get("/skills")
+async def list_team_skills(
+    workspace_id: UUID | None = Query(None),
+    current_user: dict = Depends(get_current_user),
+):
+    """The team's skill library — a store of its own, separate from the wiki
+    (procedural how-tos every agent should carry, vs. facts to look up)."""
+    workspace = await _resolve_workspace(current_user, workspace_id)
+    data = await team_service.list_team_skills(workspace["scope_user_id"])
+    return {
+        "folder_id": str(data["folder"]["id"]),
+        "skills": [
+            {
+                "id": str(page["id"]),
+                "name": page["name"],
+                "updated_at": page["updated_at"],
+            }
+            for page in data["skills"]
+        ],
+    }
+
+
+@router.get("/analytics")
+async def team_analytics(
+    workspace_id: UUID | None = Query(None),
+    current_user: dict = Depends(get_current_user),
+):
+    """Per-member session counts and estimated token volume. Deliberately
+    metadata-only: totals and timestamps, never titles or content — the audit
+    surface must not leak what the privacy default protects."""
+    workspace = await _resolve_workspace(current_user, workspace_id)
+    stats = await team_service.member_session_stats(workspace["id"])
+    return {
+        "members": [
+            {
+                "id": str(row["id"]),
+                "name": row["name"],
+                "display_name": row["display_name"],
+                "sessions_total": row["sessions_total"],
+                "sessions_7d": row["sessions_7d"],
+                "sessions_30d": row["sessions_30d"],
+                "est_tokens_30d": row["est_tokens_30d"],
+                "last_session_at": row["last_session_at"],
+            }
+            for row in stats
+        ]
+    }

--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -18,7 +18,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile
 from fastapi.responses import PlainTextResponse
 
-from ..auth import get_current_user, get_scope
+from ..auth import get_current_user, get_scope, require_session_uploads
 from ..database import get_pool
 from ..services import (
     memory_service,
@@ -54,7 +54,7 @@ async def upload_transcript(
     cwd: str | None = Form(None),
     session_folder_id: UUID | None = Form(None),
     replace: bool = Form(False),
-    current_user: dict = Depends(get_current_user),
+    current_user: dict = Depends(require_session_uploads),
     scope_user_id: UUID = Depends(get_scope),
 ):
     """Parse the uploaded JSONL into history_events rows.

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -158,6 +158,7 @@ async def update_me(req: UserUpdateRequest, current_user: dict = Depends(get_cur
             referral_source=req.referral_source,
             use_case=req.use_case,
             plan_intent=req.plan_intent,
+            session_uploads_enabled=req.session_uploads_enabled,
         )
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))

--- a/backend/services/curation_service.py
+++ b/backend/services/curation_service.py
@@ -29,6 +29,24 @@ _MAX_SOURCE_DOCS = 100
 _SNIPPET = 280
 
 
+def _team_shared_event_condition(event_alias: str, scope_arg: int) -> str:
+    """Events of members' sessions that feed team learning, when the scope
+    ${scope_arg} is a workspace. Consent is input-side and opt-out: every
+    member session participates unless its owner excluded it. For a personal
+    scope the workspaces join matches nothing and the branch is inert."""
+    from .permission_service import _workspace_member_condition_expr
+
+    owner_is_member = _workspace_member_condition_expr("team_ws", "team_s.owner_user_id")
+    return (
+        f"EXISTS (SELECT 1 FROM sessions team_s "
+        f"JOIN workspaces team_ws ON team_ws.scope_user_id = ${scope_arg} "
+        f"WHERE team_s.owner_user_id = {event_alias}.owner_user_id "
+        f"AND team_s.session_id = {event_alias}.session_id "
+        f"AND NOT team_s.team_memory_excluded AND team_s.deleted_at IS NULL "
+        f"AND {owner_is_member})"
+    )
+
+
 async def has_changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | None) -> bool:
     """True if anything the curator cares about changed after `since`. A cheap
     gate — the beat task skips a curator run (and the sprite wake) when False."""
@@ -36,12 +54,14 @@ async def has_changes_since(owner_user_id: UUID, user_id: UUID, since: datetime 
         return True  # never curated → bootstrap.
     pool = get_pool()
     memory_ids = await files_tree_service.memory_subtree_folder_ids(owner_user_id)
+    team_shared = _team_shared_event_condition("he", 1)
     exists = await pool.fetchval(
-        """
+        f"""
         SELECT
-          EXISTS (SELECT 1 FROM history_events
-                  WHERE owner_user_id = $1 AND created_at > $2
-                    AND (session_id IS NULL OR session_id NOT LIKE 'agent-curate-%'))
+          EXISTS (SELECT 1 FROM history_events he
+                  WHERE (he.owner_user_id = $1 OR {team_shared})
+                    AND he.created_at > $2
+                    AND (he.session_id IS NULL OR he.session_id NOT LIKE 'agent-curate-%'))
           OR EXISTS (SELECT 1 FROM pages
                      WHERE owner_user_id = $1 AND updated_at > $2
                        AND ($3::uuid[] IS NULL OR folder_id IS NULL
@@ -57,6 +77,9 @@ async def has_changes_since(owner_user_id: UUID, user_id: UUID, since: datetime 
           OR EXISTS (SELECT 1 FROM instagram_save_docs
                      WHERE owner_user_id = $1 AND updated_at > $2
                        AND hydration_status = 'done' AND deleted_at IS NULL)
+          OR EXISTS (SELECT 1 FROM pages
+                     WHERE owner_user_id = $1 AND needs_recuration
+                       AND deleted_at IS NULL)
         """,
         owner_user_id,
         since,
@@ -83,6 +106,10 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
             "content": (e.get("content") or "")[:_SNIPPET],
             "created_at": _iso(e.get("created_at")),
             "folder": e.get("folder"),
+            "author": e.get("author"),
+            # For provenance: `--source <session_id>@<session_owner>` when
+            # writing pages built from this event's session.
+            "session_owner": str(e["session_owner"]) if e.get("session_owner") else None,
         }
         for e in events
     ]
@@ -206,6 +233,24 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
         for r in save_rows
     ]
 
+    # Pages whose recorded sources were excluded from team memory: the
+    # curator must rebuild each from its remaining material. A page write
+    # that restates sources clears the flag.
+    stale_rows = await pool.fetch(
+        "SELECT id, name, folder_id FROM pages "
+        "WHERE owner_user_id = $1 AND needs_recuration AND deleted_at IS NULL "
+        "ORDER BY updated_at",
+        owner_user_id,
+    )
+    stale_pages = [
+        {
+            "id": str(r["id"]),
+            "name": r["name"],
+            "folder_id": str(r["folder_id"]) if r["folder_id"] else None,
+        }
+        for r in stale_rows
+    ]
+
     all_sources = await source_service.list_sources(owner_user_id, user_id)
     sources = [
         {"source": s.get("source"), "type": s.get("type"), "display_name": s.get("display_name")}
@@ -222,6 +267,7 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
             "source_docs": len(source_docs),
             "saves": len(saves),
             "sources": len(sources),
+            "stale_pages": len(stale_pages),
         },
         "history": history,
         "history_has_more": history_has_more,
@@ -230,6 +276,7 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
         "source_docs": source_docs,
         "saves": saves,
         "sources": sources,
+        "stale_pages": stale_pages,
     }
 
 
@@ -251,7 +298,13 @@ async def _feed_events(
     folder of expert-sanctioned traces), so the curator must see it."""
     pool = get_pool()
     args: list = [owner_user_id]
-    where = "he.owner_user_id = $1 AND (he.session_id IS NULL OR he.session_id NOT LIKE 'agent-curate-%')"
+    # Own-scope events, plus — when $1 is a workspace scope — events of
+    # member sessions not excluded from team memory. The team wiki learns
+    # from everything members left in.
+    where = (
+        f"(he.owner_user_id = $1 OR {_team_shared_event_condition('he', 1)}) "
+        "AND (he.session_id IS NULL OR he.session_id NOT LIKE 'agent-curate-%')"
+    )
     if since is not None:
         args.append(since)
         where += f" AND he.created_at > ${len(args)}"
@@ -260,11 +313,13 @@ async def _feed_events(
         where += f" AND he.created_at <= ${len(args)}"
     rows = await pool.fetch(
         f"SELECT he.session_id, he.agent_name, he.event_type, he.content, he.created_at, "
-        f"sf.name AS folder "
+        f"he.owner_user_id AS session_owner, "
+        f"sf.name AS folder, author.display_name AS author "
         f"FROM history_events he "
         f"LEFT JOIN sessions s ON s.owner_user_id = he.owner_user_id "
         f"  AND s.session_id = he.session_id "
         f"LEFT JOIN session_folders sf ON sf.id = s.session_folder_id "
+        f"LEFT JOIN users author ON author.id = he.created_by "
         f"WHERE {where} "
         f"ORDER BY he.created_at, he.id LIMIT {limit + 1}",
         *args,

--- a/backend/services/page_provenance_service.py
+++ b/backend/services/page_provenance_service.py
@@ -1,0 +1,75 @@
+"""Which sessions a page was built from — and what that unlocks.
+
+Provenance turns two prompt-level hopes into mechanisms:
+- Excluding a session from team memory flags every page derived from it
+  (`needs_recuration`), so the curator's next run rebuilds them without the
+  excluded material. Opt-out reaches the past, not just the future.
+- A workspace's Team Skills page must cite sessions from >=2 distinct
+  authors. The bar is checked at write time and fails loud — never trusted
+  to the curator's good behavior.
+"""
+
+from uuid import UUID
+
+from ..database import get_pool
+from .team_service import TEAM_SKILLS_FOLDER
+
+
+class SkillsBarNotMet(Exception):
+    """A Team Skills write without >=2 distinct authors' sessions behind it."""
+
+
+async def enforce_team_skills_bar(
+    folder_id: UUID | None, sources: list[tuple[UUID, str]] | None
+) -> None:
+    """Writes into a workspace's Team Skills folder must cite sessions from
+    at least two distinct authors. Other folders (and personal scopes, which
+    have no workspace row) are unaffected."""
+    if folder_id is None:
+        return
+    pool = get_pool()
+    is_team_skills = await pool.fetchval(
+        "SELECT EXISTS (SELECT 1 FROM folders f "
+        "JOIN workspaces w ON w.scope_user_id = f.owner_user_id "
+        "WHERE f.id = $1 AND f.parent_folder_id IS NULL AND f.name = $2)",
+        folder_id,
+        TEAM_SKILLS_FOLDER,
+    )
+    if not is_team_skills:
+        return
+    distinct_authors = {owner for owner, _ in (sources or [])}
+    if len(distinct_authors) < 2:
+        raise SkillsBarNotMet(
+            "A team skill needs supporting sessions from at least two people "
+            "(pass source_sessions with >=2 distinct authors)."
+        )
+
+
+async def set_sources(page_id: UUID, sources: list[tuple[UUID, str]]) -> None:
+    """Replace the page's recorded sources and clear its recuration flag —
+    a write that states fresh sources IS the rebuild."""
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute("DELETE FROM page_sources WHERE page_id = $1", page_id)
+            await conn.executemany(
+                "INSERT INTO page_sources (page_id, session_owner_user_id, session_id) "
+                "VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
+                [(page_id, owner, session_id) for owner, session_id in sources],
+            )
+            await conn.execute("UPDATE pages SET needs_recuration = false WHERE id = $1", page_id)
+
+
+async def flag_pages_for_session(session_owner_user_id: UUID, session_id: str) -> int:
+    """Mark every page built from this session for recuration. Returns the
+    count so the consent surface can show the flip's real consequences."""
+    pool = get_pool()
+    result = await pool.execute(
+        "UPDATE pages SET needs_recuration = true "
+        "WHERE deleted_at IS NULL AND id IN "
+        "(SELECT page_id FROM page_sources "
+        " WHERE session_owner_user_id = $1 AND session_id = $2)",
+        session_owner_user_id,
+        session_id,
+    )
+    return int(result.split(" ")[-1])

--- a/backend/services/permission_service.py
+++ b/backend/services/permission_service.py
@@ -176,20 +176,25 @@ def _public_read_container_condition(
     return None
 
 
-def workspace_member_condition(workspace_alias: str, user_arg: int) -> str:
-    """SQL predicate: is user ${user_arg} a member of the workspace row at
-    `workspace_alias`? The single definition of membership: derived for
-    on-domain users (verified email on the workspace's domain — nothing to
-    enroll or revoke) plus stored `workspace_members` rows (explicit admin
-    adds, off-domain only)."""
+def _workspace_member_condition_expr(workspace_alias: str, user_expr: str) -> str:
+    """SQL predicate: is the user identified by `user_expr` (any SQL uuid
+    expression) a member of the workspace row at `workspace_alias`? The single
+    definition of membership: derived for on-domain users (verified email on
+    the workspace's domain — nothing to enroll or revoke) plus stored
+    `workspace_members` rows (explicit admin adds, off-domain only)."""
     return (
         f"(EXISTS (SELECT 1 FROM workspace_members member_row "
         f"WHERE member_row.workspace_id = {workspace_alias}.id "
-        f"AND member_row.user_id = ${user_arg}) "
+        f"AND member_row.user_id = {user_expr}) "
         f"OR EXISTS (SELECT 1 FROM users member_u "
-        f"WHERE member_u.id = ${user_arg} AND member_u.email_verified "
+        f"WHERE member_u.id = {user_expr} AND member_u.email_verified "
         f"AND lower(split_part(member_u.email, '@', 2)) = {workspace_alias}.domain))"
     )
+
+
+def workspace_member_condition(workspace_alias: str, user_arg: int) -> str:
+    """`_workspace_member_condition_expr` with the user as query arg ${user_arg}."""
+    return _workspace_member_condition_expr(workspace_alias, f"${user_arg}")
 
 
 def readable_content_condition(

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -203,6 +203,38 @@ Use the `stash` CLI for everything — every subcommand supports `--json`.
   global/approved (e.g. "Global — approved for learning") holds traces an
   expert has sanctioned: treat those as trustworthy, general knowledge and
   weight them above unsorted activity.
+- Each history event may carry an `author` — the person whose session it is.
+  On a team's wiki, attribution IS the value: write "Sam chose X because Y",
+  never an anonymous "it was decided that X". A wiki with one author reads
+  naturally without names; use judgment.
+- **Personal-session backstop (team wikis only).** If a session reads as
+  personal rather than work — health, compensation, job search, private
+  life — skip it entirely and add a Log line
+  (`skipped <session> — looks personal`). This is a backstop, not the
+  boundary: the owner's exclusion switch is the real control. When in doubt,
+  skip.
+- **Team Skills (team scopes only).** Alongside the wiki, maintain the
+  separate root-level `Team Skills` folder (a store of its own, NOT a wiki
+  category — find it with `stash ls / --json`): short, prescriptive,
+  procedural pages ("when doing X, do it this way") — the knowledge every
+  agent should carry, where the wiki holds the facts they look up. The bar
+  for a skill page: supported by **at least two different authors'**
+  sessions; one person's pattern stays a bullet on their relevant wiki page
+  until someone else exhibits it. Prefer updating an existing skill page
+  over creating a near-duplicate — eight copies of "write plain English" is
+  failure, one maintained page is success. Wiki pages may link to skills,
+  but skill content lives only in the skill folder.
+- **Record provenance on every write.** When a page draws on sessions, pass
+  each as `--source <session_id>@<session_owner>` to `stash memory write`
+  (both values are on the history events). Provenance is load-bearing, not
+  bookkeeping: it is how a person's later opt-out finds and rebuilds pages,
+  and how Team Skills' two-author bar is enforced — a skills write without
+  two distinct owners' sources is rejected.
+- **`stale_pages` in the delta are rebuild orders.** Their sources were
+  excluded from team memory. Rewrite each page from its remaining valid
+  material — drop what the excluded sessions contributed — and restate the
+  surviving `--source` entries, which clears the flag. Log each as
+  `rebuilt <page> — source excluded`.
 - `stash memory --json` — confirms the Memory folder id (`{memory_folder_id}`).
 - `stash ls /memory --json` and `stash read <page_id>` to inspect existing
   wiki pages. `stash search "<topic>" --json` to pull related source/file

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -10,7 +10,7 @@ from . import security_audit_service, session_folder_service
 
 _SELECT_COLS = (
     "id, owner_user_id, session_id, agent_name, cwd, files_touched, "
-    "started_at, finished_at, created_by"
+    "started_at, finished_at, created_by, team_memory_excluded"
 )
 
 

--- a/backend/services/team_service.py
+++ b/backend/services/team_service.py
@@ -1,0 +1,115 @@
+"""Team surface: membership and usage analytics for a workspace.
+
+Raw traces are never listed here — teammates see a transcript only via an
+explicit per-person share. What the team shares automatically is the
+*distilled* layer (the workspace curator's wiki + skills), whose inputs are
+every member session not excluded from team memory.
+"""
+
+from uuid import UUID
+
+from ..database import get_pool
+from .permission_service import _workspace_member_condition_expr
+
+# Rough tokens-from-characters divisor for usage analytics. An estimate is
+# honest here (the column is labeled estimated); exact counts would need
+# token counting at event ingest.
+_CHARS_PER_TOKEN = 4
+
+
+async def list_members(workspace_id: UUID) -> list[dict]:
+    """Everyone in the workspace: on-domain verified users (derived) plus
+    explicit off-domain adds. Mirrors `workspace_member_condition` exactly."""
+    pool = get_pool()
+    rows = await pool.fetch(
+        "SELECT u.id, u.name, u.display_name, u.email "
+        "FROM users u, workspaces w "
+        "WHERE w.id = $1 AND "
+        + _workspace_member_condition_expr("w", "u.id")
+        + " ORDER BY lower(u.display_name)",
+        workspace_id,
+    )
+    return [dict(row) for row in rows]
+
+
+TEAM_SKILLS_FOLDER = "Team Skills"
+
+
+async def get_or_create_team_skills_folder(scope_user_id: UUID) -> dict:
+    """The workspace's skill library — a root folder OUTSIDE the Memory wiki.
+
+    Experiment (2026-08-15): skills as a separate first-class store rather
+    than a promoted wiki category, to compare how the two shapes feel. The
+    curator writes short procedural pages here; the wiki keeps facts and
+    decisions."""
+    pool = get_pool()
+    select = (
+        "SELECT id, owner_user_id, parent_folder_id, name, created_by, created_at, updated_at "
+        "FROM folders WHERE owner_user_id = $1 AND parent_folder_id IS NULL "
+        "AND name = $2 LIMIT 1"
+    )
+    row = await pool.fetchrow(select, scope_user_id, TEAM_SKILLS_FOLDER)
+    if row:
+        return dict(row)
+    row = await pool.fetchrow(
+        "INSERT INTO folders (owner_user_id, name, created_by) VALUES ($1, $2, $1) "
+        "ON CONFLICT DO NOTHING "
+        "RETURNING id, owner_user_id, parent_folder_id, name, created_by, created_at, updated_at",
+        scope_user_id,
+        TEAM_SKILLS_FOLDER,
+    )
+    if row is None:  # lost a race — read the winner.
+        row = await pool.fetchrow(select, scope_user_id, TEAM_SKILLS_FOLDER)
+    return dict(row)
+
+
+async def list_team_skills(scope_user_id: UUID) -> dict:
+    """The skill library's pages, alphabetical. Creating the folder lazily
+    means the section exists from a team's first day."""
+    pool = get_pool()
+    folder = await get_or_create_team_skills_folder(scope_user_id)
+    pages = await pool.fetch(
+        "SELECT id, name, updated_at FROM pages "
+        "WHERE folder_id = $1 AND deleted_at IS NULL ORDER BY lower(name)",
+        folder["id"],
+    )
+    return {"folder": folder, "skills": [dict(p) for p in pages]}
+
+
+async def member_session_stats(workspace_id: UUID) -> list[dict]:
+    """Per-member session counts and estimated token volume for org
+    analytics. Metadata only — no titles, no content, no cwd: the audit
+    surface must never become a way to read what the privacy default
+    protects. Exclusion counts are deliberately NOT here: showing teammates
+    who opts out how often creates social pressure against using the
+    escape hatch, which would quietly break the consent design."""
+    pool = get_pool()
+    member = _workspace_member_condition_expr("w", "u.id")
+    rows = await pool.fetch(
+        f"""
+        SELECT u.id, u.name, u.display_name,
+               COUNT(DISTINCT s.id) FILTER (WHERE s.deleted_at IS NULL) AS sessions_total,
+               COUNT(DISTINCT s.id) FILTER (
+                 WHERE s.deleted_at IS NULL
+                   AND s.started_at > now() - interval '7 days') AS sessions_7d,
+               COUNT(DISTINCT s.id) FILTER (
+                 WHERE s.deleted_at IS NULL
+                   AND s.started_at > now() - interval '30 days') AS sessions_30d,
+               MAX(s.started_at) FILTER (WHERE s.deleted_at IS NULL) AS last_session_at,
+               (COALESCE(tok.chars_30d, 0) / {_CHARS_PER_TOKEN})::bigint AS est_tokens_30d
+        FROM users u
+        JOIN workspaces w ON w.id = $1
+        LEFT JOIN sessions s ON s.owner_user_id = u.id
+        LEFT JOIN LATERAL (
+          SELECT SUM(length(he.content)) AS chars_30d
+          FROM history_events he
+          WHERE he.owner_user_id = u.id
+            AND he.created_at > now() - interval '30 days'
+        ) tok ON true
+        WHERE {member}
+        GROUP BY u.id, u.name, u.display_name, tok.chars_30d
+        ORDER BY sessions_30d DESC, lower(u.display_name)
+        """,
+        workspace_id,
+    )
+    return [dict(row) for row in rows]

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -50,7 +50,7 @@ async def get_user_by_id(user_id: UUID) -> dict | None:
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT id, name, display_name, email, description, created_at, last_seen, "
-        "       role, referral_source, use_case "
+        "       role, referral_source, use_case, session_uploads_enabled "
         "FROM users WHERE id = $1",
         user_id,
     )
@@ -80,6 +80,7 @@ async def update_user(
     referral_source: str | None = None,
     use_case: str | None = None,
     plan_intent: str | None = None,
+    session_uploads_enabled: bool | None = None,
 ) -> dict:
     """Update profile fields. Password changes must present `current_password`,
     and revoke every other API key so a stolen session can't outlive the rotation.
@@ -128,10 +129,14 @@ async def update_user(
         sets.append(f"plan_intent = ${idx}")
         args.append(plan_intent)
         idx += 1
+    if session_uploads_enabled is not None:
+        sets.append(f"session_uploads_enabled = ${idx}")
+        args.append(session_uploads_enabled)
+        idx += 1
     if not sets:
         row = await pool.fetchrow(
             "SELECT id, name, display_name, email, description, created_at, last_seen, "
-            "       role, referral_source, use_case, plan, plan_intent "
+            "       role, referral_source, use_case, plan, plan_intent, session_uploads_enabled "
             "FROM users WHERE id = $1",
             user_id,
         )
@@ -140,7 +145,7 @@ async def update_user(
     row = await pool.fetchrow(
         f"UPDATE users SET {', '.join(sets)} WHERE id = ${idx} "
         "RETURNING id, name, display_name, email, description, created_at, last_seen, "
-        "          role, referral_source, use_case, plan, plan_intent",
+        "          role, referral_source, use_case, plan, plan_intent, session_uploads_enabled",
         *args,
     )
 

--- a/backend/services/workspace_service.py
+++ b/backend/services/workspace_service.py
@@ -58,6 +58,12 @@ async def create_workspace(name: str, domain: str) -> dict:
         scope_user["id"],
     )
     await user_scope_service.seed_user_scope(scope_user["id"])
+
+    # The team's Memory wiki: the workspace scope gets its own nightly curator,
+    # which learns from the scope's content plus members' team-visible sessions.
+    from . import agent_service
+
+    await agent_service.get_or_create_curator(scope_user["id"])
     return dict(workspace)
 
 

--- a/backend/tests/test_multiplier.py
+++ b/backend/tests/test_multiplier.py
@@ -1,0 +1,386 @@
+"""Multiplier: input-side consent for team learning.
+
+What matters here:
+- The master upload switch rejects loudly (403), never drops silently.
+- Raw transcripts are NEVER team-readable — a workspace co-member sees a
+  teammate's session only via an explicit per-person share.
+- Every member session feeds the team curator's inputs BY DEFAULT; the
+  per-session exclusion is the escape hatch, flippable only by the owner.
+- Team analytics stay metadata-only.
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from backend.services import curation_service
+
+from .conftest import unique_name
+from .test_permissions import _auth, _register_with_email
+from .test_workspaces import ADMIN, _create_workspace, _verify_email
+
+
+@pytest.fixture(autouse=True)
+def _admin_token(monkeypatch):
+    monkeypatch.setattr("backend.routers.admin.settings.ADMIN_PASSWORD", ADMIN["X-Admin-Token"])
+
+
+def _domain() -> str:
+    return f"{unique_name('team')}.com".lower()
+
+
+async def _member(client: AsyncClient, pool, domain: str) -> tuple[str, dict]:
+    key, body = await _register_with_email(client, f"{unique_name('u')}@{domain}")
+    await _verify_email(pool, uuid.UUID(body["id"]))
+    return key, body
+
+
+async def _push_event(client: AsyncClient, key: str, session_id: str, content: str) -> int:
+    resp = await client.post(
+        "/api/v1/me/sessions/events",
+        json={
+            "agent_name": "tester",
+            "event_type": "user_message",
+            "content": content,
+            "session_id": session_id,
+        },
+        headers=_auth(key),
+    )
+    return resp.status_code
+
+
+# --- The master upload switch (Idea 9) ---
+
+
+@pytest.mark.asyncio
+async def test_upload_switch_rejects_loudly_and_reversibly(client: AsyncClient):
+    key, _ = await _register_with_email(client, f"{unique_name('solo')}@example.com")
+
+    resp = await client.patch(
+        "/api/v1/users/me", json={"session_uploads_enabled": False}, headers=_auth(key)
+    )
+    assert resp.status_code == 200
+    assert resp.json()["session_uploads_enabled"] is False
+
+    assert await _push_event(client, key, "sess-blocked", "nope") == 403
+    resp = await client.post(
+        "/api/v1/me/sessions/events/batch",
+        json={
+            "events": [
+                {
+                    "agent_name": "tester",
+                    "event_type": "user_message",
+                    "content": "nope",
+                    "session_id": "sess-blocked",
+                }
+            ]
+        },
+        headers=_auth(key),
+    )
+    assert resp.status_code == 403
+
+    await client.patch(
+        "/api/v1/users/me", json={"session_uploads_enabled": True}, headers=_auth(key)
+    )
+    assert await _push_event(client, key, "sess-open", "hello") == 201
+
+
+# --- Raw traces never leak to the team ---
+
+
+@pytest.mark.asyncio
+async def test_raw_sessions_are_never_team_readable(client: AsyncClient, pool):
+    domain = _domain()
+    await _create_workspace(client, domain)
+    owner_key, _ = await _member(client, pool, domain)
+    teammate_key, _ = await _member(client, pool, domain)
+
+    assert await _push_event(client, owner_key, "sess-raw", "my private words") == 201
+
+    # In team memory by default — and STILL not readable by a co-member:
+    # participation feeds the distillation, never the transcript.
+    resp = await client.get("/api/v1/me/sessions/sess-raw", headers=_auth(owner_key))
+    assert resp.status_code == 200
+    assert resp.json()["team_memory_excluded"] is False
+
+    resp = await client.get("/api/v1/sessions/sess-raw", headers=_auth(teammate_key))
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_explicit_share_still_grants_a_teammate_the_transcript(client: AsyncClient, pool):
+    domain = _domain()
+    await _create_workspace(client, domain)
+    owner_key, owner = await _member(client, pool, domain)
+    teammate_key, teammate = await _member(client, pool, domain)
+
+    assert await _push_event(client, owner_key, "sess-handoff", "context for you") == 201
+    session = (
+        await client.get("/api/v1/me/sessions/sess-handoff", headers=_auth(owner_key))
+    ).json()
+
+    email = await pool.fetchval("SELECT email FROM users WHERE id = $1", uuid.UUID(teammate["id"]))
+    resp = await client.post(
+        "/api/v1/share",
+        json={"object_type": "session", "object_id": session["id"], "email": email},
+        headers=_auth(owner_key),
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = await client.get("/api/v1/sessions/sess-handoff", headers=_auth(teammate_key))
+    assert resp.status_code == 200
+
+
+# --- Per-session exclusion (the opt-out) ---
+
+
+@pytest.mark.asyncio
+async def test_only_the_owner_can_flip_exclusion(client: AsyncClient, pool):
+    domain = _domain()
+    await _create_workspace(client, domain)
+    owner_key, _ = await _member(client, pool, domain)
+    teammate_key, _ = await _member(client, pool, domain)
+
+    assert await _push_event(client, owner_key, "sess-mine", "mine") == 201
+
+    resp = await client.patch(
+        "/api/v1/me/sessions/sess-mine/team-memory",
+        json={"excluded": True},
+        headers=_auth(teammate_key),
+    )
+    assert resp.status_code == 404  # not their session, not their call
+
+    resp = await client.patch(
+        "/api/v1/me/sessions/sess-mine/team-memory",
+        json={"excluded": True},
+        headers=_auth(owner_key),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["team_memory_excluded"] is True
+
+
+# --- The team curator's inputs (opt-out semantics) ---
+
+
+@pytest.mark.asyncio
+async def test_workspace_curator_feed_default_in_exclusion_respected(client: AsyncClient, pool):
+    domain = _domain()
+    ws = await _create_workspace(client, domain)
+    scope_user_id = uuid.UUID(ws["scope_user_id"])
+    owner_key, owner = await _member(client, pool, domain)
+
+    assert await _push_event(client, owner_key, "sess-default-in", "a work learning") == 201
+    assert await _push_event(client, owner_key, "sess-opted-out", "keep this out") == 201
+    resp = await client.patch(
+        "/api/v1/me/sessions/sess-opted-out/team-memory",
+        json={"excluded": True},
+        headers=_auth(owner_key),
+    )
+    assert resp.status_code == 200
+
+    delta = await curation_service.changes_since(scope_user_id, scope_user_id, None)
+    feed_sessions = {e["session_id"] for e in delta["history"]}
+    assert "sess-default-in" in feed_sessions  # participates without any action
+    assert "sess-opted-out" not in feed_sessions  # exclusion is honored
+    default_event = next(e for e in delta["history"] if e["session_id"] == "sess-default-in")
+    assert default_event["author"] == owner["display_name"]
+
+    # The cheap gate agrees with the feed.
+    epoch = await pool.fetchval("SELECT now() - interval '1 day'")
+    assert await curation_service.has_changes_since(scope_user_id, scope_user_id, epoch)
+
+    # The owner's PERSONAL curator still sees both — exclusion is a team
+    # boundary, not a personal one.
+    personal = await curation_service.changes_since(
+        uuid.UUID(owner["id"]), uuid.UUID(owner["id"]), None
+    )
+    personal_sessions = {e["session_id"] for e in personal["history"]}
+    assert {"sess-default-in", "sess-opted-out"} <= personal_sessions
+
+
+# --- Team endpoints ---
+
+
+@pytest.mark.asyncio
+async def test_team_membership_and_metadata_only_analytics(client: AsyncClient, pool):
+    domain = _domain()
+    await _create_workspace(client, domain)
+    owner_key, owner = await _member(client, pool, domain)
+    teammate_key, _ = await _member(client, pool, domain)
+    loner_key, _ = await _register_with_email(client, f"{unique_name('l')}@nowhere.com")
+
+    assert await _push_event(client, owner_key, "sess-a", "learning one") == 201
+    assert await _push_event(client, owner_key, "sess-b", "keep out") == 201
+    await client.patch(
+        "/api/v1/me/sessions/sess-b/team-memory",
+        json={"excluded": True},
+        headers=_auth(owner_key),
+    )
+
+    resp = await client.get("/api/v1/me/team", headers=_auth(teammate_key))
+    assert resp.status_code == 200
+    member_ids = {m["id"] for m in resp.json()["members"]}
+    assert owner["id"] in member_ids and len(member_ids) >= 2
+
+    resp = await client.get("/api/v1/me/team/analytics", headers=_auth(teammate_key))
+    assert resp.status_code == 200
+    owner_row = next(m for m in resp.json()["members"] if m["id"] == owner["id"])
+    assert owner_row["sessions_total"] == 2
+    assert owner_row["est_tokens_30d"] > 0
+    # Metadata only — and deliberately NO exclusion counts: teammates seeing
+    # who opts out how often would pressure people away from the escape hatch.
+    assert set(owner_row) == {
+        "id",
+        "name",
+        "display_name",
+        "sessions_total",
+        "sessions_7d",
+        "sessions_30d",
+        "est_tokens_30d",
+        "last_session_at",
+    }
+
+    resp = await client.get("/api/v1/me/team", headers=_auth(loner_key))
+    assert resp.status_code == 404
+
+
+# --- Provenance: honest opt-out + the enforced skills bar ---
+
+
+@pytest.mark.asyncio
+async def test_exclusion_flags_derived_pages_and_curator_sees_rebuild_orders(
+    client: AsyncClient, pool
+):
+    domain = _domain()
+    ws = await _create_workspace(client, domain)
+    scope = ws["scope_user_id"]
+    owner_key, owner = await _member(client, pool, domain)
+
+    assert await _push_event(client, owner_key, "sess-src", "the learning") == 201
+
+    # A team wiki page recorded as built from that session.
+    resp = await client.post(
+        "/api/v1/me/pages/new",
+        json={
+            "name": "Derived learning",
+            "content": "distilled",
+            "source_sessions": [
+                {"owner_user_id": owner["id"], "session_id": "sess-src"}
+            ],
+        },
+        headers={**_auth(owner_key), "X-Stash-Scope": scope},
+    )
+    assert resp.status_code == 201, resp.text
+    page_id = resp.json()["id"]
+
+    # The owner opts the session out — the derived page is flagged, and the
+    # response says so.
+    resp = await client.patch(
+        "/api/v1/me/sessions/sess-src/team-memory",
+        json={"excluded": True},
+        headers=_auth(owner_key),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["pages_flagged"] == 1
+
+    flagged = await pool.fetchval(
+        "SELECT needs_recuration FROM pages WHERE id = $1", uuid.UUID(page_id)
+    )
+    assert flagged is True
+
+    # The workspace curator's delta carries the rebuild order.
+    delta = await curation_service.changes_since(
+        uuid.UUID(scope), uuid.UUID(scope), None
+    )
+    assert any(p["id"] == page_id for p in delta["stale_pages"])
+    epoch = await pool.fetchval("SELECT now() - interval '1 day'")
+    assert await curation_service.has_changes_since(
+        uuid.UUID(scope), uuid.UUID(scope), epoch
+    )
+
+    # A rebuild that restates sources clears the flag.
+    resp = await client.patch(
+        f"/api/v1/me/pages/{page_id}",
+        json={"content": "rebuilt without it", "source_sessions": []},
+        headers={**_auth(owner_key), "X-Stash-Scope": scope},
+    )
+    assert resp.status_code == 200, resp.text
+    flagged = await pool.fetchval(
+        "SELECT needs_recuration FROM pages WHERE id = $1", uuid.UUID(page_id)
+    )
+    assert flagged is False
+
+
+@pytest.mark.asyncio
+async def test_team_skills_bar_is_enforced_at_write_time(client: AsyncClient, pool):
+    domain = _domain()
+    ws = await _create_workspace(client, domain)
+    scope = ws["scope_user_id"]
+    author_a_key, author_a = await _member(client, pool, domain)
+    _, author_b = await _member(client, pool, domain)
+
+    assert await _push_event(client, author_a_key, "sess-a1", "pattern") == 201
+
+    resp = await client.get("/api/v1/me/team/skills", headers=_auth(author_a_key))
+    assert resp.status_code == 200
+    skills_folder = resp.json()["folder_id"]
+
+    # One author's sessions: rejected loudly.
+    resp = await client.post(
+        "/api/v1/me/pages/new",
+        json={
+            "name": "One-person pattern",
+            "content": "not yet a team skill",
+            "folder_id": skills_folder,
+            "source_sessions": [
+                {"owner_user_id": author_a["id"], "session_id": "sess-a1"}
+            ],
+        },
+        headers={**_auth(author_a_key), "X-Stash-Scope": scope},
+    )
+    assert resp.status_code == 422
+
+    # No sources at all: also rejected.
+    resp = await client.post(
+        "/api/v1/me/pages/new",
+        json={"name": "Sourceless", "content": "no", "folder_id": skills_folder},
+        headers={**_auth(author_a_key), "X-Stash-Scope": scope},
+    )
+    assert resp.status_code == 422
+
+    # Two distinct authors: accepted.
+    resp = await client.post(
+        "/api/v1/me/pages/new",
+        json={
+            "name": "Real team skill",
+            "content": "do it this way",
+            "folder_id": skills_folder,
+            "source_sessions": [
+                {"owner_user_id": author_a["id"], "session_id": "sess-a1"},
+                {"owner_user_id": author_b["id"], "session_id": "sess-b1"},
+            ],
+        },
+        headers={**_auth(author_a_key), "X-Stash-Scope": scope},
+    )
+    assert resp.status_code == 201, resp.text
+
+    # Personal scopes are untouched by the bar.
+    resp = await client.post(
+        "/api/v1/me/pages/new",
+        json={"name": "My own note", "content": "mine"},
+        headers=_auth(author_a_key),
+    )
+    assert resp.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_new_workspace_gets_a_curator(client: AsyncClient, pool):
+    ws = await _create_workspace(client, _domain())
+    row = await pool.fetchrow(
+        "SELECT run_mode, schedule_cron FROM agents WHERE user_id = $1 AND is_curator",
+        uuid.UUID(ws["scope_user_id"]),
+    )
+    assert row is not None
+    assert row["run_mode"] == "scheduled"
+    assert row["schedule_cron"]

--- a/cli/client.py
+++ b/cli/client.py
@@ -413,6 +413,7 @@ class StashClient:
         content_type: str = "markdown",
         content_html: str = "",
         html_layout: str | None = None,
+        source_sessions: list[dict] | None = None,
     ) -> dict:
         body: dict = {
             "name": name,
@@ -424,6 +425,8 @@ class StashClient:
             body["folder_id"] = folder_id
         if html_layout:
             body["html_layout"] = html_layout
+        if source_sessions is not None:
+            body["source_sessions"] = source_sessions
         return self._post("/api/v1/me/pages/new", json=body)
 
     def list_pages(self) -> list:

--- a/cli/main.py
+++ b/cli/main.py
@@ -3418,6 +3418,12 @@ def memory_write(
         "Missing subfolders are created; a trailing .md is stripped.",
     ),
     content: str = typer.Option(None, "--content", help="Page body. Reads stdin if omitted."),
+    sources: list[str] = typer.Option(
+        None,
+        "--source",
+        help="A session this page draws on, as <session_id>@<owner_uuid>. "
+        "Repeatable. Provenance drives opt-out cleanup and the team-skills bar.",
+    ),
     as_json: bool = typer.Option(False, "--json"),
 ):
     """Create or update a Memory wiki page at a path — the direct write
@@ -3427,6 +3433,17 @@ def memory_write(
     if content is None:
         console.print("[red]No content: pass --content or pipe the body on stdin.[/red]")
         raise typer.Exit(1)
+    source_sessions = None
+    if sources:
+        source_sessions = []
+        for token in sources:
+            session_id, sep, owner = token.partition("@")
+            if not sep or not session_id or not owner:
+                console.print(
+                    f"[red]--source must be <session_id>@<owner_uuid>, got '{token}'[/red]"
+                )
+                raise typer.Exit(1)
+            source_sessions.append({"session_id": session_id, "owner_user_id": owner})
     with _client() as c:
         try:
             page, folder_id, page_name = _resolve_memory_target(c, path)
@@ -3437,10 +3454,19 @@ def memory_write(
             _err(e)
         try:
             if page is None:
-                data = c.create_page(page_name, content=content, folder_id=folder_id)
+                data = c.create_page(
+                    page_name,
+                    content=content,
+                    folder_id=folder_id,
+                    source_sessions=source_sessions,
+                )
                 action = "created"
             else:
-                data = c.update_page(page["id"], content=content)
+                data = c.update_page(
+                    page["id"],
+                    content=content,
+                    **({"source_sessions": source_sessions} if source_sessions is not None else {}),
+                )
                 action = "updated"
         except StashError as e:
             _err(e)

--- a/frontend/src/app/(app)/activity/page.tsx
+++ b/frontend/src/app/(app)/activity/page.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import ActivityFeed from "@/components/ActivityFeed";
+import SessionUploadsSection from "@/components/settings/SessionUploadsSection";
+import { useAuth } from "@/hooks/useAuth";
+import {
+  listFileActivity,
+  listMySessions,
+  setSessionTeamMemory,
+  type ActivityEvent,
+  type SessionSummary,
+} from "@/lib/api";
+
+function relative(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return "just now";
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+// The command center: exactly what has been uploaded, in detail, with the
+// consent controls beside it. The trust surface of Multiplier.
+export default function CommandCenterPage() {
+  const { user, refresh } = useAuth();
+  const [sessions, setSessions] = useState<SessionSummary[] | null>(null);
+  const [events, setEvents] = useState<ActivityEvent[] | null>(null);
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+
+  useEffect(() => {
+    listMySessions(100)
+      .then(setSessions)
+      .catch((e) => setError(e instanceof Error ? e.message : "Load failed"));
+    listFileActivity({ limit: 50 })
+      .then((feed) => setEvents(feed.events))
+      .catch((e) => setError(e instanceof Error ? e.message : "Load failed"));
+  }, []);
+
+  async function toggleTeamMemory(session: SessionSummary) {
+    const next = !session.team_memory_excluded;
+    try {
+      const result = await setSessionTeamMemory(session.session_id, next);
+      setNotice(
+        next && result.pages_flagged > 0
+          ? `Excluded. ${result.pages_flagged} team memory page${
+              result.pages_flagged === 1 ? "" : "s"
+            } built from this session will be rebuilt without it on the next curator run.`
+          : ""
+      );
+      setSessions((prev) =>
+        prev
+          ? prev.map((s) =>
+              s.session_id === session.session_id
+                ? { ...s, team_memory_excluded: next }
+                : s
+            )
+          : prev
+      );
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Update failed");
+    }
+  }
+
+  return (
+    <main className="flex-1 overflow-y-auto px-4 py-10">
+      <div className="w-full max-w-3xl mx-auto space-y-8">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Command center</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Exactly what has been uploaded to your stash, and who can see it.
+          </p>
+        </div>
+
+        {user && <SessionUploadsSection user={user} onUpdated={refresh} />}
+        {error && <p className="text-xs text-error">{error}</p>}
+        {notice && (
+          <p className="rounded-lg border border-border bg-surface px-3 py-2 text-xs text-muted-foreground">
+            {notice}
+          </p>
+        )}
+
+        <section className="rounded-2xl border border-border bg-surface p-6">
+          <h2 className="text-base font-semibold text-foreground">Uploaded transcripts</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Every session in your stash. Raw transcripts stay private; by
+            default each session feeds your team&apos;s distilled wiki and
+            skills — the toggle excludes one.
+          </p>
+          <div className="mt-4 divide-y divide-border">
+            {sessions === null && (
+              <p className="py-3 text-sm text-muted-foreground">Loading…</p>
+            )}
+            {sessions?.length === 0 && (
+              <p className="py-3 text-sm text-muted-foreground">No sessions yet.</p>
+            )}
+            {sessions?.map((session) => (
+              <div
+                key={`${session.owner_user_id}-${session.session_id}`}
+                className="flex items-center gap-3 py-2.5"
+              >
+                <div className="min-w-0 flex-1">
+                  <Link
+                    href={`/sessions/${encodeURIComponent(session.session_id)}`}
+                    className="block truncate text-sm text-foreground hover:underline"
+                  >
+                    {session.title}
+                  </Link>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {[
+                      session.agent_name,
+                      session.session_folder_name,
+                      `${session.event_count} events`,
+                      relative(session.last_event_at),
+                    ]
+                      .filter(Boolean)
+                      .join(" · ")}
+                  </p>
+                </div>
+                {user && session.owner_user_id === user.id && session.id && (
+                  <button
+                    type="button"
+                    onClick={() => toggleTeamMemory(session)}
+                    className={`shrink-0 cursor-pointer rounded-md px-2 py-1 text-[11.5px] font-medium ${
+                      session.team_memory_excluded
+                        ? "bg-amber-600 text-white"
+                        : "border border-border text-muted-foreground hover:text-foreground"
+                    }`}
+                    title={
+                      session.team_memory_excluded
+                        ? "Excluded from team learning — click to include"
+                        : "Feeds team wiki & skills — click to exclude"
+                    }
+                  >
+                    {session.team_memory_excluded ? "Excluded" : "In team memory"}
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-border bg-surface p-6">
+          <h2 className="text-base font-semibold text-foreground">Files & pages</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Recent uploads and edits across your stash.
+          </p>
+          {events === null ? (
+            <p className="mt-4 text-sm text-muted-foreground">Loading…</p>
+          ) : events.length === 0 ? (
+            <p className="mt-4 text-sm text-muted-foreground">No activity yet.</p>
+          ) : (
+            <ActivityFeed events={events} />
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/(app)/sessions/[sessionId]/SessionClient.tsx
+++ b/frontend/src/app/(app)/sessions/[sessionId]/SessionClient.tsx
@@ -20,6 +20,7 @@ import {
   listSkills,
   materializeSession,
   renameSession,
+  setSessionTeamMemory,
   trashItem,
   type SessionDetail,
   type SessionEvent,
@@ -162,6 +163,38 @@ export default function SessionViewerPage({ sessionId }: { sessionId: string }) 
           >
             Resume in chat →
           </Link>
+        )}
+        {sessionDetail.owner_user_id === user.id && (
+          // Owner-only: excluding a session from team learning is personal
+          // consent, flipped here (or the command center) and nowhere else.
+          <button
+            type="button"
+            onClick={async () => {
+              const next = !sessionDetail.team_memory_excluded;
+              try {
+                await setSessionTeamMemory(sessionId, next);
+                setSessionDetail((prev) =>
+                  prev ? { ...prev, team_memory_excluded: next } : prev
+                );
+              } catch (e) {
+                setError(e instanceof Error ? e.message : "Update failed");
+              }
+            }}
+            className={`inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 text-[12.5px] font-medium ${
+              sessionDetail.team_memory_excluded
+                ? "bg-amber-600 text-white hover:bg-amber-700"
+                : "border border-border text-foreground hover:bg-surface-hover"
+            }`}
+            title={
+              sessionDetail.team_memory_excluded
+                ? "Excluded — your team's wiki and skills never learn from this session"
+                : "This session feeds your team's distilled memory — click to exclude it"
+            }
+          >
+            {sessionDetail.team_memory_excluded
+              ? "Excluded from team memory"
+              : "In team memory"}
+          </button>
         )}
         <ResourceShareButton
           objectType="session"

--- a/frontend/src/app/(app)/team/page.tsx
+++ b/frontend/src/app/(app)/team/page.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import {
+  askScopeStream,
+  getMyTeam,
+  getTeamAnalytics,
+  getTeamMemoryTree,
+  getTeamSkills,
+  type Team,
+  type TeamMemberStats,
+  type TeamSkill,
+  type TeamWikiFolder,
+  type TeamWikiTree,
+} from "@/lib/api";
+
+function relative(iso: string | null): string {
+  if (!iso) return "—";
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return "just now";
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+// The killer interaction: ask the team's shared brain, get a streamed
+// answer grounded in the team scope's wiki, skills, and shared material.
+function AskTeamBrain({ scopeUserId }: { scopeUserId: string }) {
+  const [question, setQuestion] = useState("");
+  const [answer, setAnswer] = useState("");
+  const [asking, setAsking] = useState(false);
+  const [error, setError] = useState("");
+
+  async function ask() {
+    const prompt = question.trim();
+    if (!prompt || asking) return;
+    setAsking(true);
+    setAnswer("");
+    setError("");
+    try {
+      await askScopeStream(scopeUserId, prompt, (delta) =>
+        setAnswer((prev) => prev + delta)
+      );
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Ask failed");
+    } finally {
+      setAsking(false);
+    }
+  }
+
+  return (
+    <section className="rounded-2xl border border-border bg-surface p-6">
+      <h2 className="text-base font-semibold text-foreground">
+        Ask the team brain
+      </h2>
+      <p className="mt-0.5 text-xs text-muted-foreground">
+        Answers come from team memory — the wiki, skills, and what members
+        have shared. Try &ldquo;how did we decide to enforce org
+        isolation?&rdquo;
+      </p>
+      <form
+        className="mt-3 flex gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          ask();
+        }}
+      >
+        <input
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          placeholder="Ask anything your team has worked on…"
+          className="min-w-0 flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500/40"
+        />
+        <button
+          type="submit"
+          disabled={asking || !question.trim()}
+          className="shrink-0 cursor-pointer rounded-lg bg-[var(--color-brand-600)] px-4 py-2 text-sm font-medium text-white hover:bg-[var(--color-brand-700)] disabled:opacity-60"
+        >
+          {asking ? "Thinking…" : "Ask"}
+        </button>
+      </form>
+      {error && <p className="mt-2 text-xs text-error">{error}</p>}
+      {answer && (
+        <div className="mt-3 whitespace-pre-wrap rounded-lg bg-background p-4 text-sm text-foreground">
+          {answer}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function WikiPageList({ pages }: { pages: { id: string; name: string }[] }) {
+  if (pages.length === 0) return null;
+  return (
+    <ul className="space-y-1">
+      {pages.map((page) => (
+        <li key={page.id}>
+          <Link
+            href={`/p/${page.id}`}
+            className="text-sm text-foreground hover:underline"
+          >
+            {page.name.replace(/\.md$/, "")}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function WikiCategory({ folder }: { folder: TeamWikiFolder }) {
+  return (
+    <div>
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {folder.name}
+      </h3>
+      <div className="mt-1.5 space-y-4 pl-3 border-l border-border">
+        <WikiPageList pages={folder.pages} />
+        {folder.folders.map((child) => (
+          <WikiCategory key={child.id} folder={child} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function compact(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+// The team page: who's here, what the shared brain is built from, and
+// usage analytics. Raw traces are never listed — teammates see a transcript
+// only via an explicit per-person share. Analytics are metadata-only by
+// design: counts and timestamps, never content.
+export default function TeamPage() {
+  const [team, setTeam] = useState<Team | null | undefined>(undefined);
+  const [stats, setStats] = useState<TeamMemberStats[] | null>(null);
+  const [wiki, setWiki] = useState<TeamWikiTree | null>(null);
+  const [skills, setSkills] = useState<TeamSkill[] | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    getMyTeam()
+      .then((result) => {
+        setTeam(result);
+        if (!result) return;
+        getTeamAnalytics()
+          .then((data) => setStats(data.members))
+          .catch((e) => setError(e instanceof Error ? e.message : "Load failed"));
+        getTeamMemoryTree(result.scope_user_id)
+          .then(setWiki)
+          .catch((e) => setError(e instanceof Error ? e.message : "Load failed"));
+        getTeamSkills()
+          .then((data) => setSkills(data.skills))
+          .catch((e) => setError(e instanceof Error ? e.message : "Load failed"));
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : "Load failed"));
+  }, []);
+
+  if (team === undefined) {
+    return (
+      <main className="flex-1 px-4 py-10">
+        <p className="mx-auto max-w-3xl text-sm text-muted-foreground">Loading…</p>
+      </main>
+    );
+  }
+
+  if (team === null) {
+    return (
+      <main className="flex-1 px-4 py-10">
+        <div className="mx-auto max-w-3xl space-y-2">
+          <h1 className="text-2xl font-semibold text-foreground">Team</h1>
+          <p className="text-sm text-muted-foreground">
+            You&apos;re not in a workspace yet. Workspaces are created by the
+            Stash team for your company domain — reach out and we&apos;ll set
+            one up.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="flex-1 overflow-y-auto px-4 py-10">
+      <div className="w-full max-w-3xl mx-auto space-y-8">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">{team.name}</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            {team.members.length} member{team.members.length === 1 ? "" : "s"} ·{" "}
+            {team.domain}
+          </p>
+        </div>
+        {error && <p className="text-xs text-error">{error}</p>}
+
+        <AskTeamBrain scopeUserId={team.scope_user_id} />
+
+        <section className="rounded-2xl border border-border bg-surface p-6">
+          <h2 className="text-base font-semibold text-foreground">Team skills</h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Procedural know-how distilled from at least two members&apos; work —
+            the part of team knowledge agents should carry, not look up.
+            (Auto-loading into agents is coming; for now they live here.)
+          </p>
+          <div className="mt-4">
+            {skills === null ? (
+              <p className="text-sm text-muted-foreground">Loading…</p>
+            ) : skills.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No skills yet — the curator distills them from members&apos;
+                sessions.
+              </p>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {skills.map((skill) => (
+                  <Link
+                    key={skill.id}
+                    href={`/p/${skill.id}`}
+                    className="rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground hover:border-foreground/30"
+                  >
+                    {skill.name.replace(/\.md$/, "")}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-border bg-surface p-6">
+          <h2 className="text-base font-semibold text-foreground">Team wiki</h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Every member&apos;s sessions feed the team&apos;s wiki and skills
+            by default — distilled and attributed, never the raw transcripts.
+            Exclude any session from the{" "}
+            <Link href="/activity" className="underline hover:text-foreground">
+              command center
+            </Link>{" "}
+            or its own page. The curator runs nightly.
+          </p>
+          <div className="mt-4">
+            {wiki === null ? (
+              <p className="text-sm text-muted-foreground">Loading…</p>
+            ) : wiki.folders.length === 0 && wiki.pages.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No pages yet — the curator writes here after its first run.
+              </p>
+            ) : (
+              <div className="space-y-4">
+                <WikiPageList pages={wiki.pages} />
+                {wiki.folders.map((folder) => (
+                  <WikiCategory key={folder.id} folder={folder} />
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-border bg-surface p-6">
+          <h2 className="text-base font-semibold text-foreground">Usage</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Per member — metadata only, never content. Token volume is
+            estimated from transcript size.
+          </p>
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs text-muted-foreground">
+                  <th className="py-1.5 pr-4 font-medium">Member</th>
+                  <th className="py-1.5 pr-4 font-medium text-right">7d</th>
+                  <th className="py-1.5 pr-4 font-medium text-right">30d</th>
+                  <th className="py-1.5 pr-4 font-medium text-right">Total</th>
+                  <th className="py-1.5 pr-4 font-medium text-right">
+                    ~Tokens (30d)
+                  </th>
+                  <th className="py-1.5 font-medium text-right">Last session</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {stats === null && (
+                  <tr>
+                    <td colSpan={6} className="py-3 text-muted-foreground">
+                      Loading…
+                    </td>
+                  </tr>
+                )}
+                {stats?.map((member) => (
+                  <tr key={member.id}>
+                    <td className="py-2 pr-4 text-foreground">
+                      {member.display_name}
+                    </td>
+                    <td className="py-2 pr-4 text-right">{member.sessions_7d}</td>
+                    <td className="py-2 pr-4 text-right">{member.sessions_30d}</td>
+                    <td className="py-2 pr-4 text-right">{member.sessions_total}</td>
+                    <td className="py-2 pr-4 text-right">
+                      {compact(member.est_tokens_30d)}
+                    </td>
+                    <td className="py-2 text-right text-muted-foreground">
+                      {relative(member.last_session_at)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -8,6 +8,7 @@ import IntegrationsSettings from "../../components/integrations/IntegrationsSett
 import SubscriptionSection from "../../components/settings/SubscriptionSection";
 import AgentModelSection from "../../components/settings/AgentModelSection";
 import ExportSection from "../../components/settings/ExportSection";
+import SessionUploadsSection from "../../components/settings/SessionUploadsSection";
 import { AccountSettingsSkeleton, ApiKeysSkeleton } from "../../components/SkeletonStates";
 import { useAuth } from "../../hooks/useAuth";
 import {
@@ -54,6 +55,7 @@ export default function SettingsPage() {
             </p>
           </div>
           <Profile user={user} onUpdated={refresh} />
+          <SessionUploadsSection user={user} onUpdated={refresh} />
           <SubscriptionSection />
           <AgentModelSection />
           <IntegrationsSettings embedded />

--- a/frontend/src/components/memory/BrainDashboard.tsx
+++ b/frontend/src/components/memory/BrainDashboard.tsx
@@ -139,9 +139,19 @@ export default function BrainDashboard() {
   return (
     <div className="h-full min-h-0 overflow-y-auto">
       <div className="mx-auto max-w-[1360px] px-8 pb-10 pt-7">
-        <h1 className="font-display text-[22px] font-semibold tracking-tight text-foreground">
-          Welcome back{firstName ? `, ${firstName}` : ""}
-        </h1>
+        <div className="flex items-baseline justify-between gap-4">
+          <h1 className="font-display text-[22px] font-semibold tracking-tight text-foreground">
+            Welcome back{firstName ? `, ${firstName}` : ""}
+          </h1>
+          <div className="flex shrink-0 gap-3 text-[12.5px] text-muted-foreground">
+            <Link href="/activity" className="hover:text-foreground hover:underline">
+              Command center
+            </Link>
+            <Link href="/team" className="hover:text-foreground hover:underline">
+              Team
+            </Link>
+          </div>
+        </div>
 
         {vitals && (
           <div className="mt-4 grid max-w-lg grid-cols-3 gap-3">

--- a/frontend/src/components/settings/SessionUploadsSection.tsx
+++ b/frontend/src/components/settings/SessionUploadsSection.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { updateMe } from "../../lib/api";
+import type { User } from "../../lib/types";
+
+// The master consent switch (Multiplier). Off = the backend rejects new
+// session uploads outright, so agents surface the refusal instead of
+// streaming into a void.
+export default function SessionUploadsSection({
+  user,
+  onUpdated,
+}: {
+  user: User;
+  onUpdated: () => void;
+}) {
+  const enabled = user.session_uploads_enabled !== false;
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  async function toggle() {
+    setSaving(true);
+    setError("");
+    try {
+      await updateMe({ session_uploads_enabled: !enabled });
+      onUpdated();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Update failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="rounded-2xl border border-border bg-surface p-6 space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-base font-semibold text-foreground">Session uploads</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {enabled
+              ? "Your agents' session transcripts are uploaded to your private stash. " +
+                "Raw transcripts stay private; distilled learnings feed your team's " +
+                "wiki and skills unless you exclude a session."
+              : "Uploads are off: agents attempting to push transcripts get an " +
+                "explicit error. Existing sessions are untouched."}
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={enabled}
+          onClick={toggle}
+          disabled={saving}
+          className={`cursor-pointer relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors disabled:opacity-60 ${
+            enabled ? "bg-brand" : "bg-border"
+          }`}
+        >
+          <span
+            className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+              enabled ? "translate-x-6" : "translate-x-1"
+            }`}
+          />
+        </button>
+      </div>
+      {error && <p className="text-xs text-error">{error}</p>}
+    </section>
+  );
+}

--- a/frontend/src/components/workspace/rail.test.tsx
+++ b/frontend/src/components/workspace/rail.test.tsx
@@ -1,7 +1,8 @@
-// The rail is the app's whole navigation surface, and its five sections are a
+// The rail is the app's whole navigation surface, and its six sections are a
 // claim about where content lives: Sessions and Skills are VFS mounts, not
-// destinations of their own. If a session route stopped lighting up the VFS
-// button, the user would be inside a section the rail says they aren't in.
+// destinations of their own (Team covers the shared brain + command center).
+// If a session route stopped lighting up the VFS button, the user would be
+// inside a section the rail says they aren't in.
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
@@ -51,12 +52,12 @@ afterEach(() => {
 });
 
 describe("Rail", () => {
-  it("offers exactly the five sections", () => {
+  it("offers exactly the six sections", () => {
     renderAt("/");
     const labels = Array.from(document.querySelectorAll("[aria-label]")).map((el) =>
       el.getAttribute("aria-label"),
     );
-    expect(labels).toEqual(["Integrations", "Home", "Viz", "VFS", "Chat", "Settings"]);
+    expect(labels).toEqual(["Integrations", "Home", "Team", "Viz", "VFS", "Chat", "Settings"]);
   });
 
   it("shows sessions as part of the VFS, not a section of their own", () => {

--- a/frontend/src/components/workspace/rail.tsx
+++ b/frontend/src/components/workspace/rail.tsx
@@ -3,7 +3,7 @@
 import { Fragment, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Bot, FolderTree, Home, Network, Plug, Settings } from "lucide-react";
+import { Bot, FolderTree, Home, Network, Plug, Settings, Users } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import { useWorkspace, type RailSection } from "@/lib/workspace-store";
@@ -16,6 +16,7 @@ type RailItem = { key: RailSection; label: string; icon: typeof Bot; match: (p: 
 const PRIMARY: RailItem[] = [
   { key: "integrations", label: "Integrations", icon: Plug, match: (p) => p.startsWith("/integrations") },
   { key: "home", label: "Home", icon: Home, match: (p) => p === "/" },
+  { key: "team", label: "Team", icon: Users, match: (p) => p.startsWith("/team") || p.startsWith("/activity") },
   { key: "viz", label: "Viz", icon: Network, match: (p) => p.startsWith("/viz") },
   { key: "files", label: "VFS", icon: FolderTree, match: (p) => p === "/files" || p.startsWith("/f/") || p.startsWith("/p/") || p.startsWith("/folders/") || p.startsWith("/tables/") || p.startsWith("/sessions") || p.startsWith("/session-folders") || p.startsWith("/skills") },
   { key: "agents", label: "Chat", icon: Bot, match: (p) => p.startsWith("/agents") },
@@ -121,6 +122,7 @@ export default function Rail({ user, onLogout }: { user: User; onLogout: () => v
     // Every other section is a page; the rail is pure navigation.
     const LANDING: Record<Exclude<RailSection, "files" | "computer">, string> = {
       home: "/",
+      team: "/team",
       agents: "/agents",
       integrations: "/integrations",
       viz: "/viz",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -135,8 +135,10 @@ export async function apiFetch<T>(
   if (token) {
     headers["Authorization"] = `Bearer ${token}`;
   }
+  // The switcher's scope is the default; a caller that names a scope in its
+  // own headers (e.g. the Team page reading the team wiki) wins.
   const scopeUserId = getScopeUserId();
-  if (scopeUserId) {
+  if (scopeUserId && !headers[SCOPE_HEADER]) {
     headers[SCOPE_HEADER] = scopeUserId;
   }
 
@@ -215,6 +217,7 @@ export async function updateMe(data: {
   referral_source?: string;
   use_case?: string;
   plan_intent?: string;
+  session_uploads_enabled?: boolean;
 }): Promise<User> {
   return apiFetch("/api/v1/users/me", {
     method: "PATCH",
@@ -1209,6 +1212,7 @@ export interface SessionSummary {
   last_event_at: string;
   session_folder_id: string | null;
   session_folder_name: string | null;
+  team_memory_excluded: boolean | null;
 }
 
 export type GeneralPermission = "none" | "read" | "comment" | "write";
@@ -1355,6 +1359,7 @@ export interface SessionDetail {
   started_at: string | null;
   finished_at: string | null;
   created_by: string | null;
+  team_memory_excluded: boolean;
   artifacts: SessionArtifact[];
 }
 
@@ -1374,6 +1379,133 @@ export async function renameSession(
       body: JSON.stringify({ title }),
     }
   );
+}
+
+// Exclude one of your own sessions from (or return it to) team learning.
+// Sessions feed the team's distilled memory by default; this is the opt-out.
+export async function setSessionTeamMemory(
+  sessionId: string,
+  excluded: boolean
+): Promise<{ team_memory_excluded: boolean; pages_flagged: number }> {
+  return apiFetch(
+    `${ME}/sessions/${encodeURIComponent(sessionId)}/team-memory`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ excluded }),
+    }
+  );
+}
+
+export interface TeamMember {
+  id: string;
+  name: string;
+  display_name: string;
+  email: string | null;
+}
+
+export interface Team {
+  id: string;
+  name: string;
+  domain: string;
+  scope_user_id: string;
+  members: TeamMember[];
+}
+
+// null = the user is not in a workspace (the Team page shows its empty state).
+export async function getMyTeam(): Promise<Team | null> {
+  try {
+    return await apiFetch<Team>(`${ME}/team`);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return null;
+    throw err;
+  }
+}
+
+export interface TeamWikiFolder {
+  id: string;
+  name: string;
+  folders: TeamWikiFolder[];
+  pages: { id: string; name: string }[];
+}
+
+export interface TeamWikiTree {
+  folders: TeamWikiFolder[];
+  pages: { id: string; name: string }[];
+}
+
+// The team's Memory wiki, read in the workspace's scope. The explicit scope
+// header makes this independent of whatever scope the switcher has active;
+// membership is enforced server-side.
+export async function getTeamMemoryTree(scopeUserId: string): Promise<TeamWikiTree> {
+  return apiFetch(`${ME}/memory-tree`, {
+    headers: { [SCOPE_HEADER]: scopeUserId },
+  });
+}
+
+export interface TeamSkill {
+  id: string;
+  name: string;
+  updated_at: string;
+}
+
+// The team's skill library — separate store from the wiki (experiment):
+// procedural how-tos every agent should carry vs. facts to look up.
+export async function getTeamSkills(): Promise<{ folder_id: string; skills: TeamSkill[] }> {
+  return apiFetch(`${ME}/team/skills`);
+}
+
+// Ask a scope's brain one question, streaming text deltas as they arrive.
+// Used by the Team page with the workspace's scope — "ask the team brain".
+export async function askScopeStream(
+  scopeUserId: string,
+  prompt: string,
+  onDelta: (text: string) => void
+): Promise<void> {
+  const token = await getAuthToken();
+  const res = await fetch(`${API_BASE}${ME}/ask`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      [SCOPE_HEADER]: scopeUserId,
+    },
+    body: JSON.stringify({ messages: [{ role: "user", content: prompt }] }),
+  });
+  if (!res.ok || !res.body) {
+    const body = await res.json().catch(() => ({ detail: res.statusText }));
+    throw new ApiError(res.status, body.detail ?? `API error ${res.status}`);
+  }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const frames = buffer.split("\n\n");
+    buffer = frames.pop() ?? "";
+    for (const frame of frames) {
+      if (!frame.startsWith("data: ")) continue;
+      const event = JSON.parse(frame.slice(6));
+      if (event.type === "text" && event.delta) onDelta(event.delta);
+    }
+  }
+}
+
+export interface TeamMemberStats {
+  id: string;
+  name: string;
+  display_name: string;
+  sessions_total: number;
+  sessions_7d: number;
+  sessions_30d: number;
+  est_tokens_30d: number;
+  last_session_at: string | null;
+}
+
+export async function getTeamAnalytics(): Promise<{ members: TeamMemberStats[] }> {
+  return apiFetch(`${ME}/team/analytics`);
 }
 
 export async function deleteSession(sessionRowId: string): Promise<void> {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -6,6 +6,7 @@ export interface User {
   description: string;
   created_at: string;
   last_seen: string;
+  session_uploads_enabled?: boolean;
 }
 
 export interface RegisterResponse {

--- a/frontend/src/lib/workspace-store.ts
+++ b/frontend/src/lib/workspace-store.ts
@@ -13,7 +13,14 @@ import { WORKBENCH_TAB_KINDS } from "@/lib/workspace-routes";
  * components/workspace/persistence.tsx (localStorage).
  */
 
-export type RailSection = "home" | "files" | "agents" | "integrations" | "viz" | "computer";
+export type RailSection =
+  | "home"
+  | "team"
+  | "files"
+  | "agents"
+  | "integrations"
+  | "viz"
+  | "computer";
 
 export type TabKind = "page" | "file" | "table" | "session" | "sessions-home" | "skill" | "folder" | "agent" | "agent-config" | "tool" | "machine-file" | "terminal";
 


### PR DESCRIPTION
The internal ("for your team") half of the multi-tenant design, built to the spec settled in the PM sessions: **everything a member does feeds the team's distilled memory by default; every control is input-side consent; raw transcripts never cross.**

## What this is

- **Team = the existing workspace.** No new tenancy model — the workspace scope user gets its own nightly Memory curator, whose change feed adds members' non-excluded sessions with **author attribution** ("Sam chose X because Y" — attribution is the product internally).
- **Two consent switches:**
  - `users.session_uploads_enabled` — master switch; off = upload endpoints **403 loudly**, never a silent drop.
  - `sessions.team_memory_excluded` — per-session opt-out, owner-only. Default is in.
- **Raw transcripts are never team-readable.** Participation feeds the distillation only; a teammate reads a transcript only via an explicit per-person share (existing shares machinery). Tested in both directions.
- **Team skills as a separate library** (deliberate experiment vs. promoted-wiki-category — both shapes are in this branch's history for comparison): a root-level folder on the workspace scope with its own endpoint and Team-page section.
- **Provenance makes the guarantees mechanical, not prompted:**
  - `page_sources` records which sessions each curated page was built from (`stash memory write --source <session>@<owner>`).
  - Excluding a session **flags every derived page for rebuild** (`pages.needs_recuration` → `stale_pages` in the curator delta; a write restating sources clears it). The toggle response reports the consequence count.
  - A Team Skills write **requires sessions from ≥2 distinct authors or 422s** — the dedupe/privacy bar is enforced at the API, not requested of the curator.

## Surfaces

- **Team** rail section (sixth icon) → `/team`: ask-the-team-brain (streamed, scoped `/me/ask`), the skills library, the team wiki tree, and metadata-only usage analytics. Deliberately **no per-member exclusion counts** — surfacing who opts out would socially pressure people away from the escape hatch.
- **Command center** (`/activity`): every uploaded transcript with its in/out toggle + consequences, the master switch, and the file/page feed.
- Settings gains the Session-uploads section; session pages gain the in/out toggle.

## Not in this PR (known, deliberate)

Skills auto-loading into agents (the push channel), plugin-side "this will feed team memory" indicator, real token counts at ingest (analytics uses labeled estimates), and the workspace curator's first real run (needs agent credentials).

## Verification

- Backend: **1377 passed** (9 new in `test_multiplier.py`: switch semantics, never-team-readable, share-still-works, owner-only flips, curator feed default-in/exclusion, provenance flagging, enforced skills bar, workspace-curator creation). Ruff clean.
- Frontend: **317 passed**, lint clean, production build clean.
- Migrations 0185–0188 up/down clean; exercised live end-to-end on a seeded demo workspace (two users, shared/excluded sessions, provenance-backed wiki + skills, ask box answering from team memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes privacy/consent defaults (sessions feed team learning unless excluded), expands curator inputs across workspace members, and adds migrations plus enforced write-time rules on team skills — high impact if misconfigured or misunderstood.
> 
> **Overview**
> Introduces **Multiplier** — workspace-scoped team learning on top of existing workspaces, with input-side consent and no team-wide raw transcript access.
> 
> **Consent & uploads:** `session_uploads_enabled` on users blocks session/event/transcript uploads with **403** via `require_session_uploads`. Per-session `team_memory_excluded` (opt-out by default in) is owner-only via `PATCH /me/sessions/{id}/team-memory`; excluding flags derived wiki pages for rebuild and returns `pages_flagged`.
> 
> **Team memory & curator:** Workspace scopes get a nightly Memory curator (create + migration backfill). The curator delta now includes **non-excluded member sessions** (with `author` / `session_owner`), `stale_pages` when opt-out invalidates provenance, and workspace **memory recompute** runs against the active scope’s curator. Curator prompts add Team Skills, attribution, provenance, and personal-content backstop rules.
> 
> **Provenance:** `page_sources` + `needs_recuration`; page create/update accepts `source_sessions` and **422s** Team Skills writes without ≥2 distinct session authors. CLI `stash memory write --source` passes provenance through.
> 
> **API & UI:** New `/api/v1/me/team` (members, skills, metadata-only analytics). Frontend **Team** and **Command center** (`/activity`) pages, session upload settings, rail updates, and team-memory toggles on sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f06ee7fb3720f29244d41d2f86d248a03ac0b8a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->