### PR TITLE
Fix the health-check outage: lazy Drive extraction off the event loop, 2 uvicorn workers

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -48,4 +48,8 @@ USER stash
 EXPOSE 3456
 
 ENTRYPOINT ["/app/entrypoint.sh"]
-CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "3456", "--proxy-headers", "--forwarded-allow-ips", "*"]
+# Two workers so one request wedging its event loop (CPU-bound work, a stuck
+# call) can't take the whole instance's /health down with it — a single-worker
+# instance froze and was killed by Render's health check on 2026-08-19.
+# Celery services override this CMD, so this only affects the web service.
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "3456", "--workers", "2", "--proxy-headers", "--forwarded-allow-ips", "*"]

--- a/backend/database.py
+++ b/backend/database.py
@@ -52,8 +52,17 @@ async def init_db() -> None:
                 managed_cfg = Config(managed_ini)
                 alembic_cmd.upgrade(managed_cfg, "head")
 
+    # Serialize migrations across processes: with --workers 2 (and two Render
+    # instances) several backends boot concurrently, and alembic has no lock of
+    # its own — concurrent `upgrade head` runs race on alembic_version. The
+    # session-level advisory lock is held until the connection closes.
     loop = asyncio.get_running_loop()
-    await loop.run_in_executor(None, functools.partial(_run_alembic))
+    lock_conn = await asyncpg.connect(settings.DATABASE_URL)
+    try:
+        await lock_conn.execute("SELECT pg_advisory_lock(715551)")  # arbitrary app-wide key
+        await loop.run_in_executor(None, functools.partial(_run_alembic))
+    finally:
+        await lock_conn.close()
 
     pool = await asyncpg.create_pool(
         settings.DATABASE_URL,

--- a/backend/integrations/google/indexer.py
+++ b/backend/integrations/google/indexer.py
@@ -19,6 +19,7 @@ API silently drops Shared Drive items.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -601,7 +602,7 @@ async def extract_drive_text(
             # XLSX export keeps every visible sheet (Drive's CSV export drops
             # everything except the first).
             xlsx = await _export_bytes(client, file_id, _XLSX_MIME)
-            text = extract_text(xlsx, _XLSX_MIME)
+            text = await asyncio.to_thread(extract_text, xlsx, _XLSX_MIME)
         elif mime == MIME_GOOGLE_SLIDE:
             text = await _export(client, file_id, "text/plain")
         else:
@@ -634,8 +635,12 @@ async def extract_drive_text(
             else:
                 # Defer to the file-extraction service so docx/pptx/xlsx/pdf/
                 # text/* share the same handler set as the direct-upload
-                # extraction queue.
-                text = extract_text(content, mime)
+                # extraction queue. Off the event loop: this runs on the API
+                # request path (lazy whole-Drive reads), and a synchronous
+                # pypdf parse of a 25 MB catalog froze the loop long enough to
+                # fail Render's 5s health check and get the instance killed
+                # (prod incident, 2026-08-19).
+                text = await asyncio.to_thread(extract_text, content, mime)
 
         # Every branch lands here, Google-native exports included — an export
         # that came back empty must not be stored as a blank 'done' document.


### PR DESCRIPTION
previously, our backend worker would get so intently focused on parsing pdfs from google drive sync that it would forget to respond to render's automated healthcheck and then render would unceremoniously restart our server.

move pdf parsing off the event loop and into a thread so our main thread isn't unable to respond to render's automated health check.




<img width="1562" height="1084" alt="CleanShot 2026-08-19 at 04 34 01@2x" src="https://github.com/user-attachments/assets/4a891d2f-a56c-4ce5-998d-eb86e00d80b9" />

<img width="1612" height="1176" alt="CleanShot 2026-08-19 at 04 33 58@2x" src="https://github.com/user-attachments/assets/6e52dfd7-5537-4ea4-a0e3-0ca50a9e94b9" />


# slop

## Why this exists, and why it should merge promptly

**This fixes the cause of this morning's production outage.** On 2026-08-19 at 08:23–08:25 UTC, a `stash_backend` instance froze, failed Render's 5-second health check ("HTTP health check failed (timed out after 5 seconds)"), and was killed and restarted. While it was frozen, every request routed to it hung until clients gave up at 30 seconds. Until this merges, any agent that greps a whole-Drive source can reproduce the outage at will — one `stash vfs "grep -r … /sources/google"` is the entire trigger. Merging deploys the fix to prod automatically.

## What happened

A VFS grep over a whole-Drive source fanned out into 719 per-document reads in 15 minutes. A whole-Drive source is index-only: each read lazily downloads the file from Google Drive and extracts its text on the request path. `extract_text` (pypdf for PDFs) ran **synchronously on the event loop**, in a **single-process** uvicorn server. The scan swept a shared folder full of 25 MB scanned parts catalogs; parsing them froze the loop solid, `/health` could not answer, and Render killed the instance.

## The fix

1. **`extract_drive_text` runs `extract_text` in a thread** (`asyncio.to_thread`), so a big parse no longer freezes the event loop and health checks keep answering. The folder-source sync path already runs extraction in a child process; the lazy whole-Drive read path was the one place extraction still ran inline in the web server.
2. **The web service runs `uvicorn --workers 2`** (backend/Dockerfile CMD), so even if some future endpoint wedges one worker, the sibling still answers `/health`. The Celery services override the CMD and are unaffected.
3. Because two workers boot concurrently and both run `alembic upgrade head`, **`init_db` now holds a Postgres advisory lock around migrations**. This also closes the pre-existing race between the two Render instances booting after every deploy, which was only ever avoided by lucky timing.

## Verification

- Full backend suite passes: **1374 passed**.
- Two concurrent `init_db()` runs against one database serialize cleanly on the advisory lock (no deadlock, no duplicate-migration error).
- `ruff check` and `ruff format --check` clean.

## Notes for review

- Per-instance DB connections double with 2 workers (pool max 20 → up to 40 per instance, 80 across both). Neon prod has headroom for this, but it is worth a glance.
- Not addressed here, deliberately: a VFS grep over an index-only source still live-fetches every document from the provider (expensive, and heavy on Google API quota even when it no longer kills the instance). That deserves its own change — either excluding lazy-fetch sources from scan fan-out with a loud error, or serving scans only from stored text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches deploy topology (dual workers, higher DB connection use) and startup migrations; core change is threading on the hot request path rather than auth or data semantics.
> 
> **Overview**
> Addresses a production outage where lazy whole-Drive reads ran **synchronous PDF/XLSX extraction on the asyncio event loop**, freezing `/health` until Render killed the instance.
> 
> **`extract_drive_text`** now runs `extract_text` via **`asyncio.to_thread`** for native files and Sheet XLSX exports on the request path, so heavy parses no longer block the web process.
> 
> The web **`Dockerfile` CMD** starts **uvicorn with `--workers 2`** so one wedged worker does not take down all health checks (Celery images still override CMD).
> 
> **`init_db`** acquires a **Postgres advisory lock** around Alembic `upgrade head` so concurrent boots from two workers and multiple instances do not race on `alembic_version`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4478ba4ffad4fc5297af72274066aaae0a733e28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->