### PR TITLE
stash sql reads mounted external Postgres (Supabase et al.)

### DIFF
--- a/backend/migrations/versions/0185_pg_mounts.py
+++ b/backend/migrations/versions/0185_pg_mounts.py
@@ -1,0 +1,37 @@
+"""External read-only Postgres mounts, queryable through stash sql.
+
+A mount names a customer-side database (e.g. a Supabase project) whose
+tables materialize into the per-query DuckDB alongside the scope's native
+tables. The DSN is Fernet-encrypted with the integrations keyring, same as
+OAuth tokens.
+
+Revision ID: 0185
+Revises: 0184
+"""
+
+from alembic import op
+
+revision = "0185"
+down_revision = "0184"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE pg_mounts (
+            id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            owner_user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            name text NOT NULL,
+            dsn_encrypted bytea NOT NULL,
+            remote_schema text NOT NULL DEFAULT 'public',
+            created_at timestamptz NOT NULL DEFAULT now(),
+            UNIQUE (owner_user_id, name)
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE pg_mounts")

--- a/backend/models.py
+++ b/backend/models.py
@@ -498,6 +498,22 @@ class SqlQueryResponse(BaseModel):
     truncated: bool
 
 
+class PgMountCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=32)
+    dsn: str = Field(..., min_length=1, max_length=2000)
+    remote_schema: str = Field("public", min_length=1, max_length=63)
+
+
+class PgMountInfo(BaseModel):
+    id: str
+    name: str
+    host: str
+    database: str
+    remote_schema: str
+    created_at: str
+    table_count: int | None = None
+
+
 # --- History ---
 
 

--- a/backend/routers/sql.py
+++ b/backend/routers/sql.py
@@ -1,13 +1,15 @@
-"""SQL router: read-only queries over the scope's tables via stash sql."""
+"""SQL router: read-only queries over the scope's tables via stash sql,
+plus the scope's external Postgres mounts."""
 
 from uuid import UUID
 
+import asyncpg
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from ..auth import get_current_user, get_scope
 from ..middleware import limiter
-from ..models import SqlQueryRequest, SqlQueryResponse
-from ..services import security_audit_service, sql_service, user_scope_service
+from ..models import PgMountCreate, PgMountInfo, SqlQueryRequest, SqlQueryResponse
+from ..services import pg_mount_service, security_audit_service, sql_service, user_scope_service
 
 router = APIRouter(prefix="/api/v1/me", tags=["sql"])
 
@@ -39,3 +41,43 @@ async def run_sql(
         metadata={"via": "sql", "result_rows": result["row_count"]},
     )
     return SqlQueryResponse(**result)
+
+
+@router.get("/sql/mounts", response_model=list[PgMountInfo])
+async def list_pg_mounts(
+    current_user: dict = Depends(get_current_user),
+    scope_user_id: UUID = Depends(get_scope),
+):
+    if not await user_scope_service.can_read(scope_user_id, current_user["id"]):
+        raise HTTPException(status_code=403, detail="Not the scope owner")
+    return await pg_mount_service.list_mounts(scope_user_id)
+
+
+@router.post("/sql/mounts", response_model=PgMountInfo, status_code=201)
+async def create_pg_mount(
+    req: PgMountCreate,
+    current_user: dict = Depends(get_current_user),
+    scope_user_id: UUID = Depends(get_scope),
+):
+    if not await user_scope_service.can_write(scope_user_id, current_user["id"]):
+        raise HTTPException(status_code=403, detail="Not the scope owner")
+    try:
+        return await pg_mount_service.create_mount(
+            scope_user_id, req.name, req.dsn, req.remote_schema
+        )
+    except pg_mount_service.PgMountError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    except asyncpg.UniqueViolationError:
+        raise HTTPException(status_code=409, detail=f"mount {req.name!r} already exists") from None
+
+
+@router.delete("/sql/mounts/{name}", status_code=204)
+async def delete_pg_mount(
+    name: str,
+    current_user: dict = Depends(get_current_user),
+    scope_user_id: UUID = Depends(get_scope),
+):
+    if not await user_scope_service.can_write(scope_user_id, current_user["id"]):
+        raise HTTPException(status_code=403, detail="Not the scope owner")
+    if not await pg_mount_service.delete_mount(scope_user_id, name):
+        raise HTTPException(status_code=404, detail=f"no mount named {name!r}")

