### PR TITLE
Tell the user their CLI is stale, instead of guessing why

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -38,6 +38,8 @@ COPY docs/skills/ ./docs/skills/
 COPY stashvfs/ ./stashvfs/
 COPY backend/entrypoint.sh ./entrypoint.sh
 COPY alembic.ini ./alembic.ini
+# The CLI release number clients are told about (backend/cli_release.py).
+COPY pyproject.toml ./pyproject.toml
 
 RUN mkdir -p /app/.secrets && \
     chmod 700 /app/.secrets && \

--- a/backend/cli_release.py
+++ b/backend/cli_release.py
@@ -1,0 +1,38 @@
+"""The stash CLI release clients are told about.
+
+Sourced from the repo's pyproject version — the same number publish.yml pushes
+to PyPI — so cutting a release stays a one-line edit. Served on every response
+as X-Stash-Cli-Latest; a CLI that finds itself older says so (see
+stashai/release.py). Note this is the version of the build this backend was cut
+from, which is the newest published release only because a merge to main
+deploys the backend and publishes the CLI from the same commit.
+
+A missing or malformed version raises at import: a backend that cannot name a
+release clients can compare would silently stop warning anyone, which is the
+failure this path exists to end.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+LATEST_VERSION_HEADER = "X-Stash-Cli-Latest"
+
+_PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+def _read_release(pyproject: Path) -> str:
+    with pyproject.open("rb") as f:
+        release = tomllib.load(f)["project"]["version"]
+    # A pre-release ("0.1.365rc1") is PEP-440-valid and would publish fine, but
+    # clients compare plain dotted numbers and would read it as *older* —
+    # silently muting the warning until the next plain release.
+    if not re.fullmatch(r"\d+(\.\d+)*", release):
+        raise ValueError(
+            f"pyproject version {release!r} is not a plain dotted release; "
+            "clients cannot compare it and would stop noticing new releases."
+        )
+    return release
+
+
+LATEST_CLI_VERSION: str = _read_release(_PYPROJECT)

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,7 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from starlette.responses import JSONResponse
 
+from . import cli_release
 from . import exports as _exports  # noqa: F401 — registers exporter Celery tasks
 from . import integrations as _integrations  # noqa: F401 — registers providers + importers
 from .config import settings
@@ -184,6 +185,9 @@ async def add_security_headers(request: Request, call_next):
     for key, value in SECURITY_HEADERS.items():
         if key not in response.headers:
             response.headers[key] = value
+    # Every client learns the current release from traffic it already makes, so
+    # noticing a stale install costs no extra request and needs no hook.
+    response.headers[cli_release.LATEST_VERSION_HEADER] = cli_release.LATEST_CLI_VERSION
     return response
 
 

--- a/backend/tests/test_cli_release_header.py
+++ b/backend/tests/test_cli_release_header.py
@@ -1,0 +1,49 @@
+"""The backend names the current CLI release on every response.
+
+This header is the only thing that tells a stale install it is stale — without
+it the CLI has no idea, which is how an install sat weeks behind while its
+session-start upgrade ran thousands of times. It rides on responses clients
+already make, so it must be present unconditionally, including on requests that
+carry no valid auth.
+"""
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from backend import cli_release
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.asyncio
+async def test_every_response_names_the_current_release(client):
+    response = await client.get("/health")
+    assert response.headers["X-Stash-Cli-Latest"] == cli_release.LATEST_CLI_VERSION
+
+
+@pytest.mark.asyncio
+async def test_error_responses_carry_it_too(client):
+    """A CLI whose token expired still gets 401s — and still deserves to learn
+    it is stale, since upgrading may be what fixes it."""
+    response = await client.get("/api/v1/me/files")
+    assert response.status_code in (401, 403)
+    assert response.headers["X-Stash-Cli-Latest"] == cli_release.LATEST_CLI_VERSION
+
+
+def test_release_is_the_published_version():
+    """One source of truth: the number publish.yml ships to PyPI. If these
+    diverge, clients are told to chase a release that does not exist."""
+    with (REPO_ROOT / "pyproject.toml").open("rb") as f:
+        assert cli_release.LATEST_CLI_VERSION == tomllib.load(f)["project"]["version"]
+
+
+def test_a_prerelease_version_is_refused_at_import(tmp_path):
+    """Clients compare plain dotted numbers, so '0.1.365rc1' would read as
+    *older* than what they run, and every install would go quiet. The backend
+    must refuse to serve it rather than serve it silently."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nversion = "0.1.365rc1"\n')
+    with pytest.raises(ValueError, match="not a plain dotted release"):
+        cli_release._read_release(pyproject)

