### PR TITLE
Add a moderation path for Stash Pages

### DIFF
--- a/backend/scripts/delete_pastes.py
+++ b/backend/scripts/delete_pastes.py
@@ -1,0 +1,65 @@
+"""Remove pastes by slug.
+
+Stash Pages publishes anonymously and the public delete endpoint requires the
+creator's edit_token, so there is no way for us to take down content someone
+else published — which is how 13 payment-fraud SEO pages sat on the domain in
+August 2026. This is the moderation path until an admin surface exists.
+
+Prints each row and writes a JSON backup before deleting anything, so a
+mistaken takedown can be restored. Comments cascade with the paste.
+
+    python -m backend.scripts.delete_pastes <slug> [<slug> ...] --backup out.json
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+
+from ..database import close_db, get_pool, init_pool
+
+SELECT_SQL = """
+    SELECT id, slug, edit_token, title, content_type, content, visibility,
+           comments_enabled, view_count, created_at, updated_at
+      FROM pastes
+     WHERE slug = ANY($1::text[])
+"""
+
+DELETE_SQL = "DELETE FROM pastes WHERE slug = ANY($1::text[])"
+
+
+async def delete_pastes(slugs: list[str], backup_path: str) -> None:
+    await init_pool()
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(SELECT_SQL, slugs)
+        found = {r["slug"] for r in rows}
+        missing = [s for s in slugs if s not in found]
+        if missing:
+            raise SystemExit(f"No paste with these slugs: {', '.join(missing)}")
+
+        with open(backup_path, "w") as f:
+            json.dump([dict(r) for r in rows], f, indent=2, default=str)
+        print(f"Backed up {len(rows)} pastes to {backup_path}\n")
+
+        for r in rows:
+            print(f"  {r['slug']}  [{r['visibility']}]  {r['title']}")
+
+        # One statement in a transaction: either every named paste goes or none does.
+        async with conn.transaction():
+            result = await conn.execute(DELETE_SQL, slugs)
+        print(f"\n{result}")
+
+    await close_db()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Delete Stash Pages pastes by slug.")
+    parser.add_argument("slugs", nargs="+")
+    parser.add_argument("--backup", required=True, help="Path to write the JSON backup")
+    args = parser.parse_args()
+    asyncio.run(delete_pastes(args.slugs, args.backup))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stash Pages publishes anonymously, and `DELETE /api/v1/pastes/{slug}` requires the creator's `edit_token` — so **nobody at Stash can remove content someone else published.**

That is how 13 payment-fraud SEO pages have sat on `joinstash.ai` since 2026-08-03: titles like "How to Make a USDT top up virtual card Faster and Easier to Reconcile" and "How to Use no kyc virtual credit cards", one of them linking out to `vccbusiness.com`. They were fully indexable and linked from `/pages`, which is in our sitemap. #1059 makes them `noindex`; this PR is how we actually take them down.

## Why it matters beyond SEO

`noindex` stops search exposure, but the URLs still resolve and still carry `joinstash.ai`'s reputation. Pastebin spam is mostly monetized by dropping links into email and DMs, where a trusted host domain gets past filters — which puts the domain at risk of spam blocklists and Safe Browsing. We send sales and transactional mail from this domain (SPF, DKIM and DMARC are all on the zone), so that is the expensive failure mode, and `noindex` does nothing about it.

## The script

    python -m backend.scripts.delete_pastes <slug> ... --backup out.json

- Prints every matched row and writes a JSON backup **before** deleting, so a mistaken takedown is recoverable.
- Deletes inside a transaction — a run is all-or-nothing.
- Unknown slugs abort the whole run rather than silently deleting the subset that matched.
- Comments cascade with the paste (existing FK).

Parameterized `$1` placeholders, no fallbacks, fails loud on a missing slug — per CLAUDE.md.

## Note

This is a stopgap. If Pages stays up in any form it wants a real admin surface and some rate limiting, otherwise this script gets run every time someone finds the open publish endpoint again.

Touches `backend/**`, so merging cuts a release — which is why it is split out of the `www`-only #1059.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxGyzQbUhHjaiRafk1pHf3