### PR TITLE
fix: clicking a file in an integration folder opened two doc viewers

### DIFF
--- a/frontend/src/app/(app)/integrations/[provider]/page.tsx
+++ b/frontend/src/app/(app)/integrations/[provider]/page.tsx
@@ -8,7 +8,6 @@ import { MoreHorizontal } from "lucide-react";
 import { useBreadcrumbs } from "@/components/BreadcrumbContext";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { useAuth } from "@/hooks/useAuth";
-import SourceDocViewer from "@/components/SourceDocViewer";
 import {
   ApiError,
   deleteSource,
@@ -1398,16 +1397,6 @@ function NavigablePanel({
             );
           })}
         </div>
-      )}
-
-      {openDoc && (
-        <SourceDocViewer
-          source={source.source}
-          providerLabel={providerLabel}
-          refValue={openDoc.ref}
-          name={openDoc.name}
-          onClose={() => setOpenDoc(null)}
-        />
       )}
 
       {source.type === "slack" || source.type === "gong_calls" ? (


### PR DESCRIPTION
silly ui bug

screenshots needed


Clicking any file in a folder-style integration browser (Drive, GitHub, …) rendered the document twice: the original inline `DocViewer` under the clicked row, and a second monospace `SourceDocViewer` appended at the bottom of `NavigablePanel`. Both blocks keyed off the same `openDoc` state — #860 added the bottom block without removing the inline one.

Fix: keep the inline viewer (it opens in place, under the file you clicked) and delete the bottom `SourceDocViewer` block plus its now-unused import. The `SourceDocViewer` component itself is untouched — the search page still uses it, and `SearchablePanel`'s own viewers are unaffected.

Verified in the live app: opening a Drive file now renders exactly one viewer (one Close button, one content render). `npm test`: 309 passed; lint: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only deduplication in the integrations browse panel; no auth, API, or shared component behavior changes beyond removing redundant rendering.
> 
> **Overview**
> Fixes **double document viewers** when opening a file in folder-style integration browse (Drive, GitHub, etc.). Both an inline `DocViewer` under the clicked row and a bottom `SourceDocViewer` were tied to the same `openDoc` state, so content appeared twice.
> 
> The change **drops the extra bottom `SourceDocViewer` block** and its import on the integrations provider page, leaving the in-place inline viewer. `SourceDocViewer` is unchanged and still used elsewhere (e.g. search).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b99d0afd761178db2387cbf398d32b893099959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->