### PR TITLE
fix: transcript events default to the whole session, not the first 100

### DIFF
--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -250,14 +250,19 @@ async def get_transcript_metadata(
 @router.get("/{session_id}/events")
 async def get_transcript_events(
     session_id: str,
-    limit: int = 100,
+    limit: int | None = None,
     offset: int = 0,
     current_user: dict = Depends(get_current_user),
 ):
-    """One page of chat-thread turns for a session, oldest first, sourced
-    directly from history_events. The viewer loads the first page on open and
-    fetches more as the reader scrolls. offset is a turn ordinal, so a future
-    in-session search can jump straight to a match's window.
+    """Chat-thread turns for a session, oldest first, sourced directly from
+    history_events. offset is a turn ordinal, so a future in-session search can
+    jump straight to a match's window.
+
+    Omitting limit returns the whole session. Paging is opt-in because the
+    callers that cannot page are the ones that read this as a file: the VFS
+    renders sessions/<name>/transcript.md from this route, and a default page
+    size silently truncated every long transcript it served. The viewer asks
+    for a limit explicitly and scrolls through offsets.
 
     No ownership gate: can_read_session is enforced per scope below, so
     another user the session is shared with can read it."""

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -344,13 +344,16 @@ async def read_session_events(
 async def read_session_events_page(
     owner_user_id: UUID,
     session_id: str,
-    limit: int,
+    limit: int | None,
     offset: int,
 ) -> tuple[list[dict], int]:
     """One page of renderable session events (oldest first) plus the total
     renderable count, for the lazily-loaded transcript viewer. Filtering to
     renderable event types keeps the offset aligned with the turn ordinal the
-    viewer shows. Callers enforce readability."""
+    viewer shows. Callers enforce readability.
+
+    A None limit reads the session whole: Postgres treats LIMIT NULL as
+    LIMIT ALL, so the unpaged read stays on this one codepath."""
     pool = get_pool()
     total = await pool.fetchval(
         "SELECT COUNT(*) FROM history_events "

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -100,6 +100,46 @@ async def test_upload_inserts_events_and_events_roundtrip(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_events_endpoint_without_limit_returns_whole_session(client: AsyncClient):
+    """Omitting limit must return every turn. The VFS renders
+    sessions/<name>/transcript.md from this route and cannot page, so any
+    default page size here silently truncates that file — an agent grepping a
+    long transcript gets a clean miss instead of the match."""
+    key = await _register(client)
+    headers = {"Authorization": f"Bearer {key}"}
+
+    turns = 150
+    body = (
+        "\n".join(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"content": f"msg-{i}"},
+                    "timestamp": f"2026-05-10T20:00:00.{i:03d}Z",
+                }
+            )
+            for i in range(turns)
+        )
+        + "\n"
+    ).encode()
+    up = await client.post(
+        "/api/v1/me/transcripts",
+        files={"file": ("s.jsonl", io.BytesIO(body), "application/jsonl")},
+        data={"session_id": "sess-unpaged", "agent_name": "claude"},
+        headers=headers,
+    )
+    assert up.status_code == 201, up.text
+
+    resp = await client.get("/api/v1/me/transcripts/sess-unpaged/events", headers=headers)
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["total"] == turns
+    assert payload["has_more"] is False
+    assert len(payload["events"]) == turns
+    assert payload["events"][-1]["content"] == f"msg-{turns - 1}"
+
+
+@pytest.mark.asyncio
 async def test_events_endpoint_paginates(client: AsyncClient):
     """The viewer loads the transcript a page at a time. offset is a turn
     ordinal, total is the full turn count, and has_more drives infinite scroll —

--- a/backend/tests/test_vfs.py
+++ b/backend/tests/test_vfs.py
@@ -7,6 +7,8 @@ partner: reads run as the calling credential, and the caller's cloud computer is
 not part of the tree.
 """
 
+import io
+import json
 from uuid import UUID
 
 import pytest
@@ -280,3 +282,48 @@ async def test_overview_reports_machine_provisioned_state(client: AsyncClient, m
     )
     after = await client.get("/api/v1/me/overview", headers=_auth(api_key))
     assert after.json()["machine"] == {"provisioned": True}
