### PR TITLE
Local embeddings: pin torch to CPU, add EMBEDDING_PROVIDER=none

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,7 @@ CORS_ORIGINS=http://localhost:3457,http://localhost:3456
 BACKEND_URL=http://localhost:3456
 
 # ── Embeddings ──────────────────────────────────────────────────
-# Provider: openai | huggingface | local | auto (default).
+# Provider: openai | huggingface | local | none | auto (default).
 # "auto" detects from available keys: OPENAI_API_KEY → openai, HF_TOKEN → huggingface, else → local.
 # With no keys set, Stash uses local sentence-transformers — no API key required.
 # EMBEDDING_PROVIDER=auto
@@ -77,6 +77,9 @@ BACKEND_URL=http://localhost:3456
 # Option 3: Local sentence-transformers (free, no API key, downloads model on first use)
 # EMBEDDING_PROVIDER=local
 # EMBEDDING_MODEL=all-MiniLM-L6-v2          # default
+
+# Option 4: Off — semantic search returns 503, everything else works
+# EMBEDDING_PROVIDER=none
 
 # Shared
 # EMBEDDING_DIMS=384                        # vector dimensions (must match your DB schema)

--- a/backend/config.py
+++ b/backend/config.py
@@ -165,7 +165,7 @@ class Settings:
     )
 
     # --- Embeddings ---
-    # Provider: "openai", "huggingface", "local", or "auto" (default).
+    # Provider: "openai", "huggingface", "local", "none", or "auto" (default).
     # Auto-detect: OPENAI_API_KEY → openai, HF_TOKEN → huggingface, else → local.
     EMBEDDING_PROVIDER: str = os.getenv("EMBEDDING_PROVIDER", "auto")
     OPENAI_API_KEY: str | None = os.getenv("OPENAI_API_KEY")

--- a/backend/services/embeddings/__init__.py
+++ b/backend/services/embeddings/__init__.py
@@ -4,6 +4,7 @@ Supports multiple providers out of the box:
   - **openai** — OpenAI, Gemini, Cohere, or any /v1/embeddings-compatible API
   - **huggingface** — Hugging Face Inference API (any HF Hub model)
   - **local** — sentence-transformers (on-device, free, no API key)
+  - **none** — embeddings off: semantic search 503s, reconcile skips
 
 Set EMBEDDING_PROVIDER in your environment, or leave it as "auto" to
 auto-detect from available API keys.

--- a/backend/services/embeddings/auto.py
+++ b/backend/services/embeddings/auto.py
@@ -31,7 +31,12 @@ def get_embedder() -> BaseEmbedder:
 
     provider = os.getenv("EMBEDDING_PROVIDER", "auto").lower()
 
-    if provider == "openai":
+    if provider == "none":
+        from .disabled import DisabledEmbedder
+
+        _embedder = DisabledEmbedder()
+
+    elif provider == "openai":
         from .openai_compat import OpenAICompatEmbedder
 
         _embedder = OpenAICompatEmbedder()
@@ -62,7 +67,8 @@ def get_embedder() -> BaseEmbedder:
 
     else:
         raise ValueError(
-            f"Unknown EMBEDDING_PROVIDER={provider!r}. Choose: openai, huggingface, local, or auto."
+            f"Unknown EMBEDDING_PROVIDER={provider!r}. "
+            "Choose: openai, huggingface, local, none, or auto."
         )
 
     logger.info("Embedding provider: %s", _embedder.name)