--- a/cli/client.py
+++ b/cli/client.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import httpx
 
+from stashai import release
 from stashvfs import VfsClientError
 
 
@@ -101,6 +102,7 @@ class StashClient:
         headers = kwargs.pop("headers", {})
         headers.update(self._headers())
         resp = self._http.request(method, path, headers=headers, **kwargs)
+        release.note_latest(resp.headers.get(release.LATEST_VERSION_HEADER, ""))
         if not resp.is_success:
             detail = ""
             try:

--- a/cli/main.py
+++ b/cli/main.py
@@ -82,21 +82,23 @@ def root(
 @app.command()
 def upgrade() -> None:
     """Upgrade the stash CLI to the latest version on PyPI."""
-    import shutil
     import subprocess
 
-    if not shutil.which("uv"):
+    from stashai import release
+
+    if release.is_editable():
+        typer.echo("This is an editable checkout — `git pull` to update it.", err=True)
+        raise typer.Exit(1)
+    command = release.upgrade_command()
+    if command is None:
         typer.echo(
-            "uv is not on PATH. Re-run the installer: "
-            'bash -c "$(curl -fsSL https://joinstash.ai/install)"',
+            "This install has no working upgrader (no uv, no pip). "
+            f"Re-run the installer: {release.INSTALLER}",
             err=True,
         )
         raise typer.Exit(1)
     typer.echo(f"Upgrading stashai from {__version__}…")
-    result = subprocess.run(
-        ["uv", "tool", "install", "--force", "--reinstall", "--refresh", "stashai"]
-    )
-    raise typer.Exit(result.returncode)
+    raise typer.Exit(subprocess.run(command).returncode)
 
 
 def _client(auto: bool = False) -> StashClient:

--- a/cli/telemetry.py
+++ b/cli/telemetry.py
@@ -12,6 +12,8 @@ import threading
 
 import httpx
 
+from stashai import release
+
 from .config import load_config
 
 
@@ -30,7 +32,13 @@ def _post(base_url: str, api_key: str, command: str) -> None:
                         {
                             "surface": "cli",
                             "event_name": "cli.command_invoked",
-                            "properties": {"command": command},
+                            # The version makes fleet staleness a query instead
+                            # of an investigation: without it, "how many users
+                            # are running months-old code?" is unanswerable.
+                            "properties": {
+                                "command": command,
+                                "version": release.current_version(),
+                            },
                         }
                     ]
                 },

