### PR TITLE
chore: bump stash release to 0.1.365 and plugin to 0.1.436

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "stash",
       "source": "./plugins/claude-plugin",
       "description": "Connect Claude Code to Stash \u2014 stream activity to history, inject agent memory, collaborate in workspaces.",
-      "version": "0.1.435",
+      "version": "0.1.436",
       "category": "productivity",
       "homepage": "https://joinstash.ai",
       "author": {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -60,7 +60,7 @@ services:
       retries: 5
 
   backend:
-    image: ghcr.io/fergana-labs/stash-backend:0.1.364
+    image: ghcr.io/fergana-labs/stash-backend:0.1.365
     restart: always
     expose:
       - "3456"
@@ -83,7 +83,7 @@ services:
       start_period: 30s
 
   worker:
-    image: ghcr.io/fergana-labs/stash-backend:0.1.364
+    image: ghcr.io/fergana-labs/stash-backend:0.1.365
     restart: always
     depends_on:
       postgres:
@@ -105,7 +105,7 @@ services:
   # a 30-min task. Concurrency 2 keeps 2 children x 800MB (see
   # worker_max_memory_per_child) plus the parent inside a 2GB box.
   heavy-worker:
-    image: ghcr.io/fergana-labs/stash-backend:0.1.362
+    image: ghcr.io/fergana-labs/stash-backend:0.1.365
     restart: always
     depends_on:
       postgres:
@@ -123,7 +123,7 @@ services:
     command: ["celery", "-A", "backend.celery_app", "worker", "--loglevel=info", "--concurrency=2", "-Q", "heavy"]
 
   beat:
-    image: ghcr.io/fergana-labs/stash-backend:0.1.364
+    image: ghcr.io/fergana-labs/stash-backend:0.1.365
     restart: always
     depends_on:
       redis:
@@ -139,7 +139,7 @@ services:
     command: ["celery", "-A", "backend.celery_app", "beat", "--loglevel=info"]
 
   frontend:
-    image: ghcr.io/fergana-labs/stash-frontend:0.1.364
+    image: ghcr.io/fergana-labs/stash-frontend:0.1.365
     restart: always
     expose:
       - "3457"

--- a/plugins/claude-plugin/.claude-plugin/plugin.json
+++ b/plugins/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stash",
-  "version": "0.1.435",
+  "version": "0.1.436",
   "description": "Connect Claude Code to Stash \u2014 stream activity to your Stash and collaborate with your other agents.",
   "author": {
     "name": "Fergana Labs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.364"
+version = "0.1.365"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
bump version


# slop


The published 0.1.364 wheel predates the stash-revamp merge (#1021), so the released CLI has no `stash sql` — verified against PyPI: 0.1.364 was uploaded 2026-08-10 16:43, before the revamp landed. Running `stash sql` on the released CLI today errors with "No such command 'sql'". This release picks up `stash sql` and everything since.

Also brings `docker-compose.prod.yml`'s `heavy-worker` image from 0.1.362 to 0.1.365 — it was left behind by the last two bumps while every sibling service moved in lockstep. Flagging in case the pin was deliberate; nothing in the file says so.

On merge, `publish.yml` tags `v0.1.365`, publishes the sdist + wheel to PyPI, and dispatches the GHCR image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime code changes—only version strings and GHCR image tags for self-hosted compose; merge triggers standard publish workflows.
> 
> **Overview**
> **Release cut** so PyPI/GHCR ship code merged after 0.1.364 (notably **`stash sql`** from the stash-revamp work). On merge, `publish.yml` should tag `v0.1.365`, publish the `stashai` wheel/sdist, and build the pinned container images.
> 
> Version-only edits: `pyproject.toml` → **0.1.365**; Claude plugin marketplace + `plugin.json` → **0.1.436**; `docker-compose.prod.yml` pins **backend/worker/beat/frontend** at **0.1.365**. **`heavy-worker`** moves from **0.1.362** to **0.1.365** so it matches the other backend services (was lagging prior bumps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86f679bbbd9d2f42e890f8411a90a563dcbf6386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->