--- a/backend/services/pg_mount_service.py
+++ b/backend/services/pg_mount_service.py
@@ -1,0 +1,244 @@
+"""External read-only Postgres mounts for stash sql.
+
+A mount points at a database the scope's owner controls — for an integrator,
+typically a read-only role on their own Postgres (Supabase, RDS, …). At query
+time every table in the mount's remote schema that the role can SELECT is
+materialized into the throwaway DuckDB under a schema named after the mount,
+so `SELECT * FROM supabase.world_observations` works next to native tables.
+
+The trust posture matches the rest of the scope contract: the customer's
+role/view IS the access control. We additionally open every connection with
+`default_transaction_read_only = on` so a mis-granted role still cannot be
+written through, and a statement timeout so a wedged remote fails the query
+instead of hanging the worker.
+
+The user's SQL never sees the DSN and never gets a network path: rows are
+fetched server-side here, and DuckDB keeps `enable_external_access` off.
+"""
+
+import json
+import re
+from urllib.parse import urlsplit
+from uuid import UUID
+
+import asyncpg
+
+from ..database import get_pool
+from ..integrations.crypto import integration_fernet
+
+CONNECT_TIMEOUT_SECONDS = 5
+# Applied server-side per session; covers each count and fetch statement.
+REMOTE_STATEMENT_TIMEOUT_MS = 10_000
+
+_NAME_RE = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
+# Schemas stash sql already owns, plus DuckDB/Postgres system schemas.
+_RESERVED_NAMES = {"main", "files", "memory", "temp", "system", "information_schema", "pg_catalog"}
+
+_PG_TO_DUCKDB = {
+    "smallint": "BIGINT",
+    "integer": "BIGINT",
+    "bigint": "BIGINT",
+    "numeric": "DOUBLE",
+    "real": "DOUBLE",
+    "double precision": "DOUBLE",
+    "boolean": "BOOLEAN",
+    "date": "DATE",
+    "timestamp without time zone": "TIMESTAMP",
+    "timestamp with time zone": "TIMESTAMP",
+}
+
+
+class PgMountError(Exception):
+    """The mount cannot be created or read; message is user-facing."""
+
+
+def validate_name(name: str) -> None:
+    if not _NAME_RE.match(name):
+        raise PgMountError("mount name must be a short lowercase identifier ([a-z][a-z0-9_]{0,31})")
+    if name in _RESERVED_NAMES:
+        raise PgMountError(f"mount name {name!r} is reserved")
+
+
+def validate_dsn(dsn: str) -> None:
+    if not dsn.startswith(("postgresql://", "postgres://")):
+        raise PgMountError("dsn must be a postgresql:// URL")
+
+
+def _redacted(dsn: str) -> dict:
+    """Host and database only — the DSN (with its password) never leaves the
+    server after creation."""
+    parsed = urlsplit(dsn)
+    return {"host": parsed.hostname or "", "database": parsed.path.lstrip("/")}
+
+
+async def create_mount(owner_user_id: UUID, name: str, dsn: str, remote_schema: str) -> dict:
+    validate_name(name)
+    validate_dsn(dsn)
+    # Prove the DSN before storing it: connect, and enumerate the schema so a
+    # typo'd password or empty schema fails the create, not tomorrow's query.
+    tables = await _fetch_remote_tables(name, dsn, remote_schema, include_rows=False)
+    row = await get_pool().fetchrow(
+        """
+        INSERT INTO pg_mounts (owner_user_id, name, dsn_encrypted, remote_schema)
+        VALUES ($1, $2, $3, $4)
+        RETURNING id, name, remote_schema, created_at
+        """,
+        owner_user_id,
+        name,
+        integration_fernet().encrypt(dsn.encode()),
+        remote_schema,
+    )
+    return {
+        "id": str(row["id"]),
+        "name": row["name"],
+        "remote_schema": row["remote_schema"],
+        "created_at": row["created_at"].isoformat(),
+        "table_count": len(tables),
+        **_redacted(dsn),
+    }
+
+
+async def list_mounts(owner_user_id: UUID) -> list[dict]:
+    rows = await get_pool().fetch(
+        "SELECT id, name, dsn_encrypted, remote_schema, created_at "
+        "FROM pg_mounts WHERE owner_user_id = $1 ORDER BY name",
+        owner_user_id,
+    )
+    result = []
+    for row in rows:
+        dsn = integration_fernet().decrypt(bytes(row["dsn_encrypted"])).decode()
+        result.append(
+            {
+                "id": str(row["id"]),
+                "name": row["name"],
+                "remote_schema": row["remote_schema"],
+                "created_at": row["created_at"].isoformat(),
+                **_redacted(dsn),
+            }
+        )
+    return result
+
+
+async def delete_mount(owner_user_id: UUID, name: str) -> bool:
+    status = await get_pool().execute(
+        "DELETE FROM pg_mounts WHERE owner_user_id = $1 AND name = $2",
+        owner_user_id,
+        name,
+    )
+    return status.endswith("1")
+
+
+async def fetch_mounted_tables(owner_user_id: UUID, row_budget: int) -> list[dict]:
+    """Every mounted table with columns and rows, ready to materialize.
+
+    Returns [{schema, name, columns: [(name, duckdb_type)], rows: [tuple]}].
+    A mount that cannot be reached fails the whole query — a silently absent
+    table would make the agent conclude the data doesn't exist. `row_budget`
+    is what remains of the scope's materialization cap after native tables;
+    rows are counted before they are fetched, so an oversized remote table
+    fails the budget check instead of exhausting worker memory.
+    """
+    rows = await get_pool().fetch(
+        "SELECT name, dsn_encrypted, remote_schema FROM pg_mounts "
+        "WHERE owner_user_id = $1 ORDER BY name",
+        owner_user_id,
+    )
+    tables: list[dict] = []
+    for row in rows:
+        dsn = integration_fernet().decrypt(bytes(row["dsn_encrypted"])).decode()
+        fetched = await _fetch_remote_tables(
+            row["name"], dsn, row["remote_schema"], include_rows=True, row_budget=row_budget
+        )
+        row_budget -= sum(len(t["rows"]) for t in fetched)
+        tables.extend(fetched)
+    return tables
+
+
+async def _fetch_remote_tables(
+    mount_name: str,
+    dsn: str,
+    remote_schema: str,
+    *,
+    include_rows: bool,
+    row_budget: int = 0,
+) -> list[dict]:
+    try:
+        con = await asyncpg.connect(
+            dsn,
+            timeout=CONNECT_TIMEOUT_SECONDS,
+            server_settings={
+                "default_transaction_read_only": "on",
+                "statement_timeout": str(REMOTE_STATEMENT_TIMEOUT_MS),
+            },
+        )
+    except (OSError, asyncpg.PostgresError, TimeoutError) as exc:
+        raise PgMountError(f"mount {mount_name!r} unreachable: {exc}") from None
+    try:
+        relations = await con.fetch(
+            """
+            SELECT c.relname AS name
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = $1
+              AND c.relkind IN ('r', 'p', 'v', 'm')
+              AND has_table_privilege(c.oid, 'SELECT')
+            ORDER BY c.relname
+            """,
+            remote_schema,
+        )
+        if not relations:
+            raise PgMountError(
+                f"mount {mount_name!r}: no readable tables in schema {remote_schema!r}"
+            )
+        tables = []
+        remaining = row_budget
+        for relation in relations:
+            table_name = relation["name"]
+            columns = await con.fetch(
+                """
+                SELECT column_name, data_type
+                FROM information_schema.columns
+                WHERE table_schema = $1 AND table_name = $2
+                ORDER BY ordinal_position
+                """,
+                remote_schema,
+                table_name,
+            )
+            column_defs = [
+                (c["column_name"], _PG_TO_DUCKDB.get(c["data_type"], "VARCHAR")) for c in columns
+            ]
+            table = {"schema": mount_name, "name": table_name, "columns": column_defs}
+            if include_rows:
+                qualified = f'"{remote_schema}"."{table_name}"'
+                count = await con.fetchval(f"SELECT count(*) FROM {qualified}")
+                if count > remaining:
+                    raise PgMountError(
+                        f"mount {mount_name!r}: table {table_name!r} has {count} rows, "
+                        f"above the remaining stash sql budget of {remaining}"
+                    )
+                remaining -= count
+                records = await con.fetch(f"SELECT * FROM {qualified}")
+                table["rows"] = [
+                    tuple(_duckdb_value(record[name], duck_type) for name, duck_type in column_defs)
+                    for record in records
+                ]
+            tables.append(table)
+        return tables
+    except asyncpg.PostgresError as exc:
+        raise PgMountError(f"mount {mount_name!r}: {exc}") from None
+    finally:
+        await con.close()
+
+
+def _duckdb_value(value, duck_type: str):
+    if value is None:
+        return None
+    if duck_type == "TIMESTAMP" and getattr(value, "tzinfo", None) is not None:
+        return value.replace(tzinfo=None) - value.utcoffset()
+    if duck_type != "VARCHAR" or isinstance(value, str):
+        return value
+    # asyncpg returns json/jsonb as str already; what remains is uuids,
+    # arrays, ranges, bytea — stringify so the VARCHAR column always loads.
+    if isinstance(value, (list, dict)):
+        return json.dumps(value, default=str)
+    return str(value)