--- a/cli/tests/test_release_header_wire.py
+++ b/cli/tests/test_release_header_wire.py
@@ -1,0 +1,68 @@
+"""Both HTTP clients must read the release header off every response.
+
+The warning is worthless if nothing feeds it. The CLI client covers
+`stash <command>`; the plugin client covers hook traffic, which for an active
+user is thousands of requests a day.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from cli.client import StashClient
+from stashai import release
+from stashai.plugin.stash_client import StashClient as PluginClient
+
+
+def test_the_header_name_is_the_wire_literal():
+    """The backend serves this exact string (backend/cli_release.py), and the
+    CLI ships separately, so the two constants cannot import each other. Every
+    other test here builds its mocks from the constant itself, so without this
+    pin, renaming it would pass the whole suite while every deployed CLI
+    silently stopped seeing the header."""
+    assert release.LATEST_VERSION_HEADER == "X-Stash-Cli-Latest"
+
+
+@pytest.fixture
+def seen(monkeypatch) -> list[str]:
+    latest: list[str] = []
+    monkeypatch.setattr(release, "note_latest", latest.append)
+    return latest
+
+
+def _transport(headers: dict[str, str]) -> httpx.MockTransport:
+    return httpx.MockTransport(lambda request: httpx.Response(200, json={}, headers=headers))
+
+
+def test_cli_client_reads_the_header(seen):
+    client = StashClient("https://example.test", api_key="k")
+    client._http = httpx.Client(
+        base_url="https://example.test",
+        transport=_transport({release.LATEST_VERSION_HEADER: "0.1.365"}),
+    )
+
+    client._get("/api/v1/me/files")
+
+    assert seen == ["0.1.365"]
+
+
+def test_plugin_client_reads_the_header(seen):
+    client = PluginClient("https://example.test", api_key="k")
+    client._http = httpx.Client(
+        base_url="https://example.test",
+        transport=_transport({release.LATEST_VERSION_HEADER: "0.1.365"}),
+    )
+
+    client._get("/api/v1/me/whoami")
+
+    assert seen == ["0.1.365"]
+
+
+def test_a_backend_without_the_header_passes_an_empty_string(seen):
+    client = StashClient("https://example.test", api_key="k")
+    client._http = httpx.Client(base_url="https://example.test", transport=_transport({}))
+
+    client._get("/api/v1/me/files")
+
+    assert seen == [""]

--- a/cli/tests/test_release_warning.py
+++ b/cli/tests/test_release_warning.py
@@ -1,0 +1,159 @@
+"""The CLI tells the user when it is behind the current release.
+
+It does not upgrade itself. The agent plugins already run an upgrade at session
+start; what was missing is any signal when that upgrade is not working, which
+is how an install sat weeks behind while its hooks fired thousands of times a
+day. These tests pin the signal: it appears when the install is stale, stays
+quiet otherwise, and says something the user can act on.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from stashai import release
+
+
+@pytest.fixture(autouse=True)
+def unwarned(monkeypatch):
+    """The warning fires once per process, so every test starts fresh."""
+    monkeypatch.setattr(release, "_warned", False)
+    monkeypatch.setattr(release, "is_editable", lambda: False)
+    monkeypatch.setattr(release, "current_version", lambda: "0.1.334")
+
+
+def test_a_stale_install_says_so(capsys):
+    release.note_latest("0.1.365")
+
+    warning = capsys.readouterr().err
+    assert "0.1.334 is out of date" in warning
+    assert "0.1.365" in warning
+    assert "stash upgrade" in warning
+
+
+def test_a_current_install_says_nothing(capsys):
+    release.note_latest("0.1.334")
+
+    assert capsys.readouterr().err == ""
+
+
+def test_a_newer_install_says_nothing(capsys):
+    """Someone running a local build ahead of prod is not stale."""
+    release.note_latest("0.1.300")
+
+    assert capsys.readouterr().err == ""
+
+
+def test_a_backend_without_the_header_says_nothing(capsys):
+    """Self-hosters run their own backend; absence means 'no opinion', not
+    'upgrade to nothing'."""
+    release.note_latest("")
+
+    assert capsys.readouterr().err == ""
+
+
+def test_it_warns_once_per_process(capsys):
+    """One command can make a dozen requests. The user needs to read this once,
+    not once per HTTP call."""
+    for _ in range(5):
+        release.note_latest("0.1.365")
+
+    assert capsys.readouterr().err.count("out of date") == 1
+
+
+def test_an_editable_checkout_is_told_to_pull(monkeypatch, capsys):
+    """`stash upgrade` would replace a developer's working tree with a release,
+    so the warning points at git instead."""
+    monkeypatch.setattr(release, "is_editable", lambda: True)
+
+    release.note_latest("0.1.365")
+
+    warning = capsys.readouterr().err
+    assert "git pull" in warning
+    assert "stash upgrade" not in warning
+
+
+@pytest.mark.parametrize(
+    ("have", "want", "older"),
+    [
+        ("0.1.334", "0.1.365", True),
+        ("0.1.365", "0.1.365", False),
+        ("0.1.365", "0.1.334", False),
+        ("0.1.9", "0.1.10", True),
+        ("0.2.0", "0.1.999", False),
+        ("0.1.365.dev0", "0.1.365", False),
+    ],
+)
+def test_version_comparison(have: str, want: str, older: bool):
+    """Dotted numbers compared as integers, not strings: '0.1.9' is older than
+    '0.1.10' even though it sorts after it."""
+    assert release._is_older(have, want) is older
+
+
+def test_a_pip_install_is_upgraded_by_its_own_interpreter(monkeypatch):
+    """What `stash upgrade` runs on a pyenv install. Handing this to uv would
+    upgrade uv's copy, which is not the one the shell resolves."""
+    monkeypatch.setattr(release, "_is_uv_tool", lambda: False)
+    monkeypatch.setattr(release, "_has_pip", lambda: True)
+    monkeypatch.setattr(release, "_is_externally_managed", lambda: False)
+
+    assert release.upgrade_command() == [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--quiet",
+        "--upgrade",
+        "stashai",
+    ]
+
+
+def test_a_pep668_python_gets_the_flags_it_requires(monkeypatch):
+    """Debian's python and our own Fly Sprites refuse a plain `pip install`."""
+    monkeypatch.setattr(release, "_is_uv_tool", lambda: False)
+    monkeypatch.setattr(release, "_has_pip", lambda: True)
+    monkeypatch.setattr(release, "_is_externally_managed", lambda: True)
+
+    command = release.upgrade_command()
+
+    assert command[-2:] == ["--user", "--break-system-packages"]
+
+
+def test_a_python_without_pip_has_no_upgrader(monkeypatch):
+    """uv venvs ship without pip, so `python -m pip` there fails on a missing
+    module. `stash upgrade` must say so rather than run it."""
+    monkeypatch.setattr(release, "_is_uv_tool", lambda: False)
+    monkeypatch.setattr(release, "_has_pip", lambda: False)
+
+    assert release.upgrade_command() is None
+
+
+def test_uv_environments_are_recognised_by_their_receipt(monkeypatch, tmp_path: Path):
+    """Recognising uv by the shape of sys.prefix breaks the moment UV_TOOL_DIR
+    is set, sending uv installs down the pip branch — where a uv environment
+    has no pip at all."""
+    monkeypatch.setenv("UV_TOOL_DIR", str(tmp_path / "somewhere-else"))
+    (tmp_path / "uv-receipt.toml").write_text("")
+    monkeypatch.setattr(sys, "prefix", str(tmp_path))
+    monkeypatch.setattr(release, "_find_uv", lambda: "/usr/local/bin/uv")
+
+    assert release.upgrade_command() == [
+        "/usr/local/bin/uv",
+        "tool",
+        "install",
+        "--quiet",
+        "stashai@latest",
+    ]
+
+
+def test_a_uv_install_with_no_uv_has_no_upgrader(monkeypatch, tmp_path: Path):
+    """uv removed after the fact. `stash upgrade` reports it instead of
+    pretending; the user is told to re-run the installer."""
+    (tmp_path / "uv-receipt.toml").write_text("")
+    monkeypatch.setattr(sys, "prefix", str(tmp_path))
+    monkeypatch.setattr(release, "_find_uv", lambda: None)
+
+    assert release.upgrade_command() is None