+
+
+async def test_transcript_md_renders_the_whole_session(client: AsyncClient):
+    """sessions/<name>/transcript.md renders from the transcript events route,
+    which this loader reads in one shot — it has no way to page. A default page
+    size there truncated the file, so an agent reading or grepping a long
+    session got a clean miss for anything past the cap instead of the match."""
+    api_key, _ = await _register(client)
+
+    turns = 150
+    body = (
+        "\n".join(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"content": f"msg-{i}"},
+                    "timestamp": f"2026-05-10T20:00:00.{i:03d}Z",
+                }
+            )
+            for i in range(turns)
+        )
+        + "\n"
+    ).encode()
+    up = await client.post(
+        "/api/v1/me/transcripts",
+        files={"file": ("s.jsonl", io.BytesIO(body), "application/jsonl")},
+        data={"session_id": "sess-vfs-long", "agent_name": "claude"},
+        headers=_auth(api_key),
+    )
+    assert up.status_code == 201, up.text
+
+    located = await _vfs(client, api_key, "find /sessions -name transcript.md")
+    assert located.status_code == 200
+    path = located.json()["stdout"].strip()
+    assert path, located.json()
+
+    # Read transcript.md by its own path. A recursive grep of the session
+    # directory would pass on the uncapped transcript.jsonl beside it and never
+    # exercise the markdown at all.
+    resp = await _vfs(client, api_key, f'cat "{path}"')
+
+    assert resp.status_code == 200
+    result = resp.json()
+    assert result["exit_code"] == 0, result
+    assert f"msg-{turns - 1}" in result["stdout"]


### PR DESCRIPTION
This is a high-priority bug that significantly affects model performance: API calls that pull sessions default to only displaying the first 100 events. This is fine for the paginated web UI, but it means that, when using stash vfs to, for example, cat a file, we only actually look at the first 100 events in a transcript, and the rest are silently hidden. This PR just changes the default API behavior to be returning entire session transcripts. The web UI is still paginated, but this change lets models actually access all of long session transcripts.

## The bug

`GET /api/v1/me/transcripts/{session_id}/events` defaulted to `limit=100`.

The VFS renders `sessions/<name>/transcript.md` and `events.json` by calling that route **in one shot** (`stashvfs/model.py`), and neither client passes a limit — not `cli/client.py` (`stash vfs`), not `backend/services/vfs_service.py` (the `/me/vfs` endpoint, ask-the-stash, the `stash_vfs` MCP tool). So every session longer than 100 turns was served truncated, with no marker and exit 0.

Two ways that bites:

- **The render is oldest-first**, so the part silently dropped is the most recent work — usually the part you opened the file for.
- **`stash vfs "rg ..."` over `/sessions` returns a clean miss** for anything past the cap. The shell prefetches file bodies and regexes them, so a miss is indistinguishable from "not in any session."

It also makes two surfaces disagree. Server-side search reads `history_events` directly and is uncapped, so `stash search` can legitimately return a hit at event #400 — and a follow-up `cat` of that same session won't show it. That reads as a stale index or a hallucinated result, not as pagination.

`transcript.jsonl` in the same directory was always complete (it goes through `export.jsonl` → `read_session_events`, unbounded), which is what made the truncation easy to miss.

## The fix

Paging is now opt-in: omitting `limit` returns the whole session.

- `backend/routers/transcripts.py` — `limit: int = 100` → `limit: int | None = None`
- `backend/services/memory_service.py` — `read_session_events_page` takes `int | None`

Postgres treats `LIMIT NULL` as `LIMIT ALL`, so the unpaged read stays on the same single codepath — no branch, no second query, no compatibility shim.

**The viewer is unaffected.** `getSessionEventsPage` (`frontend/src/lib/api.ts`) always writes `limit` into the query string, so infinite scroll behaves exactly as before. The callers that *cannot* page are precisely the ones reading this route as a file, which is why the default belongs on their side.

## Tests

- `test_events_endpoint_without_limit_returns_whole_session` — 150 turns, no `limit`, asserts all 150 return with `has_more` false.
- `test_transcript_md_renders_the_whole_session` — end-to-end through the real VFS: uploads 150 turns, locates `transcript.md` via `find`, cats it, asserts the last turn is present.

Note on the second one: my first draft used `grep -r ... /sessions` and **passed even with the bug present** — it was matching the uncapped `transcript.jsonl` beside it and never touching the markdown. It now reads `transcript.md` by its own path, and a comment records why, so nobody re-broadens it.

Both tests were confirmed to fail against the old default before being committed.

## Verification

- Full backend suite: **1366 passed** (exit 0)
- `ruff check backend/ cli/` + `ruff format --check backend/ cli/`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)