### PR TITLE
Free accounts' Memory-curator runs use the managed tier (metered by the existing monthly allowance)

### DIFF
--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -264,12 +264,14 @@ async def recompute_memory(
                 "curator runs per month; the enterprise plan is unlimited.",
             )
     try:
-        await agent_auth.resolve(user_id, curator["model_provider"])
+        await agent_auth.resolve(user_id, curator["model_provider"], curator_run=True)
     except agent_auth.NeedsAuth:
+        # Only reachable when the curator is pinned to a provider the user
+        # hasn't connected — the managed tier covers everyone else.
         raise HTTPException(
             status_code=402,
-            detail="Connect your Claude, Codex, or OpenRouter key in settings, "
-            "or upgrade to Pro to run the Memory curator.",
+            detail="The curator is set to a model you haven't connected — "
+            "connect that key in settings.",
         )
     except agent_auth.ProviderNotConfigured:
         raise HTTPException(status_code=503, detail="The agent is not configured.")

--- a/backend/services/agent_auth.py
+++ b/backend/services/agent_auth.py
@@ -133,12 +133,19 @@ async def delete_credential(user_id: UUID, provider: str) -> None:
     )
 
 
-async def resolve(user_id: UUID, prefer_provider: str | None = None) -> RunAuth:
+async def resolve(
+    user_id: UUID, prefer_provider: str | None = None, curator_run: bool = False
+) -> RunAuth:
     """The harness + credential injection for this user's next turn.
 
     `prefer_provider` is an agent's model override: if the user has that
     provider's credential, run it; a managed OpenRouter preference on Pro uses
     the managed GLM. Falls back to the user's default resolution otherwise.
+
+    `curator_run` marks a Memory-curator run: the managed tier is open to free
+    accounts there, because curator runs are already capped by the monthly
+    allowance (FREE_CURATOR_RUNS_PER_MONTH) — unlike interactive chat, which
+    stays Pro-gated.
     """
     # Local dev: the machine's own harness login; inject nothing.
     if settings.AGENT_EXEC_MODE == "local":
@@ -148,9 +155,9 @@ async def resolve(user_id: UUID, prefer_provider: str | None = None) -> RunAuth:
         cred = await _get_credential(user_id, prefer_provider)
         if cred is not None:
             return _byo_auth(cred)
-        # Preferred managed OpenRouter with no BYO key → managed GLM (Pro gate).
+        # Preferred managed OpenRouter with no BYO key → managed GLM.
         if prefer_provider == "openrouter":
-            return await _managed(user_id)
+            return await _managed(user_id, curator_run)
         # The agent explicitly picked a model the user hasn't connected — fail
         # loud rather than silently running a different harness.
         raise NeedsAuth
@@ -158,12 +165,13 @@ async def resolve(user_id: UUID, prefer_provider: str | None = None) -> RunAuth:
     cred = await _get_credential(user_id)
     if cred is not None:
         return _byo_auth(cred)
-    return await _managed(user_id)
+    return await _managed(user_id, curator_run)
 
 
-async def _managed(user_id: UUID) -> RunAuth:
-    """The managed agent: opencode on OpenRouter GLM, Pro only."""
-    if not await billing_service.is_pro(user_id):
+async def _managed(user_id: UUID, curator_run: bool = False) -> RunAuth:
+    """The managed agent: opencode on OpenRouter GLM. Pro only, except curator
+    runs — those are metered by the free monthly allowance instead."""
+    if not curator_run and not await billing_service.is_pro(user_id):
         raise NeedsAuth
     key = settings.OPENROUTER_API_KEY
     if not key:

--- a/backend/services/sprite_agent_service.py
+++ b/backend/services/sprite_agent_service.py
@@ -407,6 +407,7 @@ async def run_scheduled(agent: dict, run_stamp: str) -> str:
         model_provider=agent["model_provider"],
         persona=agent["system_prompt"],
         agent_name=agent["name"],