--- a/plugins/claude-plugin/scripts/ensure_cli.sh
+++ b/plugins/claude-plugin/scripts/ensure_cli.sh
@@ -38,11 +38,16 @@ version_below() {
   }'
 }
 
-# Hooks run with a minimal PATH, so PATH alone is not enough to find uv.
-# install.sh puts it in ~/.local/bin.
+# Hooks run with a minimal PATH, so PATH alone is not enough to find uv. Checking
+# only ~/.local/bin (where install.sh puts it) missed every user who had already
+# installed uv another way — a Homebrew uv meant this script silently upgraded
+# nothing, forever, with no output to say so.
 find_uv() {
   command -v uv 2>/dev/null && return 0
-  [ -x "$HOME/.local/bin/uv" ] && echo "$HOME/.local/bin/uv" && return 0
+  for candidate in "$HOME/.local/bin/uv" "$HOME/.cargo/bin/uv" \
+                   /opt/homebrew/bin/uv /usr/local/bin/uv; do
+    [ -x "$candidate" ] && echo "$candidate" && return 0
+  done
   return 1
 }
 
@@ -66,7 +71,7 @@ fi
 if [ -z "$UV" ]; then
   echo "stash: CLI ${CURRENT:-not found} is older than $MIN_VERSION and uv is not" \
        "installed, so it cannot upgrade itself. Session activity is not being" \
