### PR TITLE
Don't spend an LLM call titling a session that only ended

### DIFF
--- a/backend/tasks/session_titles.py
+++ b/backend/tasks/session_titles.py
@@ -13,6 +13,15 @@ from ._celery_helpers import run_async
 MAX_SOURCE_CHARS = 2_000
 RECONCILE_BATCH_SIZE = 25
 
+# Every query below reads past session_end events. A session_end event is a
+# wrap-up marker the plugin hook and the history importer emit for every
+# session -- "Session ended.", "Session ended. 2 tool uses.", "Imported
+# historical session (27 KB)" -- so it is non-blank content that names nothing
+# the session did. A session carrying only that marker therefore has no
+# titleable content at all and never reaches the LLM. Keeping the marker out of
+# _session_stats also keeps it out of source_hash, so a session that was already
+# titled while it ran is not re-titled just because it later ended.
+
 
 def _clean_text(text: str) -> str:
     return " ".join(text.split())
@@ -35,6 +44,7 @@ async def _session_stats(owner_user_id: UUID, session_id: str) -> dict | None:
         WHERE h.owner_user_id = $1
           AND h.session_id = $2
           AND NULLIF(BTRIM(h.content), '') IS NOT NULL
+          AND h.event_type <> 'session_end'
           AND s.deleted_at IS NULL
         GROUP BY h.session_id
         """,
@@ -53,6 +63,7 @@ async def _session_events(owner_user_id: UUID, session_id: str) -> list[dict]:
         WHERE owner_user_id = $1
           AND session_id = $2
           AND NULLIF(BTRIM(content), '') IS NOT NULL
+          AND event_type <> 'session_end'
         ORDER BY created_at ASC, id ASC
         LIMIT 16
         """,
@@ -173,6 +184,7 @@ async def _reconcile_missing() -> int:
           AND s.title IS NULL
           AND s.deleted_at IS NULL
           AND NULLIF(BTRIM(h.content), '') IS NOT NULL
+          AND h.event_type <> 'session_end'
         GROUP BY h.owner_user_id, h.session_id
         ORDER BY MAX(h.created_at) DESC
         LIMIT $1