+        curator_run=agent["is_curator"],
     )
 
 
@@ -578,10 +579,12 @@ async def run_chat(
     model_provider: str | None = None,
     persona: str | None = None,
     agent_name: str = AGENT_NAME,
+    curator_run: bool = False,
 ) -> str:
     """Non-streaming turn for Slack/Telegram/scheduled: returns the final answer.
     `channel` ('slack'|'telegram') selects the bound agent's model + persona;
-    a scheduled run passes model_provider/persona directly.
+    a scheduled run passes model_provider/persona directly. `curator_run` opens
+    the managed tier to free accounts (metered by the monthly allowance).
     Raises NeedsAuth for an unconnected free account so the channel can prompt."""
     if channel:
         agent = await agent_service.channel_agent(user_id, channel)
@@ -589,7 +592,7 @@ async def run_chat(
         persona = agent["system_prompt"]
         agent_name = agent["name"]
     try:
-        auth = await agent_auth.resolve(user_id, model_provider)
+        auth = await agent_auth.resolve(user_id, model_provider, curator_run=curator_run)
     except agent_auth.NeedsAuth:
         raise NeedsAuth
     except agent_auth.ProviderNotConfigured:

--- a/backend/tasks/agent_schedules.py
+++ b/backend/tasks/agent_schedules.py
@@ -99,9 +99,13 @@ async def _run_due() -> int:
                 )
                 await agent_service.mark_run_skipped(agent["id"], "credits")
                 continue
-        # No runnable credential (unconnected free user) → nothing can run.
+        # No runnable credential → nothing can run. Curator runs pass this on
+        # the managed tier even for free accounts (the credits gate above is
+        # their meter); other scheduled agents still need BYO or Pro.
         try:
-            await agent_auth.resolve(user_id, agent["model_provider"])
+            await agent_auth.resolve(
+                user_id, agent["model_provider"], curator_run=agent["is_curator"]
+            )
         except (agent_auth.NeedsAuth, agent_auth.ProviderNotConfigured):
             logger.info("agent schedule: no credential for agent %s — skipping", agent["id"])
             await agent_service.mark_run_skipped(agent["id"], "no_credential")

--- a/backend/tests/test_agent_auth.py
+++ b/backend/tests/test_agent_auth.py
@@ -93,6 +93,27 @@ async def test_no_credential_pro_gets_managed_openrouter_glm(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_no_credential_free_curator_run_gets_managed(monkeypatch):
+    """A free account with nothing connected still gets its Memory curator: the
+    managed tier is open to curator runs because the monthly allowance already
+    caps their cost. Interactive chat stays Pro-gated (next test)."""
+    monkeypatch.setattr(settings, "AGENT_EXEC_MODE", "sprites")
+    monkeypatch.setattr(settings, "OPENROUTER_API_KEY", "sk-managed-or")
+
+    async def no_cred(_uid):
+        return None
+
+    async def not_pro(_uid):
+        return False
+
+    monkeypatch.setattr(agent_auth, "_get_credential", no_cred)
+    monkeypatch.setattr(billing_service, "is_pro", not_pro)
+    auth = await agent_auth.resolve(uuid.uuid4(), curator_run=True)
+    assert auth.harness is h.OPENCODE
+    assert auth.env == {"OPENROUTER_API_KEY": "sk-managed-or"}
+
+
+@pytest.mark.asyncio
 async def test_no_credential_free_is_gated(monkeypatch):
     monkeypatch.setattr(settings, "AGENT_EXEC_MODE", "sprites")
 

--- a/backend/tests/test_agent_schedule_alerts.py
+++ b/backend/tests/test_agent_schedule_alerts.py
@@ -143,7 +143,7 @@ async def test_run_due_failure_sends_alert(client: AsyncClient, monkeypatch):
         user_id, "test", "user_message", "hello", user_id, f"sess-{uuid.uuid4()}"
     )
 
