### PR TITLE
A transcript keeps the order its events were uploaded in

### DIFF
--- a/backend/migrations/versions/0189_history_event_seq.py
+++ b/backend/migrations/versions/0189_history_event_seq.py
@@ -1,0 +1,41 @@
+"""Record the order events were written in, so a batch reads back in order.
+
+push_events_batch stamps every event in one upload with the same created_at,
+and transcript reads order by (created_at, id) where id is a random UUID — so
+a question and the answer to it, uploaded together, came back in either order.
+About half the time the transcript showed the answer above the question. seq is
+a monotonic counter that breaks those ties by insertion order.
+
+Existing rows are deliberately left NULL. The order they were inserted in was
+never stored, so it cannot be recovered, and backfilling would rewrite a
+multi-gigabyte table while the backend waits on it at boot (migrations run at
+startup). NULLs sort last and tie among themselves, falling through to id —
+exactly what those rows do today.
+
+Revision ID: 0189
+Revises: 0188
+"""
+
+from alembic import op
+
+revision = "0189"
+down_revision = "0188"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Three statements rather than one ADD COLUMN ... DEFAULT nextval(...):
+    # nextval is volatile, and Postgres rewrites the entire table for a column
+    # added with a volatile default. Adding the column bare and attaching the
+    # default afterwards is catalog-only, so this is instant on a large table.
+    op.execute("ALTER TABLE history_events ADD COLUMN seq BIGINT")
+    op.execute("CREATE SEQUENCE history_events_seq_seq OWNED BY history_events.seq")
+    op.execute(
+        "ALTER TABLE history_events ALTER COLUMN seq SET DEFAULT nextval('history_events_seq_seq')"
+    )
+
+
+def downgrade() -> None:
+    # The sequence is OWNED BY the column, so dropping the column drops it too.
+    op.execute("ALTER TABLE history_events DROP COLUMN seq")

--- a/backend/migrations/versions/0189_history_event_seq.py
+++ b/backend/migrations/versions/0189_history_event_seq.py
@@ -7,12 +7,13 @@ back in either order. About half the time the transcript showed the answer
 above the question. seq holds the event's position in the array the caller
 sent, and the reads break ties on it.
 
-It only has to separate events that share a created_at, which is why nothing
-but the batch endpoint fills it in: the single-event endpoint and the
-transcript-file import each give their events distinct timestamps, so
-created_at already orders those.
+Every caller of push_events_batch fills it in, so this covers the other way a
+transcript ends up with tied timestamps: a JSONL file whose own events share
+one. Those now order by position in the file rather than by id. The
+single-event endpoint leaves seq NULL and needs nothing — each call stamps its
+own now().
 
-Existing rows stay NULL, as do rows from those other paths. The order a stored
+Existing rows stay NULL, as do rows written one at a time. The order a stored
 batch was written in was never recorded, so it cannot be recovered, and
 backfilling would rewrite a multi-gigabyte table while the backend waits on it
 at boot (migrations run at startup). NULLs sort last and tie among themselves,

--- a/backend/migrations/versions/0189_history_event_seq.py
+++ b/backend/migrations/versions/0189_history_event_seq.py
@@ -1,16 +1,22 @@
-"""Record the order events were written in, so a batch reads back in order.
+"""Record where an event sat in the upload that wrote it.
 
-push_events_batch stamps every event in one upload with the same created_at,
-and transcript reads order by (created_at, id) where id is a random UUID — so
-a question and the answer to it, uploaded together, came back in either order.
-About half the time the transcript showed the answer above the question. seq is
-a monotonic counter that breaks those ties by insertion order.
+push_events_batch stamps every event that arrives without its own created_at
+with the same instant, and transcript reads order by (created_at, id) where id
+is a random UUID — so a question and the answer to it, uploaded together, came
+back in either order. About half the time the transcript showed the answer
+above the question. seq holds the event's position in the array the caller
+sent, and the reads break ties on it.
 
-Existing rows are deliberately left NULL. The order they were inserted in was
-never stored, so it cannot be recovered, and backfilling would rewrite a
-multi-gigabyte table while the backend waits on it at boot (migrations run at
-startup). NULLs sort last and tie among themselves, falling through to id —
-exactly what those rows do today.
+It only has to separate events that share a created_at, which is why nothing
+but the batch endpoint fills it in: the single-event endpoint and the
+transcript-file import each give their events distinct timestamps, so
+created_at already orders those.
+
+Existing rows stay NULL, as do rows from those other paths. The order a stored
+batch was written in was never recorded, so it cannot be recovered, and
+backfilling would rewrite a multi-gigabyte table while the backend waits on it
+at boot (migrations run at startup). NULLs sort last and tie among themselves,
+falling through to id — exactly what those rows do today.
 
 Revision ID: 0189
 Revises: 0188