--- a/backend/tests/test_session_title_generation.py
+++ b/backend/tests/test_session_title_generation.py
@@ -1,0 +1,162 @@
+"""Tests for what the title generator treats as titleable session content."""
+
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+
+from backend.config import settings
+from backend.tasks import session_titles as session_titles_task
+
+from .conftest import unique_name
+
+
+async def _register(client: AsyncClient) -> str:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name(), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201
+    return resp.json()["api_key"]
+
+
+def _auth(api_key: str) -> dict:
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+async def _make_session(client: AsyncClient, api_key: str, session_id: str) -> dict:
+    scope_resp = await client.get("/api/v1/users/me", headers=_auth(api_key))
+    assert scope_resp.status_code == 200
+
+    session_resp = await client.post(
+        "/api/v1/me/sessions",
+        json={"session_id": session_id, "agent_name": "claude"},
+        headers=_auth(api_key),
+    )
+    assert session_resp.status_code == 201
+    return scope_resp.json()
+
+
+async def _add_event(pool, owner_user_id: str, session_id: str, event_type: str, content: str):
+    await pool.execute(
+        "INSERT INTO history_events "
+        "(owner_user_id, session_id, agent_name, event_type, content, created_at) "
+        "VALUES ($1, $2, 'claude', $3, $4, now())",
+        owner_user_id,
+        session_id,
+        event_type,
+        content,
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_end_marker_alone_is_not_worth_an_llm_call(
+    client: AsyncClient, pool, monkeypatch
+):
+    """The hook ends every session, including ones where nothing happened.
+
+    Titling that marker cost a model call per session and produced titles like
+    "Empty Session" -- 4,064 of them in prod before this filter existed.
+    """
+    api_key = await _register(client)
+    scope = await _make_session(client, api_key, "sess-title-marker-only")
+    await _add_event(pool, scope["id"], "sess-title-marker-only", "session_end", "Session ended.")
+
+    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", "test-key")
+
+    async def _fail_if_called(source: str) -> str:
+        raise AssertionError(f"the model was asked to title a marker: {source!r}")
+
+    monkeypatch.setattr(session_titles_task, "_generate_title", _fail_if_called)
+
+    result = await session_titles_task._generate_for_session(
+        UUID(scope["id"]), "sess-title-marker-only"
+    )
+
+    assert result == "missing"
+    row = await pool.fetchrow(
+        "SELECT title FROM sessions WHERE owner_user_id = $1 AND session_id = $2",
+        scope["id"],
+        "sess-title-marker-only",
+    )
+    assert row["title"] is None
+
+
+@pytest.mark.asyncio
+async def test_real_events_still_generate_without_the_marker_in_the_source(
+    client: AsyncClient, pool, monkeypatch
+):
+    """A session with real content is still titled, and the marker is not part
+    of what the model reads -- otherwise every transcript would end with
+    boilerplate the title could latch onto."""
+    api_key = await _register(client)
+    scope = await _make_session(client, api_key, "sess-title-real-content")
+    await _add_event(
+        pool,
+        scope["id"],
+        "sess-title-real-content",
+        "user_message",
+        "fix the flaky auth test",
+    )
+    await _add_event(
+        pool,
+        scope["id"],
+        "sess-title-real-content",
+        "session_end",
+        "Session ended. 2 tool uses.",
+    )
+
+    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", "test-key")
+
+    seen: list[str] = []
+
+    async def _capture(source: str) -> str:
+        seen.append(source)
+        return "Fix the flaky auth test"
+
+    monkeypatch.setattr(session_titles_task, "_generate_title", _capture)
+
+    result = await session_titles_task._generate_for_session(
+        UUID(scope["id"]), "sess-title-real-content"
+    )
+
+    assert result == "generated"
+    assert len(seen) == 1
+    assert "fix the flaky auth test" in seen[0]
+    assert "Session ended" not in seen[0]
+
+    row = await pool.fetchrow(
+        "SELECT title FROM sessions WHERE owner_user_id = $1 AND session_id = $2",
+        scope["id"],
+        "sess-title-real-content",
+    )
+    assert row["title"] == "Fix the flaky auth test"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_does_not_queue_marker_only_sessions(
+    client: AsyncClient, pool, monkeypatch
+):
+    """The 60s reconcile is what re-sent the same untitled sessions every tick."""
+    api_key = await _register(client)
+    scope = await _make_session(client, api_key, "sess-title-reconcile-marker")
+    await _add_event(
+        pool,
+        scope["id"],
+        "sess-title-reconcile-marker",
+        "session_end",
+        "Imported historical session (27 KB)",
+    )
+
+    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", "test-key")
+
+    queued: list[tuple] = []
+    monkeypatch.setattr(
+        session_titles_task.generate_session_title,
+        "delay",
+        lambda *args: queued.append(args),
+    )
+
+    await session_titles_task._reconcile_missing()
+
+    assert ("sess-title-reconcile-marker",) not in [(a[1],) for a in queued]


### PR DESCRIPTION
skip titling sessions whose only event is "session ended"- saves us several hundred dollars lol. we can buy more octopodes now.


# slop 
## What

The three queries that feed session-title generation now read past `session_end` events.

## Why

The plugin hook (`stashai/plugin/hooks.py:471`) pushes a `session_end` event for every session, and the history importer (`cli/import_history.py:613`) pushes one per imported conversation. Their content is a generated marker:

- `Session ended.` — 11,198 rows in prod
- `Session ended. 2 tool uses.`
- `Imported historical session (27 KB)`

That content is non-blank, so it passed the `NULLIF(BTRIM(content), '') IS NOT NULL` filter that decides what there is to title. A session where nothing else happened looked exactly like a session with content: `_source_text` rendered `session_end: Session ended.` and handed it to the model, which titled it about as well as anyone could — `Empty Session`, `Session Ended Without Activity`, `Coding Agent Session Ended`.

**4,064 sessions in prod carry a title of that shape**, one model call each. The existing `if not source: return "empty"` gate never fired for them, because the marker is not literally empty.

## What changes

`AND event_type <> 'session_end'` in `_session_stats`, `_session_events`, and `_reconcile_missing`. A session carrying only the marker now has no titleable content and stops before the API call — `_session_stats` finds no qualifying events and returns `"missing"`.

Keeping the marker out of `_session_stats` also keeps it out of `source_hash`, so a session titled while it was still running is not re-titled a second time just because it later ended.

`session_end` is skipped only as *titling input*. It stays in the transcript, the VFS, and every other reader.

## Why this doesn't cost real titles

Some `session_end` events do carry a genuine summary (there are 2,246 distinct contents). Checked against prod: of the 4,064 sessions whose only content is a `session_end` event, **4,064 are marker-shaped and 0 are not**. The summary-carrying ones always have other events alongside, where the marker was at most 1 of the 16 events read.

## Not in this PR

The ~4,000 existing `Empty Session`-style titles stay until something clears them. Nulling them out would make those sessions display by id again — that's a product call, worth deciding separately.

## Testing

- New `backend/tests/test_session_title_generation.py` — 3 tests: a marker-only session never reaches the model, a session with real content is still titled and the marker is absent from what the model reads, and the reconcile does not queue marker-only sessions.
- `pytest backend/tests/test_session_title_generation.py backend/tests/test_session_rename.py backend/tests/test_session_title_service.py backend/tests/test_agents.py` — 34 passed.
- `ruff check backend/ cli/ && ruff format --check backend/ cli/` — clean.
- `backend/tests/test_trash_session_names.py` has 2 failures, but they reproduce on unmodified `main` (500 from the event-push endpoint in this local environment) and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow SQL filter on title-generation input only; transcripts and other readers are unchanged, and existing titles are not rewritten.
> 
> **Overview**
> Stops auto-titling sessions whose only non-blank content is a wrap-up `session_end` marker (`Session ended.`, importer notes, etc.), which previously still passed the empty-content check and burned an LLM call (often producing titles like “Empty Session”).
> 
> `_session_stats`, `_session_events`, and `_reconcile_missing` now exclude `event_type = session_end`. Marker-only sessions return `"missing"` and stay untitled; real transcripts are still titled, without the boilerplate in the model source. Excluding the marker from stats also keeps it out of `source_hash`, so a live-titled session is not re-titled just because it later ended.
> 
> Adds tests covering marker-only skip, real content without the marker in the prompt, and reconcile not queueing marker-only sessions. Existing bad titles are not backfilled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a06076726923cb741bdfbf591dfeafe4d5d008ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->