### PR TITLE
Renumber the session-titles migration to 0188 — 0185 was already taken

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,13 +75,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The merge below needs a merge base, which a depth-1 clone lacks.
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - run: pip install "$(grep '^alembic' backend/requirements.txt)"
+      # GitHub builds the PR merge ref from main as of the branch's last push
+      # and does not re-run workflows when main moves, so this job can pass
+      # against a base that is weeks stale — #965 did, and collided with a
+      # migration that had landed on main in the meantime. Merging main here
+      # makes the check see the tree that will actually be deployed.
+      - name: Merge current main
+        run: |
+          git fetch origin main
+          git merge --no-commit --no-ff FETCH_HEAD || {
+            echo "::error::This branch conflicts with main; rebase onto main."
+            exit 1
+          }
       # Two PRs merging migrations onto the same parent leave alembic with two
-      # heads and break every deploy (#712 + #713 both shipped "0125"). PR CI
-      # runs against the merge ref, so this reds the second PR before merge.
+      # heads and break every deploy (#712 + #713 both shipped "0125").
       - run: python backend/migrations/check_heads.py
 
   plugin-test:

--- a/backend/migrations/check_heads.py
+++ b/backend/migrations/check_heads.py
@@ -1,11 +1,14 @@
-"""Fail unless the migration graph has exactly one head.
+"""Fail unless every migration has a unique revision id and the graph has one head.
 
 Two PRs that each add a migration on top of the same parent merge cleanly in
 git but leave alembic with two heads (or two files claiming the same revision
 id) — and every `alembic upgrade head` after that refuses to run: deploys,
-fresh test databases, local setups. That exact race shipped as #712 + #713
-(both "0125") and broke main for an hour; this check turns it into a red PR
-check instead of a broken deploy, because PR CI runs against the merge ref.
+fresh test databases, local setups. That race shipped as #712 + #713 (both
+"0125") and again as #965 + #1040 (both "0185"); this check turns it into a
+red PR check instead of a broken deploy. The workflow merges current main
+before running it, because PR CI otherwise checks a merge ref built when the
+branch last pushed — #965 passed this check against a base from ten days
+earlier that did not yet contain the migration it collided with.
 
 Run from the repo root: `python backend/migrations/check_heads.py`.
 Needs only alembic installed — no database, no backend settings.
@@ -13,7 +16,9 @@ Needs only alembic installed — no database, no backend settings.
 
 from __future__ import annotations
 
+import re
 import sys
+from pathlib import Path
 
 from alembic.config import Config
 from alembic.script import ScriptDirectory
@@ -25,14 +30,44 @@ FIX = (
     "the current head, then rebase."
 )
 
+VERSIONS = Path(__file__).parent / "versions"
+REVISION_LINE = re.compile(r'^revision = "([^"]+)"', re.MULTILINE)
+
+
+def duplicate_revision_ids() -> dict[str, list[str]]:
+    """Revision ids claimed by more than one file, mapped to those filenames.
+
+    Alembic keys its script map by revision id, so a duplicate silently drops
+    one of the two files instead of erroring — worth naming explicitly, since
+    the head count alone does not say which files collided.
+    """
+    files_by_id: dict[str, list[str]] = {}
+    for path in sorted(VERSIONS.glob("*.py")):
+        match = REVISION_LINE.search(path.read_text())
+        if not match:
+            print(f'{path.name} has no `revision = "..."` line', file=sys.stderr)
+            sys.exit(1)
+        files_by_id.setdefault(match.group(1), []).append(path.name)
+    return {rev: files for rev, files in files_by_id.items() if len(files) > 1}
+
 
 def main() -> int:
+    duplicates = duplicate_revision_ids()
+    if duplicates:
+        for revision, files in sorted(duplicates.items()):
+            print(
+                f"revision id {revision} is claimed by {' and '.join(files)}; "
+                f"alembic keeps only one of them.\n{FIX}",
+                file=sys.stderr,
+            )
+        return 1
+
     script = ScriptDirectory.from_config(Config("alembic.ini"))
     try:
         heads = script.get_heads()
     except CommandError as e:
-        # Two files claiming the same revision id fail before heads can even
-        # be computed.
+        # A down_revision pointing at a revision id no file defines fails
+        # before heads can even be computed.
         print(f"migration graph is broken: {e}\n{FIX}", file=sys.stderr)
         return 1
     if len(heads) != 1:

--- a/backend/migrations/versions/0188_session_titles_into_sessions.py
+++ b/backend/migrations/versions/0188_session_titles_into_sessions.py
@@ -8,14 +8,14 @@ session with everything about it, and one codepath for reads and writes.
 
 Carries existing titles forward in one shot, then drops the side table.
 
-Revision ID: 0185
-Revises: 0184
+Revision ID: 0188
+Revises: 0187
 """
 
 from alembic import op
 
-revision = "0185"
-down_revision = "0184"
+revision = "0188"
+down_revision = "0187"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
problem: #965 never deployed because it had a fatal error: two alembic revisions with the same number.

(1) rename conflicting migration version
(2) fix our CI check for conflicting migration names so that it first gets the latest version of main before running the `alembic heads` check! Previously, it ran this check, but against a stale version of main, so render wasn't able to deploy #965.


# slop

## What broke

PR #965 added `backend/migrations/versions/0185_session_titles_into_sessions.py` with `revision = "0185"`, `down_revision = "0184"`. `0185_sources_bind_skills.py` already had exactly that pair, so two migration files claimed the same revision id.

Alembic keys its script map by revision id, so one file silently shadowed the other (`UserWarning: Revision 0185 is present more than once` in every boot log), and on a clean database the chain resolved to two heads. That is why CI on `main` is currently red:

```
FAILED: Multiple head revisions are present for given argument 'head';
please specify a specific target revision, '<branchname>@head' ...
```

## What it did to production

Worse than a red CI. `alembic_version` on the prod Neon database (`stash-prod`) was already stamped `0187`, so `0185` counted as applied and the session-titles migration never ran and never would. Verified directly against prod:

- `sessions.title`, `title_source_hash`, `title_user_set`, `title_updated_at` — do not exist
- `session_titles` — still present

#965's code reads and writes those columns, so:

- **`stash_backend` crash-looped** — both uvicorn workers died before "Application startup complete", every ~15s for 15 minutes, until Render marked deploy `dep-da3lkke7bikc7385m95g` `update_failed`. It rolled back to the previous deploy, so api.joinstash.ai is currently serving the code from 2ce148c9.
- **The celery workers have no health check, so they deployed successfully and are failing every session-title task:**

```
backend/tasks/session_titles.py:166 in _reconcile_missing
asyncpg.exceptions.UndefinedColumnError: column s.title does not exist

backend/tasks/session_titles.py:108 in _generate_for_session
asyncpg.exceptions.UndefinedColumnError: column "title_source_hash" does not exist
```

Session titles are not being generated in prod right now.

## The change

Move the migration to `revision = "0188"` / `down_revision = "0187"`, after the real head. Its `upgrade()` only touches `sessions` and `session_titles`, and nothing in 0185, 0186 or 0187 touches either table, so the position change is safe. It applies on the next backend boot and adds the columns prod is missing.

The file is renamed and four lines change; there is no change to the SQL.

## Verification

- `alembic` resolves a single head (`0188`) and a linear chain; the duplicate-revision warning is gone.
- Upgrading a database from `0178` ran `0179` → `0188` in order, including both former-`0185` migrations. Afterwards the four title columns are on `sessions`, `session_titles` is dropped, and `alembic_version` is `0188`.
- Full backend suite passes against a database migrated through the corrected chain: **1394 passed**.
- `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches the Alembic chain and production schema (session title columns). A wrong revision/parent would skip or double-apply migrations and break deploys.
> 
> **Overview**
> Fixes a duplicate Alembic revision (`0185`) that left two heads, skipped the session-titles schema change on databases already stamped past `0185`, and broke deploys.
> 
> The session-titles migration is moved to **`0188` / `down_revision = "0187"`** (SQL unchanged) so it sits after the real head and can actually apply.
> 
> `check_heads.py` now fails on duplicate `revision` ids before Alembic silently drops one file. The CI job fetches full history and **merges current `main`** first so the check sees the tree that will deploy, not a stale merge-base.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0300f53961b23c2fbbd45ffd361a15dc16423b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->