--- a/backend/services/sql_service.py
+++ b/backend/services/sql_service.py
@@ -10,6 +10,12 @@ Addressing mirrors the VFS: every table exists as `"<folder path>"."<name>"`
 Memory wiki), plus a bare-name view in `main` when the name is unique across
 the scope, so `SELECT * FROM jobs` just works. Because it is real DuckDB,
 `information_schema` reflects all of this truthfully.
+
+External Postgres mounts (pg_mount_service) join the same instance: each
+mount's remote tables materialize under a schema named after the mount, so a
+customer's own database is queryable — and joinable against native tables —
+through the identical read-only surface. Rows are fetched server-side; the
+user's SQL still runs with no network access.
 """
 
 import base64
@@ -24,7 +30,7 @@ import anyio.to_thread
 import duckdb
 
 from ..database import get_pool
-from . import table_service
+from . import pg_mount_service, table_service
 
 # One query materializes every table in the scope (that is what makes
 # information_schema truthful and cross-table joins work), so the cap is on
@@ -82,8 +88,15 @@ async def run_query(owner_user_id: UUID, user_id: UUID, query: str) -> dict:
 
     schema_by_folder = await _folder_schema_names(owner_user_id)
 
+    try:
+        external_tables = await pg_mount_service.fetch_mounted_tables(
+            owner_user_id, MAX_MATERIALIZED_ROWS - total_rows
+        )
+    except pg_mount_service.PgMountError as exc:
+        raise SqlError(str(exc)) from None
+
     return await anyio.to_thread.run_sync(
-        _run_in_duckdb, tables, rows_by_table, schema_by_folder, query
+        _run_in_duckdb, tables, rows_by_table, schema_by_folder, external_tables, query
     )
 
 
@@ -118,6 +131,7 @@ def _run_in_duckdb(
     tables: list[dict],
     rows_by_table: dict[UUID, list[dict]],
     schema_by_folder: dict[UUID, str],
+    external_tables: list[dict],
     query: str,
 ) -> dict:
     # Parsing is where a syntax error lands, and it is the user's mistake.
@@ -145,8 +159,16 @@ def _run_in_duckdb(
     # the whole budget on INSERTs before the user's query ever starts.
     timer = threading.Timer(QUERY_TIMEOUT_SECONDS, con.interrupt)
     timer.start()
+    # Bare-name views span native and mounted tables alike, so a name is only
+    # "unique" when nothing else in the scope claims it.
+    name_counts: dict[str, int] = {}
+    for table in [*tables, *external_tables]:
+        key = table["name"].lower()
+        name_counts[key] = name_counts.get(key, 0) + 1
+
     try:
-        _materialize(con, tables, rows_by_table, schema_by_folder)
+        _materialize(con, tables, rows_by_table, schema_by_folder, name_counts)
+        _materialize_external(con, external_tables, name_counts)
         cursor = con.execute(query)
         columns = [{"name": d[0], "type": str(d[1])} for d in (cursor.description or [])]
         fetched = cursor.fetchmany(MAX_RESULT_ROWS + 1)
@@ -176,12 +198,8 @@ def _materialize(
     tables: list[dict],
     rows_by_table: dict[UUID, list[dict]],
     schema_by_folder: dict[UUID, str],
+    name_counts: dict[str, int],
 ) -> None:
-    name_counts: dict[str, int] = {}
-    for table in tables:
-        key = table["name"].lower()
-        name_counts[key] = name_counts.get(key, 0) + 1
-
     seen_qualified: set[tuple[str, str]] = set()
     for table in tables:
         table_name = table["name"]
@@ -219,6 +237,34 @@ def _materialize(
             # the rows were written) would otherwise break `stash sql` for the
             # entire scope with an opaque 500.
             raise SqlError(f"table {table['name']!r} could not be loaded: {exc}") from None
+
+
+def _materialize_external(
+    con: duckdb.DuckDBPyConnection,
+    external_tables: list[dict],
+    name_counts: dict[str, int],
+) -> None:
+    for table in external_tables:
+        qualified = f"{_ident(table['schema'])}.{_ident(table['name'])}"
+        column_sql = ", ".join(
+            f"{_ident(name)} {duck_type}" for name, duck_type in table["columns"]
+        )
+        try:
+            con.execute(f"CREATE SCHEMA IF NOT EXISTS {_ident(table['schema'])}")
+            con.execute(f"CREATE TABLE {qualified} ({column_sql})")
+            if table["rows"]:
+                placeholders = ", ".join("?" for _ in table["columns"])
+                con.executemany(f"INSERT INTO {qualified} VALUES ({placeholders})", table["rows"])
+            if name_counts[table["name"].lower()] == 1:
+                con.execute(
+                    f"CREATE VIEW main.{_ident(table['name'])} AS SELECT * FROM {qualified}"
+                )
+        except duckdb.InterruptException:
+            raise
+        except duckdb.Error as exc:
+            raise SqlError(
+                f"mounted table {table['schema']}.{table['name']} could not be loaded: {exc}"
+            ) from None
 
 
 def _column_defs(columns: list[dict]) -> list[tuple[str, str, str | None]]:

--- a/backend/tests/test_sql_mounts.py
+++ b/backend/tests/test_sql_mounts.py
@@ -1,0 +1,226 @@
+"""External Postgres mounts for stash sql.
+
+The mount contract: a customer-side database materializes into the same
+DuckDB as native tables — addressable by mount name, joinable, visible in
+information_schema — while the DSN never leaves the server and an unreachable
+or oversized mount fails the query loudly instead of silently shrinking the
+schema. The "remote" database in these tests is the test database itself,
+scoped to a fixture schema, which exercises the full asyncpg fetch path
+without a second server.
+"""
+
+import asyncpg
+import pytest
+from cryptography.fernet import Fernet
+from httpx import AsyncClient
+
+from backend.config import settings
+
+from .conftest import unique_name
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def encryption_key(monkeypatch):
+    monkeypatch.setattr(settings, "INTEGRATIONS_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+
+@pytest.fixture
+async def remote_schema():
+    """A scratch schema in the test database, standing in for a customer's
+    Supabase: a parts lookup table and a world-observations ledger."""
+    schema = unique_name("mount_fixture").replace("-", "_").lower()
+    con = await asyncpg.connect(settings.DATABASE_URL)
+    try:
+        await con.execute(f'CREATE SCHEMA "{schema}"')
+        await con.execute(
+            f'CREATE TABLE "{schema}".reference_parts ('
+            "  part_number text, tool_match text, price numeric)"
+        )
+        await con.execute(
+            f'CREATE TABLE "{schema}".world_observations ('
+            "  vin text, observation text, observed_at timestamptz, details jsonb)"
+        )
+        await con.execute(
+            f'INSERT INTO "{schema}".reference_parts VALUES '
+            "('BW-800110', 'Bendix AD-IP cartridge', 189.50), "
+            "('MER-R955320', 'Meritor slack adjuster', 74.25)"
+        )
+        await con.execute(
+            f'INSERT INTO "{schema}".world_observations VALUES '
+            "('1XKAD49X5KJ211407', 'confirmed correct fit', now(), '{\"source\": \"shop\"}')"
+        )
+        yield schema
+    finally:
+        await con.execute(f'DROP SCHEMA "{schema}" CASCADE')
+        await con.close()
+
+
+async def _register(client: AsyncClient) -> dict:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("mounts"), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    return {"Authorization": f"Bearer {resp.json()['api_key']}"}
+
+
+async def _mount(client: AsyncClient, headers: dict, schema: str, name: str = "supabase") -> dict:
+    resp = await client.post(
+        "/api/v1/me/sql/mounts",
+        json={"name": name, "dsn": settings.DATABASE_URL, "remote_schema": schema},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+async def _sql(client: AsyncClient, headers: dict, query: str) -> dict:
+    resp = await client.post("/api/v1/me/sql", json={"query": query}, headers=headers)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def test_create_reports_tables_and_redacts_dsn(client, remote_schema):
+    headers = await _register(client)
+    mount = await _mount(client, headers, remote_schema)
+    assert mount["table_count"] == 2
+    assert "dsn" not in mount
+
+    listed = (await client.get("/api/v1/me/sql/mounts", headers=headers)).json()
+    assert [m["name"] for m in listed] == ["supabase"]
+    assert all("dsn" not in m for m in listed)
+
+
+async def test_mounted_tables_are_queryable_by_mount_schema(client, remote_schema):
+    headers = await _register(client)
+    await _mount(client, headers, remote_schema)
+    result = await _sql(
+        client,
+        headers,
+        "SELECT tool_match FROM supabase.reference_parts WHERE part_number = 'BW-800110'",
+    )
+    assert result["rows"] == [["Bendix AD-IP cartridge"]]
+
+
+async def test_bare_name_resolves_and_information_schema_tells_truth(client, remote_schema):
+    headers = await _register(client)
+    await _mount(client, headers, remote_schema)
+    result = await _sql(client, headers, "SELECT vin FROM world_observations")
+    assert result["rows"] == [["1XKAD49X5KJ211407"]]
+
+    schemas = await _sql(
+        client,
+        headers,
+        "SELECT DISTINCT table_schema FROM information_schema.tables "
+        "WHERE table_schema = 'supabase'",
+    )
+    assert schemas["rows"] == [["supabase"]]
+
+
+async def test_mounted_joins_native(client, remote_schema):
+    headers = await _register(client)
+    await _mount(client, headers, remote_schema)
+    table = await client.post(
+        "/api/v1/me/tables",
+        json={"name": "notes", "columns": [{"name": "part_number", "type": "text"}]},
+        headers=headers,
+    )
+    assert table.status_code == 201
+    col_id = table.json()["columns"][0]["id"]
+    created = await client.post(
+        f"/api/v1/me/tables/{table.json()['id']}/rows",
+        json={"data": {col_id: "BW-800110"}},
+        headers=headers,
+    )
+    assert created.status_code == 201
+
+    result = await _sql(
+        client,
+        headers,
+        "SELECT p.tool_match FROM notes n "
+        "JOIN supabase.reference_parts p ON p.part_number = n.part_number",
+    )
+    assert result["rows"] == [["Bendix AD-IP cartridge"]]
+
+
+async def test_numeric_and_jsonb_columns_survive_the_crossing(client, remote_schema):
+    headers = await _register(client)
+    await _mount(client, headers, remote_schema)
+    price = await _sql(client, headers, "SELECT price FROM supabase.reference_parts ORDER BY price")
+    assert price["rows"] == [[74.25], [189.5]]
+    details = await _sql(
+        client,
+        headers,
+        "SELECT json_extract_string(details, '$.source') FROM supabase.world_observations",
+    )
+    assert details["rows"] == [["shop"]]
+
+
+async def test_bad_dsn_fails_create_loudly(client):
+    headers = await _register(client)
+    resp = await client.post(
+        "/api/v1/me/sql/mounts",
+        json={"name": "supabase", "dsn": "postgresql://nope:nope@127.0.0.1:1/nope"},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+    assert "unreachable" in resp.json()["detail"]
+
+
+async def test_reserved_and_duplicate_names_rejected(client, remote_schema):
+    headers = await _register(client)
+    resp = await client.post(
+        "/api/v1/me/sql/mounts",
+        json={"name": "memory", "dsn": settings.DATABASE_URL, "remote_schema": remote_schema},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+    assert "reserved" in resp.json()["detail"]
+
+    await _mount(client, headers, remote_schema)
+    duplicate = await client.post(
+        "/api/v1/me/sql/mounts",
+        json={"name": "supabase", "dsn": settings.DATABASE_URL, "remote_schema": remote_schema},
+        headers=headers,
+    )
+    assert duplicate.status_code == 409
+
+
+async def test_oversized_mount_fails_the_query_not_the_worker(client, remote_schema, monkeypatch):
+    from backend.services import sql_service
+
+    headers = await _register(client)
+    await _mount(client, headers, remote_schema)
+    monkeypatch.setattr(sql_service, "MAX_MATERIALIZED_ROWS", 1)
+    resp = await client.post("/api/v1/me/sql", json={"query": "SELECT 1"}, headers=headers)
+    assert resp.status_code == 400
+    assert "budget" in resp.json()["detail"]
+
+
+async def test_removed_mount_is_gone_from_queries(client, remote_schema):
+    headers = await _register(client)
+    await _mount(client, headers, remote_schema)
+    deleted = await client.delete("/api/v1/me/sql/mounts/supabase", headers=headers)
+    assert deleted.status_code == 204
+    resp = await client.post(
+        "/api/v1/me/sql",
+        json={"query": "SELECT * FROM supabase.reference_parts"},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+
+
+async def test_mount_writes_are_impossible(client, remote_schema):
+    """The SELECT-only guard plus the read-only session mean no path writes
+    through a mount; the guard rejects before any remote work happens."""
+    headers = await _register(client)
+    await _mount(client, headers, remote_schema)
+    resp = await client.post(
+        "/api/v1/me/sql",
+        json={"query": "DELETE FROM supabase.reference_parts"},
+        headers=headers,
+    )
+    assert resp.status_code == 400
+    assert "read-only" in resp.json()["detail"]

--- a/cli/client.py
+++ b/cli/client.py
@@ -794,6 +794,18 @@ class StashClient:
     def run_sql(self, query: str) -> dict:
         return self._post("/api/v1/me/sql", json={"query": query})
 
+    def list_pg_mounts(self) -> list:
+        return self._get("/api/v1/me/sql/mounts")
+
+    def create_pg_mount(self, name: str, dsn: str, remote_schema: str) -> dict:
+        return self._post(
+            "/api/v1/me/sql/mounts",
+            json={"name": name, "dsn": dsn, "remote_schema": remote_schema},
+        )
+
+    def delete_pg_mount(self, name: str) -> None:
+        self._delete(f"/api/v1/me/sql/mounts/{name}")
+
     def get_table(self, table_id: str) -> dict:
         return self._get(f"/api/v1/me/tables/{table_id}")
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -6153,6 +6153,8 @@ def sql_command(
 
     A table is addressable by bare name when unique ("SELECT * FROM jobs") and
     always by its folder path as the schema ('SELECT * FROM "files/Hiring".jobs').
+    Mounted external databases (`stash mounts`) appear under the mount's name
+    ('SELECT * FROM supabase.world_observations') and join against your tables.
     Explore with information_schema.tables / information_schema.columns.
     """
     with _client() as c:
@@ -6176,6 +6178,68 @@ def sql_command(
     print(f"({result['row_count']} rows)")
     if result["truncated"]:
         console.print("[yellow]Result truncated — add a LIMIT or tighter WHERE.[/yellow]")
+
+
+mounts_app = typer.Typer(help="External read-only Postgres databases queryable via stash sql.")
+app.add_typer(mounts_app, name="mounts")
+
+
+@mounts_app.command("add")
+def mounts_add(
+    name: str = typer.Argument(..., help="Schema name the tables appear under, e.g. 'supabase'."),
+    dsn: str = typer.Argument(..., help="postgresql:// DSN of a read-only role."),
+    remote_schema: str = typer.Option(
+        "public", "--schema", help="Remote schema whose tables are exposed."
+    ),
+    as_json: bool = typer.Option(False, "--json"),
+):
+    """Mount an external Postgres. Its tables become queryable as
+    '<name>.<table>' in `stash sql`, joinable against your Stash tables."""
+    with _client() as c:
+        try:
+            mount = c.create_pg_mount(name, dsn, remote_schema)
+        except StashError as e:
+            _err(e)
+    if _use_json(as_json):
+        output_json(mount)
+        return
+    console.print(
+        f"Mounted [bold]{mount['name']}[/bold] "
+        f"({mount['host']}/{mount['database']}, schema {mount['remote_schema']}, "
+        f"{mount['table_count']} tables)."
+    )
+
+
+@mounts_app.command("list")
+def mounts_list(as_json: bool = typer.Option(False, "--json")):
+    """List mounted databases. DSNs are never shown."""
+    with _client() as c:
+        try:
+            mounts = c.list_pg_mounts()
+        except StashError as e:
+            _err(e)
+    if _use_json(as_json):
+        output_json(mounts)
+        return
+    if not mounts:
+        console.print("No mounts. Add one with `stash mounts add <name> <dsn>`.")
+        return
+    for mount in mounts:
+        console.print(
+            f"[bold]{mount['name']}[/bold]  {mount['host']}/{mount['database']}  "
+            f"schema {mount['remote_schema']}"
+        )
+
+
+@mounts_app.command("remove")
+def mounts_remove(name: str = typer.Argument(...)):
+    """Remove a mount. The remote database is untouched."""
+    with _client() as c:
+        try:
+            c.delete_pg_mount(name)
+        except StashError as e:
+            _err(e)
+    console.print(f"Removed mount [bold]{name}[/bold].")
 
 
 def _read_vfs_raw(path: str) -> bytes:


### PR DESCRIPTION
this is a bigger guy. I'm gonna ignore this one for now since it's not immediately needed by anyone.



## What

A scope can mount a customer-side Postgres and query it through `stash sql`:

```
stash mounts add supabase 'postgresql://<read-only-role>@db.<project>.supabase.co:5432/postgres'
stash sql "SELECT o.vin, o.observation, p.tool_match
           FROM supabase.world_observations o
           JOIN supabase.reference_rows p USING (part_number)"
```

Every table in the mount's remote schema that the role can SELECT materializes into the per-query DuckDB under a schema named after the mount — joinable against native tables, visible in `information_schema`, bare-name views when unique. 

## Trust & safety posture

- **The customer's read-only role/view IS the access control** (same caller-side trust contract as org-scoped uploads). We additionally open every remote session with `default_transaction_read_only = on` plus a 10s statement timeout, so a mis-granted role still can't be written through and a wedged remote fails the query instead of hanging the worker.
- **User SQL still has zero network access.** Rows are fetched server-side by `pg_mount_service`; DuckDB keeps `enable_external_access` off. This is not `ATTACH` from user SQL.
- **DSNs are Fernet-encrypted at rest** (same keyring as OAuth tokens) and never returned by any endpoint after creation — list/create responses carry host + database only.
- **Count-before-fetch budget**: remote rows share the existing 200k materialization cap and are counted before fetching, so an oversized remote table fails the budget check loudly instead of OOMing the worker.
- **Unreachable mount = failed query**, not a silently smaller schema — a missing table would read to the agent as "the data doesn't exist".

## Surface

- Migration `0185_pg_mounts` (⚠️ numbering: the open Drive-skills stack and #1055 also claim 0185 — whichever lands second renumbers)
- `GET/POST /api/v1/me/sql/mounts`, `DELETE /api/v1/me/sql/mounts/{name}`
- CLI: `stash mounts add|list|remove`; `stash sql` help mentions mounts
- Mount names are validated identifiers with `files`/`memory`/`main`/system schemas reserved

## Tests

10 new tests in `test_sql_mounts.py` — the "remote" is the test database itself scoped to a fixture schema, exercising the real asyncpg path: queryable by mount schema, bare-name resolution, native↔mounted joins, numeric/jsonb type crossing, truthful `information_schema`, DSN redaction, loud failure on bad DSN / reserved + duplicate names / oversized mounts / deleted mounts, and the write-rejection guard. Existing `test_sql.py` (9) untouched and green; CLI suite 234 green; ruff clean. Full backend suite run in progress locally; CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f6d043559b9659443d22b9a10c6b6c4b9b35fa9b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->