### PR TITLE
Console QoL: editable key line, styled dropdowns, working avatar

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -61,6 +61,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.6",
         "@types/d3-drag": "^3.0.7",
         "@types/d3-force": "^3.0.10",
         "@types/d3-selection": "^3.0.11",
@@ -3930,6 +3931,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.6.tgz",
+      "integrity": "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tiptap/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,6 +64,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.6",
     "@types/d3-drag": "^3.0.7",
     "@types/d3-force": "^3.0.10",
     "@types/d3-selection": "^3.0.11",

--- a/frontend/src/app/(app)/developer/prompts/page.tsx
+++ b/frontend/src/app/(app)/developer/prompts/page.tsx
@@ -7,14 +7,19 @@ import { cn } from "@/lib/utils";
 
 import DeveloperGate from "@/components/developer/DeveloperGate";
 import { CodeBlock, PageHeading, SectionHeading } from "@/components/developer/DocsPrimitives";
-import { BACKFILL_PROMPT, INSTALL_PROMPT } from "@/components/developer/agentPrompts";
+import { BACKFILL_PROMPT, INSTALL_PROMPT, KEY_PLACEHOLDER } from "@/components/developer/agentPrompts";
 
 export default function DeveloperPrompts() {
+  const [apiKey, setApiKey] = useState("");
+  const installPrompt = apiKey.trim()
+    ? INSTALL_PROMPT.replace(KEY_PLACEHOLDER, apiKey.trim())
+    : INSTALL_PROMPT;
+
   return (
     <DeveloperGate>
       <PageHeading title="Prompts">
-        You don&apos;t integrate Stash by hand — your coding agent does. Copy a prompt, drop
-        your API key into the first line, and paste it into your agent, pointed at your
+        You don&apos;t integrate Stash by hand — your coding agent does. Paste your API key
+        into the first line, copy the prompt, and paste it into your agent, pointed at your
         codebase.
       </PageHeading>
 
@@ -22,9 +27,10 @@ export default function DeveloperPrompts() {
         title="Install"
         blurb="The whole onboarding in one prompt: the memory read before each turn, the
           transcript upload after it, a backfill of whatever history your database already
-          holds, and a final check that a user shows up in this console. Fill in the first
-          line with a key from the API Keys page."
-        prompt={INSTALL_PROMPT}
+          holds, and a final check that a user shows up in this console. Paste a key from
+          the API Keys page into the first line."
+        prompt={installPrompt}
+        keyField={{ value: apiKey, onChange: setApiKey }}
       />
 
       <Advanced>
@@ -63,10 +69,15 @@ function PromptSection({
   title,
   blurb,
   prompt,
+  keyField,
 }: {
   title: string;
   blurb: string;
   prompt: string;
+  // When set, the prompt's first line renders as "MY API KEY IS" plus this
+  // editable field, so a key on the clipboard can go straight in. The key
+  // lives only in component state — never persisted.
+  keyField?: { value: string; onChange: (value: string) => void };
 }) {
   const [copied, setCopied] = useState(false);
 
@@ -90,7 +101,27 @@ function PromptSection({
       </div>
       <p className="mt-2 max-w-2xl text-[13.5px] leading-6 text-muted-foreground">{blurb}</p>
       <div className="mt-4">
-        <CodeBlock>{prompt}</CodeBlock>
+        {keyField ? (
+          <div className="overflow-x-auto rounded border border-border bg-surface p-5 font-mono text-[12.5px] leading-6 text-dim">
+            <div className="flex items-center gap-2 whitespace-pre">
+              <span>MY API KEY IS</span>
+              <input
+                value={keyField.value}
+                onChange={(e) => keyField.onChange(e.target.value)}
+                placeholder={KEY_PLACEHOLDER}
+                aria-label="API key"
+                spellCheck={false}
+                autoComplete="off"
+                className="min-w-64 flex-1 rounded-sm border border-dashed border-border bg-base px-2 py-0.5 font-mono text-[12.5px] text-foreground placeholder:text-muted-foreground focus:border-solid focus:border-brand-500 focus:outline-none"
+              />
+            </div>
+            <pre className="m-0 whitespace-pre-wrap">
+              <code>{prompt.split("\n").slice(1).join("\n")}</code>
+            </pre>
+          </div>
+        ) : (
+          <CodeBlock>{prompt}</CodeBlock>
+        )}
       </div>
     </section>
   );

--- a/frontend/src/components/agents/AgentConfigPanel.tsx
+++ b/frontend/src/components/agents/AgentConfigPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
+import { Select } from "@/components/ui/select";
 import { type Citation, streamAgentRun } from "@/lib/agentChat";
 import { takeCuratorRun } from "@/lib/agent-tab-view";
 import {
@@ -279,17 +280,12 @@ export default function AgentConfigPanel({
       </Field>
 
       <Field label="Model" hint="Which harness runs this agent's turns.">
-        <select
+        <Select
           value={agent.model_provider ?? ""}
-          onChange={(e) => set("model_provider", (e.target.value || null) as Agent["model_provider"])}
-          className="w-full rounded-md border border-border bg-base px-3 py-2 text-[13px] text-foreground"
-        >
-          {MODELS.map((m) => (
-            <option key={m.value} value={m.value}>
-              {m.label}
-            </option>
-          ))}
-        </select>
+          onChange={(v) => set("model_provider", (v || null) as Agent["model_provider"])}
+          options={MODELS}
+          className="w-full px-3 py-2 text-[13px]"
+        />
       </Field>
 
       <Field label="Persona" hint="Extra instructions appended to the agent's system prompt.">

--- a/frontend/src/components/apps/AppDetail.tsx
+++ b/frontend/src/components/apps/AppDetail.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { ExternalLink, FileText, Plus, X } from "lucide-react";
 
+import { Select } from "@/components/ui/select";
 import { setRowTopics, updateTableRow } from "@/lib/api";
 import type { MiniProgramManifest, Table, TableColumn, TableRow } from "@/lib/types";
 
@@ -39,31 +40,29 @@ function FieldInput({
 }) {
   if (column.type === "select") {
     return (
-      <select
+      <Select
         value={value}
-        onChange={(event) => onChange(event.target.value)}
-        className="w-full rounded-md border border-border bg-base px-2.5 py-2 text-[12.5px] text-foreground"
-      >
-        <option value="">—</option>
-        {(column.options ?? []).map((option) => (
-          <option key={option} value={option}>
-            {option}
-          </option>
-        ))}
-      </select>
+        onChange={onChange}
+        options={[
+          { value: "", label: "—" },
+          ...(column.options ?? []).map((option) => ({ value: option, label: option })),
+        ]}
+        className="w-full px-2.5 py-2 text-[12.5px]"
+      />
     );
   }
 
   if (column.type === "boolean") {
     return (
-      <select
+      <Select
         value={value}
-        onChange={(event) => onChange(event.target.value)}
-        className="w-full rounded-md border border-border bg-base px-2.5 py-2 text-[12.5px] text-foreground"
-      >
-        <option value="false">No</option>
-        <option value="true">Yes</option>
-      </select>
+        onChange={onChange}
+        options={[
+          { value: "false", label: "No" },
+          { value: "true", label: "Yes" },
+        ]}
+        className="w-full px-2.5 py-2 text-[12.5px]"
+      />
     );
   }
 

--- a/frontend/src/components/apps/AppView.tsx
+++ b/frontend/src/components/apps/AppView.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { ArrowDown, ArrowUp, ArrowUpDown, LayoutGrid, Table2 } from "lucide-react";
 
+import { Select } from "@/components/ui/select";
 import { appFacets, getApp, getTable, installApp, listAppRows } from "@/lib/api";
 import type { AppFacets, MiniProgramManifest, Table, TableColumn, TableRow } from "@/lib/types";
 
@@ -305,33 +306,33 @@ export default function AppView({ slug }: { slug: string }) {
           </div>
 
           <div className="mt-3 flex flex-wrap items-center gap-2">
-            <select
+            <Select
               aria-label="Filter bookmarks"
               value={derived ?? ""}
-              onChange={(event) => setDerived(event.target.value || null)}
-              className="rounded-md border border-border bg-base px-2.5 py-1.5 text-[12px] text-foreground"
-            >
-              <option value="">All bookmarks</option>
-              {DERIVED.filter((item) => (facets?.[item.key] ?? 0) > 0).map((item) => (
-                <option key={item.key} value={item.key}>
-                  {item.label} ({facets?.[item.key]})
-                </option>
-              ))}
-            </select>
+              onChange={(v) => setDerived(v || null)}
+              options={[
+                { value: "", label: "All bookmarks" },
+                ...DERIVED.filter((item) => (facets?.[item.key] ?? 0) > 0).map((item) => ({
+                  value: item.key,
+                  label: `${item.label} (${facets?.[item.key]})`,
+                })),
+              ]}
+              className="px-2.5 py-1.5 text-[12px]"
+            />
 
-            <select
+            <Select
               aria-label="Filter by topic"
               value={topic ?? ""}
-              onChange={(event) => setTopic(event.target.value || null)}
-              className="rounded-md border border-border bg-base px-2.5 py-1.5 text-[12px] text-foreground"
-            >
-              <option value="">All topics</option>
-              {(facets?.topics ?? []).map((item) => (
-                <option key={item.label} value={item.label}>
-                  {item.label} ({item.count})
-                </option>
-              ))}
-            </select>
+              onChange={(v) => setTopic(v || null)}
+              options={[
+                { value: "", label: "All topics" },
+                ...(facets?.topics ?? []).map((item) => ({
+                  value: item.label,
+                  label: `${item.label} (${item.count})`,
+                })),
+              ]}
+              className="px-2.5 py-1.5 text-[12px]"
+            />
 
             {filtering && (
               <button
@@ -347,23 +348,22 @@ export default function AppView({ slug }: { slug: string }) {
             )}
 
             <div className="ml-auto flex items-center gap-2">
-              <select
+              <Select
                 aria-label="Sort bookmarks"
                 value={sortBy ?? ""}
-                onChange={(event) => {
-                  const columnId = event.target.value;
+                onChange={(columnId) => {
                   setSortBy(columnId || null);
                   setSortOrder("asc");
                 }}
-                className="rounded-md border border-border bg-base px-2.5 py-1.5 text-[12px] text-foreground"
-              >
-                <option value="">Default order</option>
-                {columns.map((column) => (
-                  <option key={column.id} value={column.id}>
-                    Sort by {column.name}
-                  </option>
-                ))}
-              </select>
+                options={[
+                  { value: "", label: "Default order" },
+                  ...columns.map((column) => ({
+                    value: column.id,
+                    label: `Sort by ${column.name}`,
+                  })),
+                ]}
+                className="px-2.5 py-1.5 text-[12px]"
+              />
 
               {sortBy && (
                 <button

--- a/frontend/src/components/developer/DeveloperShell.tsx
+++ b/frontend/src/components/developer/DeveloperShell.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 
 import ScopeSwitcher from "@/components/workspace/scope-switcher";
 import { StashIcon } from "@/components/SkillIcons";
+import AccountMenu from "@/components/workspace/account-menu";
 import { cn } from "@/lib/utils";
 import type { User } from "@/lib/types";
 
@@ -109,15 +110,7 @@ export default function DeveloperShell({
             >
               Docs
             </a>
-            <button onClick={onLogout} className="hover:text-foreground">
-              Sign out
-            </button>
-            <span
-              title={user.email ?? user.name}
-              className="flex h-7 w-7 items-center justify-center rounded-full bg-brand-500 font-mono text-[11px] font-medium text-white"
-            >
-              {user.display_name[0].toUpperCase()}
-            </span>
+            <AccountMenu user={user} onLogout={onLogout} placement="header" />
           </nav>
         </div>
       </header>

--- a/frontend/src/components/developer/MintKeyDialog.tsx
+++ b/frontend/src/components/developer/MintKeyDialog.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { Select } from "@/components/ui/select";
 import { mintDeveloperKey } from "@/lib/api";
 
 /**
@@ -21,14 +22,14 @@ import { mintDeveloperKey } from "@/lib/api";
  * The dialog portals to <body>, outside the console's data-surface wrapper,
  * so it re-declares data-surface="developer" to keep the console's tokens.
  */
-// What the Expires select offers; 0 encodes "never" since a <select> wants
-// string values anyway.
+// What the Expires select offers; "0" encodes "never" since select values are
+// strings.
 const EXPIRY_OPTIONS = [
-  { days: 0, label: "Never" },
-  { days: 7, label: "7 days" },
-  { days: 30, label: "30 days" },
-  { days: 90, label: "90 days" },
-  { days: 365, label: "1 year" },
+  { value: "0", label: "Never" },
+  { value: "7", label: "7 days" },
+  { value: "30", label: "30 days" },
+  { value: "90", label: "90 days" },
+  { value: "365", label: "1 year" },
 ];
 
 export default function MintKeyDialog({ onMinted }: { onMinted: () => void }) {
@@ -151,18 +152,13 @@ export default function MintKeyDialog({ onMinted }: { onMinted: () => void }) {
               <label htmlFor="mint-key-expiry" className="text-[15px] font-medium text-foreground">
                 Expires
               </label>
-              <select
+              <Select
                 id="mint-key-expiry"
-                value={expiryDays}
-                onChange={(e) => setExpiryDays(Number(e.target.value))}
-                className="mt-2 w-full appearance-none rounded-lg border border-border bg-base px-4 py-3 text-[15px] text-foreground focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 focus:outline-none"
-              >
-                {EXPIRY_OPTIONS.map((option) => (
-                  <option key={option.days} value={option.days}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
+                value={String(expiryDays)}
+                onChange={(v) => setExpiryDays(Number(v))}
+                options={EXPIRY_OPTIONS}
+                className="mt-2 w-full rounded-lg px-4 py-3 text-[15px]"
+              />
             </div>
             {error && <p className="text-[13px] text-error">{error}</p>}
             <div className="flex justify-end">

--- a/frontend/src/components/developer/agentPrompts.ts
+++ b/frontend/src/components/developer/agentPrompts.ts
@@ -9,7 +9,9 @@
 // real key (minted on the API Keys page) before pasting. Backfill alone is
 // the advanced path, for a stash that is already wired and missing history.
 
-export const INSTALL_PROMPT = `MY API KEY IS [INSERT API KEY HERE]
+export const KEY_PLACEHOLDER = "[INSERT API KEY HERE]";
+
+export const INSTALL_PROMPT = `MY API KEY IS ${KEY_PLACEHOLDER}
 
 Wire Stash (https://api.joinstash.ai) into this app so our agent has
 per-user memory: every user's agent reads a shared knowledge wiki plus

--- a/frontend/src/components/share/ResourceShareButton.test.tsx
+++ b/frontend/src/components/share/ResourceShareButton.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import ResourceShareButton from "./ResourceShareButton";
@@ -115,9 +116,8 @@ describe("ResourceShareButton", () => {
     fireEvent.change(screen.getByLabelText("Add people"), {
       target: { value: "ada@example.com" },
     });
-    fireEvent.change(screen.getByLabelText("Invite permission"), {
-      target: { value: "write" },
-    });
+    await userEvent.click(screen.getByLabelText("Invite permission"));
+    await userEvent.click(await screen.findByRole("option", { name: "Can edit" }));
     fireEvent.click(screen.getByRole("button", { name: "Invite" }));
 
     await waitFor(() =>
@@ -146,9 +146,8 @@ describe("ResourceShareButton", () => {
     fireEvent.click(screen.getByRole("button", { name: "Share" }));
     await screen.findByText("Ada Lovelace");
 
-    fireEvent.change(screen.getByLabelText("Change permission"), {
-      target: { value: "comment" },
-    });
+    await userEvent.click(screen.getByLabelText("Change permission"));
+    await userEvent.click(await screen.findByRole("option", { name: "Can comment" }));
 
     await waitFor(() =>
       expect(shareObjectByEmail).toHaveBeenCalledWith(

--- a/frontend/src/components/share/ResourceShareButton.tsx
+++ b/frontend/src/components/share/ResourceShareButton.tsx
@@ -9,6 +9,8 @@ import {
   useState,
 } from "react";
 
+import { Select } from "@/components/ui/select";
+
 import { useEscapeKey } from "../../hooks/useEscapeKey";
 import {
   getGeneralAccess,
@@ -285,21 +287,15 @@ export function ResourceShareDialog({
             placeholder="Add people by email"
             className="min-w-0 flex-1 rounded-md border border-border bg-base px-3 py-2 text-[13px] text-foreground placeholder:text-muted-foreground focus:border-brand focus:outline-none"
           />
-          <select
+          <Select
             value={permission}
-            onChange={(event) =>
-              setPermission(event.target.value as SharePermission)
-            }
+            onChange={(v) => setPermission(v as SharePermission)}
             disabled={busy}
             aria-label="Invite permission"
-            className="rounded-md border border-border bg-base px-2 py-2 text-[12px] text-foreground"
-          >
-            {PERMISSIONS.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+            portal={false}
+            options={PERMISSIONS}
+            className="px-2 py-2 text-[12px]"
+          />
           <button
             type="submit"
             disabled={busy || !email.trim()}
@@ -389,24 +385,21 @@ export function ResourceShareDialog({
           <span className="min-w-0 flex-1">
             {supportsGeneralAccess ? (
               <>
-                <select
-                  aria-label="General access"
+                <Select
+                  aria-label="General access" portal={false}
                   value={generalAccess === "none" ? "none" : "link"}
                   disabled={savingAccess}
-                  onChange={(e) =>
+                  onChange={(v) =>
                     void changeGeneralAccess(
-                      e.target.value === "none"
-                        ? "none"
-                        : generalAccess === "none"
-                          ? "read"
-                          : generalAccess,
+                      v === "none" ? "none" : generalAccess === "none" ? "read" : generalAccess,
                     )
                   }
-                  className="-ml-1 block cursor-pointer rounded border-none bg-transparent px-1 py-0.5 text-[13px] font-medium text-foreground hover:bg-raised focus:outline-none disabled:opacity-60"
-                >
-                  <option value="none">Restricted</option>
-                  <option value="link">Anyone with the link</option>
-                </select>
+                  options={[
+                    { value: "none", label: "Restricted" },
+                    { value: "link", label: "Anyone with the link" },
+                  ]}
+                  className="-ml-1 border-none bg-transparent px-1 py-0.5 text-[13px] font-medium hover:bg-raised"
+                />
                 <span className="block truncate px-1 text-[12px] text-muted-foreground">
                   {generalAccess === "none"
                     ? "Only people with access can open this link"
@@ -425,21 +418,14 @@ export function ResourceShareDialog({
             )}
           </span>
           {supportsGeneralAccess && generalAccess !== "none" && (
-            <select
-              aria-label="Link role"
+            <Select
+              aria-label="Link role" portal={false}
               value={generalAccess}
               disabled={savingAccess}
-              onChange={(e) =>
-                void changeGeneralAccess(e.target.value as GeneralPermission)
-              }
-              className="shrink-0 cursor-pointer rounded border border-border bg-base px-2 py-1 text-[12px] font-medium text-foreground hover:bg-raised focus:outline-none disabled:opacity-60"
-            >
-              {LINK_ROLES.map((role) => (
-                <option key={role.value} value={role.value}>
-                  {role.label}
-                </option>
-              ))}
-            </select>
+              onChange={(v) => void changeGeneralAccess(v as GeneralPermission)}
+              options={LINK_ROLES}
+              className="shrink-0 px-2 py-1 text-[12px] font-medium"
+            />
           )}
         </div>
       </section>
@@ -497,21 +483,14 @@ function AccessRow({
         <span className="block truncate text-[12px] text-muted-foreground">{sublabel}</span>
       </span>
       {onChangePermission && permission ? (
-        <select
+        <Select
           value={permission}
-          onChange={(event) =>
-            onChangePermission(event.target.value as SharePermission)
-          }
+          onChange={(v) => onChangePermission(v as SharePermission)}
           disabled={busy}
-          aria-label="Change permission"
-          className="shrink-0 rounded-md border border-border bg-base px-1.5 py-1 text-[12px] text-foreground disabled:opacity-45"
-        >
-          {PERMISSIONS.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
+          aria-label="Change permission" portal={false}
+          options={PERMISSIONS}
+          className="shrink-0 px-1.5 py-1 text-[12px]"
+        />
       ) : (
         <span className="shrink-0 text-[12px] text-muted-foreground">{permissionLabel}</span>
       )}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import * as React from "react";
+import { Select as SelectPrimitive } from "radix-ui";
+import { CheckIcon, ChevronDownIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+// Radix rejects items whose value is the empty string, but several callers use
+// "" to mean "no filter" / "unset". Map it through a sentinel at this boundary
+// so call sites keep their natural values.
+const EMPTY = "__empty__";
+
+export function Select({
+  value,
+  onChange,
+  options,
+  disabled,
+  id,
+  "aria-label": ariaLabel,
+  className,
+  portal = true,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  options: SelectOption[];
+  disabled?: boolean;
+  id?: string;
+  "aria-label"?: string;
+  className?: string;
+  // Render the options in place instead of portaling to <body>. Required
+  // inside containers that close on document-level outside clicks (e.g. the
+  // share popover), where a portaled option click reads as "outside".
+  portal?: boolean;
+}) {
+  return (
+    <SelectPrimitive.Root
+      value={value === "" ? EMPTY : value}
+      onValueChange={(v) => onChange(v === EMPTY ? "" : v)}
+      disabled={disabled}
+    >
+      <SelectPrimitive.Trigger
+        id={id}
+        aria-label={ariaLabel}
+        className={cn(
+          "flex cursor-pointer items-center justify-between gap-2 rounded-md border border-border bg-base text-left text-foreground focus:outline-none focus-visible:border-brand-500 focus-visible:ring-2 focus-visible:ring-brand-500/20 disabled:cursor-not-allowed disabled:opacity-60",
+          className,
+        )}
+      >
+        <span className="truncate">
+          <SelectPrimitive.Value />
+        </span>
+        <SelectPrimitive.Icon>
+          <ChevronDownIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        </SelectPrimitive.Icon>
+      </SelectPrimitive.Trigger>
+      <MaybePortal portal={portal}>
+        <SelectPrimitive.Content
+          position="popper"
+          sideOffset={4}
+          className="z-50 max-h-(--radix-select-content-available-height) min-w-(--radix-select-trigger-width) overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+        >
+          <SelectPrimitive.Viewport>
+            {options.map((option) => (
+              <SelectPrimitive.Item
+                key={option.value}
+                value={option.value === "" ? EMPTY : option.value}
+                className="relative flex cursor-default items-center gap-1.5 rounded-md py-1.5 pr-2 pl-7 text-[13px] outline-none select-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+              >
+                <span className="absolute left-1.5 flex w-4 justify-center">
+                  <SelectPrimitive.ItemIndicator>
+                    <CheckIcon className="h-3.5 w-3.5" />
+                  </SelectPrimitive.ItemIndicator>
+                </span>
+                <SelectPrimitive.ItemText>{option.label}</SelectPrimitive.ItemText>
+              </SelectPrimitive.Item>
+            ))}
+          </SelectPrimitive.Viewport>
+        </SelectPrimitive.Content>
+      </MaybePortal>
+    </SelectPrimitive.Root>
+  );
+}
+
+function MaybePortal({ portal, children }: { portal: boolean; children: React.ReactNode }) {
+  if (!portal) return <>{children}</>;
+  return <SelectPrimitive.Portal>{children}</SelectPrimitive.Portal>;
+}

--- a/frontend/src/components/workspace/account-menu.tsx
+++ b/frontend/src/components/workspace/account-menu.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+
+import { useEscapeKey } from "@/hooks/useEscapeKey";
+import { cn } from "@/lib/utils";
+import type { User } from "@/lib/types";
+
+/** The account control — avatar opens a small menu (settings + sign out).
+ *  The single home for account actions, shared by the workspace rail
+ *  (bottom-left, menu opens up-right) and the developer console header
+ *  (top-right, menu opens down-left). */
+export default function AccountMenu({
+  user,
+  onLogout,
+  placement = "rail",
+}: {
+  user: User;
+  onLogout: () => void;
+  placement?: "rail" | "header";
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useEscapeKey(open, () => setOpen(false));
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        title={user.email ?? user.name}
+        className="flex h-8 w-8 items-center justify-center rounded-full bg-brand-500 text-[12px] font-semibold text-white hover:ring-2 hover:ring-brand-200"
+      >
+        {user.display_name[0].toUpperCase()}
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className={cn(
+            "absolute z-40 w-56 overflow-hidden rounded-md border border-border bg-surface py-1 text-[13px] shadow-lg",
+            placement === "rail" ? "bottom-0 left-full ml-2" : "top-full right-0 mt-2",
+          )}
+        >
+          <div className="border-b border-border px-3 py-1.5 text-[11px] text-muted-foreground">
+            Signed in as <span className="break-all text-foreground">{user.email ?? user.name}</span>
+          </div>
+          <Link href="/settings" onClick={() => setOpen(false)} className="block px-3 py-1.5 text-foreground hover:bg-raised">
+            Account settings
+          </Link>
+          <button onClick={() => { setOpen(false); onLogout(); }} className="block w-full px-3 py-1.5 text-left text-foreground hover:bg-raised">
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/workspace/rail.tsx
+++ b/frontend/src/components/workspace/rail.tsx
@@ -4,6 +4,7 @@ import { Fragment, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Bot, FolderTree, MessagesSquare, GraduationCap, Home, Wrench, Settings } from "lucide-react";
+import AccountMenu from "@/components/workspace/account-menu";
 import { cn } from "@/lib/utils";
 import { useEscapeKey } from "@/hooks/useEscapeKey";
 import { useWorkspace, type RailSection } from "@/lib/workspace-store";
@@ -53,46 +54,6 @@ function RailButton({
       <Icon className="h-[18px] w-[18px]" />
       <span className="text-[10px] font-medium leading-none">{item.label}</span>
     </button>
-  );
-}
-
-/** Bottom-left account control — avatar opens a small menu (settings + sign out).
- *  This is the single home for account actions (removed from the top bar). */
-function AccountMenu({ user, onLogout }: { user: User; onLogout: () => void }) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-  useEscapeKey(open, () => setOpen(false));
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener("mousedown", onDown);
-    return () => document.removeEventListener("mousedown", onDown);
-  }, [open]);
-  return (
-    <div ref={ref} className="relative">
-      <button
-        onClick={() => setOpen((o) => !o)}
-        title={user.email ?? user.name}
-        className="flex h-8 w-8 items-center justify-center rounded-full bg-brand-500 text-[12px] font-semibold text-white hover:ring-2 hover:ring-brand-200"
-      >
-        {user.display_name[0].toUpperCase()}
-      </button>
-      {open && (
-        <div role="menu" className="absolute bottom-0 left-full z-40 ml-2 w-56 overflow-hidden rounded-md border border-border bg-surface py-1 text-[13px] shadow-lg">
-          <div className="border-b border-border px-3 py-1.5 text-[11px] text-muted-foreground">
-            Signed in as <span className="break-all text-foreground">{user.email ?? user.name}</span>
-          </div>
-          <Link href="/settings" onClick={() => setOpen(false)} className="block px-3 py-1.5 text-foreground hover:bg-raised">
-            Account settings
-          </Link>
-          <button onClick={() => { setOpen(false); onLogout(); }} className="block w-full px-3 py-1.5 text-left text-foreground hover:bg-raised">
-            Sign out
-          </button>
-        </div>
-      )}
-    </div>
   );
 }
 

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -34,3 +34,14 @@ if (!globalThis.localStorage) {
     configurable: true,
   });
 }
+
+// Radix popover-based widgets (Select, DropdownMenu) call pointer-capture and
+// scroll APIs jsdom doesn't implement.
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}


### PR DESCRIPTION
Three small console/UI polish items from tonight's pre-hackathon pass:

- **Install prompt key line is an editable field.** The Prompts page renders the prompt's first line as `MY API KEY IS [input]` — paste a key and the copied prompt carries it. Empty keeps the placeholder. The key lives only in component state, never persisted.
- **Every native `<select>` is gone.** New `ui/select.tsx` (Radix, styled to match the existing dropdown-menu), swapped into all 12 sites: mint-key expiry, agent model, app filters/sort, table cells, and the share popover. The share popover closes on document-level outside clicks, so its selects render non-portaled (`portal={false}`) — a portaled option click would read as "outside" and close it (caught by the existing share tests).
- **The console avatar does something now.** The rail's `AccountMenu` moved to a shared file with a placement prop; the console header's inert avatar span is now the same control (Signed in as / Account settings / Sign out), and the header's standalone Sign out button folded into it.

Tests: 302 frontend tests pass (share tests rewritten to drive the Radix select via user-event, with the jsdom pointer-capture shims that requires). Build passes. Verified in the browser: key field copy round-trip, expiry dropdown, account menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only: styled dropdowns, a non-persisted key input, and a shared account menu. Share/access behavior is unchanged aside from how selects are driven in tests.
> 
> **Overview**
> Frontend polish: a shared Radix `Select`, an in-prompt API-key field, and a working developer-console avatar.
> 
> **Install prompts** now treat the first line as an editable field. Pasting a key into `MY API KEY IS` substitutes it into the copied install prompt; empty keeps the placeholder. The value stays in component state only.
> 
> **Native `<select>`s are replaced** with a new `ui/select` (Radix, empty-value sentinel, optional non-portal content). Call sites include mint-key expiry, agent model, app filters/sort/cells, and the share popover (`portal={false}` so option clicks don’t close it). Share tests drive the menu via `user-event`; jsdom gets pointer-capture/scroll shims.
> 
> **Account menu** is extracted from the rail with a `placement` prop. The developer header’s inert avatar and standalone Sign out become the same control (settings + sign out).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43fd380aa1ce76f8f2f022f9d0156a5f632632d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->