--- a/backend/services/embeddings/disabled.py
+++ b/backend/services/embeddings/disabled.py
@@ -1,0 +1,26 @@
+"""Embeddings explicitly turned off (EMBEDDING_PROVIDER=none).
+
+Semantic search returns 503 and the reconcile task skips — every callsite
+already gates on is_configured(). For local dev where embeddings are not
+worth a torch install (or its crashes).
+"""
+
+import numpy as np
+
+from .base import BaseEmbedder
+
+
+class DisabledEmbedder(BaseEmbedder):
+    name = "none"
+
+    def is_configured(self) -> bool:
+        return False
+
+    async def embed_batch(self, texts: list[str]) -> list[np.ndarray] | None:
+        raise RuntimeError(
+            "Embeddings are disabled (EMBEDDING_PROVIDER=none) — "
+            "callers must check is_configured() before embedding."
+        )
+
+    async def close(self) -> None:
+        pass

--- a/backend/services/embeddings/local.py
+++ b/backend/services/embeddings/local.py
@@ -46,7 +46,10 @@ class LocalEmbedder(BaseEmbedder):
                 "Install it with: pip install sentence-transformers"
             )
         logger.info("Loading local embedding model: %s", self.model_name)
-        self._model = SentenceTransformer(self.model_name)
+        # Pinned to CPU: torch's MPS backend is not thread-safe, and encode runs
+        # on an asyncio executor thread — on Apple Silicon it segfaults the
+        # server (EXC_BAD_ACCESS in MetalShaderLibrary::exec_unary_kernel).
+        self._model = SentenceTransformer(self.model_name, device="cpu")
 
     async def embed_batch(self, texts: list[str]) -> list[np.ndarray] | None:
         if not texts:

--- a/backend/tests/test_embeddings.py
+++ b/backend/tests/test_embeddings.py
@@ -110,3 +110,19 @@ async def test_openai_embedder_clips_inputs_before_http_request():
 
     assert vectors is not None
     assert len(client.payload["input"][0]) == embedding_service.MAX_TEXT_CHARS
+
+
+@pytest.mark.asyncio
+async def test_provider_none_disables_embeddings(monkeypatch):
+    """EMBEDDING_PROVIDER=none must read as "not configured" so every gated
+    callsite (semantic search 503, reconcile skip) turns itself off — and any
+    ungated embed call must fail loud instead of silently returning vectors."""
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "none")
+    await embedding_service.close()  # drop any cached provider
+
+    try:
+        assert embedding_service.is_configured() is False
+        with pytest.raises(RuntimeError, match="disabled"):
+            await embedding_service.get_embedder().embed_batch(["text"])
+    finally:
+        await embedding_service.close()


### PR DESCRIPTION
This (probably) fixes a problem with local sentence transformers for local embedding that was messing up my dev environment. More importantly, it adds an off switch for embeddings so we don't have to spend our precious time debugging arcane debugging errors rn.



# Slop

Local dev servers with the local sentence-transformers provider die intermittently. The machine's crash-report history (117 python crash reports since 8/11) shows every one is Apple's Metal/MPS stack: segfaults in `MetalShaderLibrary::exec_unary_kernel` (torch MPS is not thread-safe, and encode runs on an asyncio executor thread) and aborts in `MPSLibrary::MPSKey_Compile` ("crashed on child side of fork pre-exec" — Metal inside celery's forked workers).

Two commits:

1. **Pin the local provider to `device="cpu"`** — removes MPS from the process entirely. `all-MiniLM-L6-v2` is tiny, so CPU encoding is not a bottleneck. Fixes local embeddings for any Apple Silicon self-hoster.
2. **`EMBEDDING_PROVIDER=none`** — an explicit off switch for local dev. Every embedding callsite already gates on `is_configured()` (semantic search 503s, reconcile skips, memory/table services opt out), so the disabled provider slots into that existing state with no new codepaths, and torch never loads at all. An ungated embed call raises. Hosted prod is unaffected — it resolves to openai via auto-detection.

Verified against a live local stack in both modes: with the CPU pin, the model loads inside uvicorn and serves semantic search without the previously-reproducible segfault; with `none`, boot logs `Embedding provider: none`, reconcile no-ops, semantic search returns a clean 503, everything else 200. `pytest -k "embed or semantic"`: 22 passed, plus a new test for the none provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)