-       "recorded. Reinstall with: curl -LsSf https://joinstash.ai/install.sh | sh" >&2
+       'recorded. Reinstall with: bash -c "$(curl -fsSL https://joinstash.ai/install)"' >&2
 else
   echo "stash: CLI ${CURRENT:-not found} is older than $MIN_VERSION. An upgrade is" \
        "running in the background; this session is not recorded, the next one will be." >&2

--- a/plugins/tests/test_event_queue.py
+++ b/plugins/tests/test_event_queue.py
@@ -44,6 +44,9 @@ class _Recorder:
             status_code = status
             is_success = status < 400
             text = "<!DOCTYPE html><title>Blocked</title>" if edge_blocked else "simulated error"
+            # The client reads the release header off every response
+            # (stashai/release.py).
+            headers: dict[str, str] = {}
 
             def json(self_inner):
                 if edge_blocked:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.365"
+version = "0.1.366"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/stashai/plugin/stash_client.py
+++ b/stashai/plugin/stash_client.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import httpx
 from filelock import FileLock
 
+from stashai import release
 from stashai.plugin.upload_status import (
     record_upload_attempt,
     record_upload_failure,
@@ -117,6 +118,7 @@ class StashClient:
         headers = kwargs.pop("headers", {})
         headers.update(self._headers())
         resp = self._http.request(method, path, headers=headers, **kwargs)
+        release.note_latest(resp.headers.get(release.LATEST_VERSION_HEADER, ""))
         if not resp.is_success:
             try:
                 payload = resp.json()

--- a/stashai/release.py
+++ b/stashai/release.py
@@ -1,0 +1,150 @@
+"""Tell the user when their `stash` is behind the current release.
+
+Every API response carries the release the backend was built from
+(X-Stash-Cli-Latest). When the running install is older, we print one line to
+stderr and stop. We deliberately do not upgrade anything from here: the agent
+plugins already run an upgrade at session start, and a warning that is always
+true is worth more than an upgrade that fails somewhere nobody can see.
+
+That is the whole point. A CLI could sit weeks behind while its session-start
+upgrade ran thousands of times, because nothing ever compared the running
+version to anything or reported it to the server — so the failure was invisible
+to the user and to us. Printing the comparison, and sending the version with
+CLI telemetry, turns "why is this install stale?" into a question we can answer
+from the machines it actually happens on, instead of guessing at causes.
+
+`upgrade_command()` is what `stash upgrade` runs. It resolves the install kind
+from the running interpreter, so a pip install under pyenv is upgraded by its
+own pip instead of by uv refreshing a copy that is not the one on PATH.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import sysconfig
+from functools import lru_cache
+from importlib.metadata import distribution, version
+from pathlib import Path
+
+LATEST_VERSION_HEADER = "X-Stash-Cli-Latest"
+
+INSTALLER = 'bash -c "$(curl -fsSL https://joinstash.ai/install)"'
+
+_warned = False
+
+
+@lru_cache(maxsize=1)
+def current_version() -> str:
+    """Cached: this runs on every API response, and a process cannot change the
+    version it is running."""
+    return version("stashai")
+
+
+def note_latest(latest: str) -> None:
+    """Handle the release header from an API response. At most one line per
+    process: a single command can make a dozen requests, and the user needs to
+    read this once."""
+    global _warned
+    if not latest or _warned:
+        return
+    current = current_version()
+    if not _is_older(current, latest):
+        return
+    _warned = True
+    if is_editable():
+        _say(
+            f"this checkout is {current}; the current release is {latest}. `git pull` to update it."
+        )
+        return
+    _say(
+        f"stash {current} is out of date; the current release is {latest}. "
+        "Run `stash upgrade` to update."
+    )
+
+
+def _is_older(have: str, want: str) -> bool:
+    return _parts(have) < _parts(want)
+
+
+def _parts(release: str) -> tuple[int, ...]:
+    """Dotted release as a comparable tuple. Non-numeric trailers ('.dev0',
+    '+local') drop out, so a locally built wheel compares on its release
+    numbers instead of raising mid-request."""
+    return tuple(int(part) for part in release.split(".") if part.isdigit())
+
+
+def upgrade_command() -> list[str] | None:
+    """How to upgrade *this* install, or None when it has no working upgrader.
+    The kind is decided by where the running interpreter lives, so a pip
+    install under pyenv is upgraded by that pip instead of by uv quietly
+    refreshing a copy nobody runs."""
+    if _is_uv_tool():
+        uv = _find_uv()
+        return [uv, "tool", "install", "--quiet", "stashai@latest"] if uv else None
+    if not _has_pip():
+        # uv venvs ship without pip, so `python -m pip` there fails on a
+        # missing module rather than on anything the user can act on.
+        return None
+    command = [sys.executable, "-m", "pip", "install", "--quiet", "--upgrade", "stashai"]
+    if _is_externally_managed():
+        # PEP 668 pythons (Debian's, the Fly Sprites we provision) refuse plain
+        # installs; these are the flags our own sprite setup installs with
+        # (backend/services/sprite_service.py).
+        command += ["--user", "--break-system-packages"]
+    return command
+
+
+def _has_pip() -> bool:
+    return importlib.util.find_spec("pip") is not None
+
+
+def _is_externally_managed() -> bool:
+    """The PEP 668 marker: this python's distributor forbids installing into it
+    without an explicit override."""
+    return (Path(sysconfig.get_path("stdlib")) / "EXTERNALLY-MANAGED").is_file()
+
+
+def _is_uv_tool() -> bool:
+    """uv drops a receipt in every tool environment it creates.
+
+    Recognising the environment by the shape of its path instead looks right on
+    a default install and breaks the moment UV_TOOL_DIR is set, which would
+    send a uv install down the pip branch — where a uv environment has no pip.
+    The receipt is a fact about this install rather than a guess at its layout."""
+    return (Path(sys.prefix) / "uv-receipt.toml").is_file()
+
+
+def is_editable() -> bool:
+    """PEP 610 records how a distribution was installed; `pip install -e .`
+    writes dir_info.editable."""
+    raw = distribution("stashai").read_text("direct_url.json")
+    if raw is None:
+        return False
+    return bool(json.loads(raw).get("dir_info", {}).get("editable"))
+
+
+def _find_uv() -> str | None:
+    """uv, whether or not it is on this process's PATH. Agent hooks run with a
+    minimal PATH, so a uv installed by Homebrew is invisible to `which`."""
+    found = shutil.which("uv")
+    if found:
+        return found
+    candidates = [
+        Path.home() / ".local/bin/uv",
+        Path.home() / ".cargo/bin/uv",
+        Path("/opt/homebrew/bin/uv"),
+        Path("/usr/local/bin/uv"),
+    ]
+    for candidate in candidates:
+        if os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
+
+
+def _say(message: str) -> None:
+    """stderr, always: hook stdout carries the JSON payload the agent parses."""
+    print(f"stash: {message}", file=sys.stderr)


### PR DESCRIPTION
okay so basically we 
(1) just print a stderr to the agent whenever the CLI is out of date on our backend API response.
(2) also try to use pip install if stash was installed via pip
(3) CLI telemetry now has a "CLI version" column so we can better understand how big of a deal CLI going out of date is
(4) look for uv installations in more places than just PATH and `~/.local/bin`, also check Homebrew + Cargo.


# slop
An alternative to #1049, which tried to fix a cause we never established.

On 27 July Sam fixed a bug where an `.html` file inside a directory upload was posted as markdown and rendered as escaped source; it shipped the next day in 0.1.335. On 14 August he hit that same bug himself — so the CLI he was running still predated 0.1.335, while 0.1.364 was current. His machine ran the session-start upgrade throughout. **No record exists of what version he was running, or of where that upgrade stopped working**, because the CLI never compared its version to anything and never reported it.

#1049 responds by replacing the upgrade path with one that covers every way it could have failed at once — Homebrew uv, pyenv shadowing, PEP 668, uv-without-pip, `UV_TOOL_DIR`. Each of those is a hypothesis. This PR does the smallest thing that ends the blindness instead, and leaves the cause to be measured.

## What this does

- Every API response carries `X-Stash-Cli-Latest`, read from the repo's `pyproject.toml` version — the same number `publish.yml` ships to PyPI.
- A CLI that finds itself older prints one line to stderr and carries on:

```
stash: stash 0.1.334 is out of date; the current release is 0.1.365. Run `stash upgrade` to update.
```

- CLI telemetry reports the running version, so "how many installs are stale?" becomes a query.

## What it deliberately does not do

It does not upgrade anything. The plugins' session-start upgrade is untouched and keeps working for everyone it already works for.

An automatic upgrade has to guess at an install kind nobody has measured, and a detached upgrade that fails is invisible in exactly the way this change exists to fix — it announces success it cannot verify, once an hour, forever. A warning is true whatever the cause. Once we can see who is stale, we can find out why on the machines it happens to.

## `stash upgrade`

Fixed, because the warning points at it. It resolved uv off PATH and assumed every install was a uv tool install, so on a pip install under pyenv it upgraded a copy the shell does not run. It now reads the install kind off the running interpreter — a uv tool environment by the receipt uv leaves in it, anything else by its own pip (with PEP 668 flags where required) — refuses an editable checkout, and finds a Homebrew uv.

## Deploy notes

- A pre-release version in `pyproject.toml` raises at import: clients compare plain dotted numbers and would read `0.1.365rc1` as *older*, silently muting the warning fleet-wide.
- `backend/Dockerfile` copies `pyproject.toml`, so a backend that cannot name a release fails at boot rather than going quiet.
- The header is the version the **backend build** was cut from. It equals the newest PyPI release only because a merge to `main` deploys the backend and publishes the CLI from the same commit. If the publish fails and the deploy succeeds, clients are told to chase a release that does not exist.

## Known limit, worth deciding before this ships

The warning goes to stderr. That reaches someone who typed a `stash` command. A notice raised inside the plugin's background transcript upload goes to a process nobody reads. If telemetry shows the fleet is stale in bulk, surfacing this at agent session start is the next step.

## Testing

- `cli/tests/test_release_warning.py` — stale warns, current and newer stay quiet, a missing header says nothing, one line per process across repeated requests, editable checkouts are told to `git pull`; plus the `stash upgrade` install-kind cases (pip by its own interpreter, PEP 668 flags, no pip, uv by receipt with `UV_TOOL_DIR` set, uv install with uv gone).
- `cli/tests/test_release_header_wire.py` — both HTTP clients read the header; the header name is pinned as a literal so renaming the constant cannot pass both suites while breaking every deployed CLI.
- `backend/tests/test_cli_release_header.py` — the header rides every response including 401s, matches the published version, and a pre-release is refused.
- 420 CLI + plugin tests pass; `ruff check` and `ruff format --check` clean on the paths CI lints. The backend tests need a database and were not run locally.
- End-to-end against a mocked backend advertising 0.1.365: a stale install prints the upgrade line once across repeated requests; an editable checkout is told to `git pull`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all API responses and shared HTTP clients, but behavior is additive (header + stderr warning) with strict version validation at backend import; upgrade path changes affect user installs directly.
> 
> **Overview**
> Adds **`X-Stash-Cli-Latest`** on every backend response (from `pyproject.toml`, including errors and unauthenticated requests), with import-time failure if the version is not a plain dotted release. The Docker image now copies `pyproject.toml` so deploys cannot boot without a comparable release number.
> 
> The CLI and plugin HTTP clients call **`stashai.release.note_latest`** on each response so a behind install prints **one** stderr line (`stash upgrade` or `git pull` for editable checkouts). **`stash upgrade`** now picks **uv tool** vs **pip** (PEP 668 flags when needed) from the running interpreter instead of always assuming uv. CLI telemetry events include **`version`** for fleet staleness queries.
> 
> The Claude plugin **`ensure_cli.sh`** widens **uv** discovery (Homebrew/cargo paths) and aligns the reinstall message with the shared installer string. Version bump to **0.1.366**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 990b0a650bbc5dfe17ac6a4c9621867b9a41e001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->