-    async def fake_resolve(user_id, prefer_provider=None):
+    async def fake_resolve(user_id, prefer_provider=None, curator_run=False):
         return None
 
     async def fake_run_scheduled(agent, stamp):
@@ -212,7 +212,7 @@ async def test_run_due_records_no_changes_skip(client: AsyncClient, monkeypatch)
         datetime.now(UTC) - timedelta(minutes=5),
     )
 
-    async def fake_resolve(user_id, prefer_provider=None):
+    async def fake_resolve(user_id, prefer_provider=None, curator_run=False):
         return None
 
     async def no_changes(owner_user_id, user_id, since):
@@ -240,7 +240,7 @@ async def test_run_due_records_missing_credential_skip(client: AsyncClient, monk
         datetime.now(UTC) - timedelta(minutes=5),
     )
 
-    async def no_credential(user_id, prefer_provider=None):
+    async def no_credential(user_id, prefer_provider=None, curator_run=False):
         raise agent_auth.NeedsAuth
 
     monkeypatch.setattr(agent_auth, "resolve", no_credential)


### PR DESCRIPTION
## Problem

Free accounts have a monthly sleep-time curator allowance (`FREE_CURATOR_RUNS_PER_MONTH = 10`, metered since #0136), but a free user who hasn't connected a Claude/Codex/OpenRouter credential can't spend it: `agent_auth._managed()` — the path that runs opencode on our OpenRouter key — was gated on Pro. Their nightly curator run ends as `skipped_no_credential` every night and the Memory wiki stays empty forever, while the empty state promises "the first appears after tonight's pass."

Live example: prod currently has 12 curators in `skipped_no_credential`, including a user who signed up on Aug 20 and messaged us "still no wiki."

## Change

`resolve()` / `_managed()` take a `curator_run` flag that bypasses the Pro gate **for curator runs only** — the existing 10-runs/month allowance (already enforced by the beat dispatcher and the manual recompute endpoint, enterprise unlimited) is the cost cap. The flag threads through the three call paths:

- the beat dispatcher's pre-flight check (`agent_schedules._run_due`)
- the manual recompute endpoint (`files_tree`) — its 402 message now covers the one case left, a curator pinned to an unconnected provider
- `run_scheduled` → `run_chat`, where the real credential resolution happens

Interactive agent chat is unchanged and stays Pro-gated (it isn't metered by `month_run_count`, so opening it up would be an unmetered giveaway).

Verified the managed path works in prod for credential-less accounts: two enterprise users with no BYO credential had curator runs launch successfully this morning on the server's OpenRouter key.

## Cost note

~150 free curators are currently being skipped nightly (138 for credits, 12 for no credential). After this deploys, each free account gets up to 10 managed GLM runs/month on our key. With a nightly cron the allowance runs out ~day 10 of the month — existing metering behavior, unchanged here.

## Tests

New test: a free, credential-less account resolves to the managed harness when `curator_run=True`, next to the existing test that the default (chat) path stays gated. Auth/curator/schedule/chat/telegram/slack suites pass (101 tests); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing/auth gating and injects the shared OpenRouter key for free-tier curator runs. Interactive chat remains Pro-gated and curator cost is still monthly-capped, but a flag leak would unmeter managed inference.
> 
> **Overview**
> Lets free accounts actually spend their monthly Memory-curator allowance on the managed OpenRouter/GLM path, instead of skipping every night as `skipped_no_credential` when they have no BYO key.
> 
> `agent_auth.resolve` / `_managed` take a `curator_run` flag that **bypasses the Pro gate for curator runs only**. Interactive chat stays Pro-gated. The flag is threaded through the scheduler pre-flight, `run_scheduled` → `run_chat`, and the manual recompute endpoint (whose 402 now only covers a curator pinned to an unconnected provider). Cost is still capped by `FREE_CURATOR_RUNS_PER_MONTH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6439a1b224c90b0a310e3c5ed651c0caa4db86e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->