@@ -25,17 +31,10 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Three statements rather than one ADD COLUMN ... DEFAULT nextval(...):
-    # nextval is volatile, and Postgres rewrites the entire table for a column
-    # added with a volatile default. Adding the column bare and attaching the
-    # default afterwards is catalog-only, so this is instant on a large table.
-    op.execute("ALTER TABLE history_events ADD COLUMN seq BIGINT")
-    op.execute("CREATE SEQUENCE history_events_seq_seq OWNED BY history_events.seq")
-    op.execute(
-        "ALTER TABLE history_events ALTER COLUMN seq SET DEFAULT nextval('history_events_seq_seq')"
-    )
+    # No default, so this is catalog-only: Postgres rewrites the whole table
+    # for a column added with a volatile default, and this table is large.
+    op.execute("ALTER TABLE history_events ADD COLUMN seq INT")
 
 
 def downgrade() -> None:
-    # The sequence is OWNED BY the column, so dropping the column drops it too.
     op.execute("ALTER TABLE history_events DROP COLUMN seq")

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -198,21 +198,26 @@ async def push_events_batch(
     metadatas = [json.dumps(e.get("metadata") or {}) for e in events]
     attachments = [json.dumps(e["attachments"]) if e.get("attachments") else None for e in events]
     timestamps = [_normalize_ts(e["created_at"]) if e.get("created_at") else now for e in events]
+    # Every event that arrives without its own created_at gets `now`, so a whole
+    # batch usually shares one timestamp and the read has nothing left to order
+    # by. seq carries the caller's order — the position in this array — across
+    # to the read.
+    seqs = list(range(len(events)))
 
     rows = await pool.fetch(
         """
         INSERT INTO history_events
             (owner_user_id, created_by, agent_name, event_type, content,
-             session_id, tool_name, metadata, attachments, created_at)
+             session_id, tool_name, metadata, attachments, created_at, seq)
         SELECT $1::uuid, $2::uuid, u.an, u.et, u.c,
                u.sid, u.tn, u.md::jsonb,
                CASE WHEN u.att IS NULL THEN NULL ELSE u.att::jsonb END,
-               u.ts
+               u.ts, u.seq
         FROM UNNEST(
             $3::varchar[], $4::varchar[], $5::text[],
             $6::varchar[], $7::varchar[],
-            $8::text[], $9::text[], $10::timestamptz[]
-        ) AS u(an, et, c, sid, tn, md, att, ts)
+            $8::text[], $9::text[], $10::timestamptz[], $11::int[]
+        ) AS u(an, et, c, sid, tn, md, att, ts, seq)
         RETURNING id, owner_user_id, created_by, agent_name, event_type,
                   session_id, tool_name, content, metadata, attachments, created_at
         """,
@@ -226,6 +231,7 @@ async def push_events_batch(
         metadatas,
         attachments,
         timestamps,
+        seqs,
     )
     results = [dict(r) for r in rows]
     await _upsert_sessions_for_events(owner_user_id, created_by, events)

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -334,7 +334,7 @@ async def read_session_events(
     rows = await pool.fetch(
         "SELECT id, agent_name, event_type, tool_name, content, metadata, created_at "
         "FROM history_events WHERE owner_user_id = $1 AND session_id = $2 "
-        "ORDER BY created_at, id",
+        "ORDER BY created_at, seq, id",
         owner_user_id,
         session_id,
     )
@@ -363,7 +363,7 @@ async def read_session_events_page(
         "SELECT id, agent_name, event_type, tool_name, content, metadata, created_at "
         "FROM history_events "
         "WHERE owner_user_id = $1 AND session_id = $2 AND event_type = ANY($3::text[]) "
-        "ORDER BY created_at, id LIMIT $4 OFFSET $5",
+        "ORDER BY created_at, seq, id LIMIT $4 OFFSET $5",
         owner_user_id,
         session_id,
         list(RENDERABLE_EVENT_TYPES),

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -1035,3 +1035,52 @@ async def test_reupload_to_deleted_session_skips_without_resurrecting(client: As
     assert (
         await pool.fetchval("SELECT deleted_at FROM sessions WHERE id = $1", row_id)
     ) is not None
+
+
+@pytest.mark.asyncio
+async def test_batch_without_timestamps_reads_back_in_submitted_order(client: AsyncClient):
+    """A batch uploaded without per-event timestamps keeps the order it was sent in.
+
+    Every event in one batch is stamped with the same created_at, so ordering
+    fell through to the row id — a random UUID — and a question could come back
+    below the answer to it. Eight alternating turns make a chance pass
+    vanishingly unlikely: with the tie broken at random, one ordering in 8!.
+    """
+    key = await _register(client)
+    headers = {"Authorization": f"Bearer {key}"}
+
+    turns = [
+        ("user_message", "q1"),
+        ("assistant_message", "a1"),
+        ("user_message", "q2"),
+        ("assistant_message", "a2"),
+        ("user_message", "q3"),
+        ("assistant_message", "a3"),
+        ("user_message", "q4"),
+        ("assistant_message", "a4"),
+    ]
+    pushed = await client.post(
+        "/api/v1/me/sessions/events/batch",
+        json={
+            "events": [
+                {
+                    "agent_name": "claude",
+                    "event_type": event_type,
+                    "content": content,
+                    "session_id": "sess-order",
+                }
+                for event_type, content in turns
+            ]
+        },
+        headers=headers,
+    )
+    assert pushed.status_code in (200, 201), pushed.text
+
+    events_resp = await client.get(
+        "/api/v1/me/transcripts/sess-order/events",
+        params={"limit": 100},
+        headers=headers,
+    )
+    assert events_resp.status_code == 200
+    events = events_resp.json()["events"]
+    assert [event["content"] for event in events] == [content for _type, content in turns]


### PR DESCRIPTION
When sessions are uploaded, they sometimes have the same timestamp (eg if we're doing a batch upload). When this happens, we are not able to determine the order that the messages should be displayed in. Here we add a second ordering for messages in a transcript that applies lexicographically after timestamp that allows us to manually fix an order for a bulk-uploaded transcript where every message shares a timestamp. We then use that order in our existing bulk upload endpoint, assigning an ordering to messages based on their position in the original array passed into our endpoint. So the first message in the array goes first, the second goes second, etc.


## The bug

`push_events_batch` stamps every event that arrives without its own `created_at` with the same instant, and the two transcript reads order by `(created_at, id)` — where `history_events.id` is `gen_random_uuid()`. So a question and the answer to it, uploaded together the way a product backend does after a turn, came back in either order. About half the time the transcript showed the answer above the question.

Whatever order comes out is what everything downstream renders: the session viewer, `sessions/<name>/transcript.md` in the VFS, and any agent grepping `/sessions`. It isn't limited to one caller — `push_events_batch` in both `cli/client.py` and `sdk/src/stash_sdk/client.py` passes the caller's event dicts straight through with no timestamp filled in, so any integrator batching a turn is exposed.

Found while building the travel-agent example against a local backend: a recorded turn read back assistant-first.

## The fix

`history_events` gains a `seq` holding the event's position in the array the caller sent, and the two transcript reads break ties on it: `ORDER BY created_at, seq, id`. `created_at` stays the primary sort, so a transcript file uploaded with real per-event timestamps still sorts by real time — the only change is that events sharing an instant come back in the order they were sent.

`push_events_batch` is the only writer that fills `seq` in. It only has to separate events that share a `created_at`, and the single-event endpoint and the transcript-file import each give their events distinct timestamps, so `created_at` already orders those.

**Existing rows stay NULL**, as do rows from those other paths. The order a stored batch was written in was never recorded, so it cannot be recovered, and backfilling would rewrite a 6 GB / 1.07M-row table while the backend waits on it at boot (migrations run at startup). NULLs sort last and tie among themselves, falling through to `id` — exactly what those rows do today, so nothing already stored shifts. The migration is a bare `ADD COLUMN` with no default, which is catalog-only and therefore instant regardless of table size.

Two alternatives considered and rejected:

- **A `nextval` default instead of an explicit position.** The first version of this PR did that, and it worked only because Postgres happens to emit `UNNEST` rows in array order and fire the default as it goes. Nothing in the code said the order was the array's, so a future plan change could have quietly gone back to scrambling turns. It also drags in a volatile default, which rewrites the whole table on `ADD COLUMN`.
- **Stamping `now + index` per event at write time.** It invents times that never happened, and it only helps events that share a batch — two turns posted as separate calls in the same millisecond would still tie.

## Verification

- New test pushes eight alternating turns in one batch and asserts the read-back order matches submission. With the tie broken at random that's one ordering in 8!, so it can't pass by luck.
- Confirmed it **fails** on the old `ORDER BY` (returned `['a4', 'q1', ...]`) and again when the positions are flattened to zeros (returned `['q2', 'a2', ...]`), and passes with the fix.
- `test_transcripts.py`, `test_history_pagination.py`, `test_vfs.py`, `test_curator.py` — 73 passed, against a database migrated from scratch.
- `ruff check` and `ruff format --check` clean; `backend/migrations/check_heads.py` (from #1076) reports a single head at 0189.

Note for merge order: `0189` assumes #1076's `0188` is the head. Any other migration landing in between needs a rebase of `down_revision` — the head check added by #1076 will catch it.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `history_events` schema and the canonical transcript sort, which drives session rendering. Migration is catalog-only and NULLs preserve existing row order, so the main risk is incomplete coverage of other readers that still sort by `(created_at, id)`.
> 
> **Overview**
> Batch-uploaded session events that share one `created_at` no longer shuffle on read. Transcripts were ordering by `(created_at, id)` with a random UUID, so a question and its answer uploaded together came back in either order.
> 
> Adds a nullable `seq` column on `history_events` (catalog-only, no default, no backfill). `push_events_batch` stores each event’s index in the submitted array, and session transcript reads now `ORDER BY created_at, seq, id`. Existing and single-insert rows stay NULL and keep today’s UUID tie-break.
> 
> Covered by a batch of eight alternating turns that must round-trip in submission order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0acf693e54dea4300bfbeff6b1e3133d176548a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->