### PR TITLE
Legacy transcript events alias serves a default limit

### DIFF
--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -350,10 +350,14 @@ async def get_transcript_metadata_legacy(
 @router.get("/{session_id}/events")
 async def get_transcript_events_legacy(
     session_id: str,
-    limit: int = Query(..., ge=1),
+    limit: int = Query(10_000, ge=1),
     offset: int = 0,
     current_user: dict = Depends(get_current_user),
 ):
+    # The clients pinned to this shape (stashai ≤0.1.366) send no limit and
+    # render the response as the whole session, so a required limit turned
+    # their every transcript read into a 422. The default is served here and
+    # only here — the canonical route above stays strict.
     return await get_transcript_events(session_id, limit, offset, current_user)
 
 

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -958,6 +958,15 @@ async def test_legacy_path_shapes_still_serve(client: AsyncClient):
     )
     assert events.status_code == 200
     assert events.json()["events"][0]["content"] == "legacy shape check"
+    # stashai ≤0.1.366 sends no limit at all; the legacy alias serves a
+    # default instead of a 422. The canonical route stays strict.
+    bare = await client.get("/api/v1/me/transcripts/legacy-shape-1/events", headers=headers)
+    assert bare.status_code == 200
+    assert bare.json()["events"][0]["content"] == "legacy shape check"
+    strict = await client.get(
+        "/api/v1/me/transcripts/events", params={"session_id": "legacy-shape-1"}, headers=headers
+    )
+    assert strict.status_code == 422
     export = await client.get("/api/v1/me/transcripts/legacy-shape-1/export.jsonl", headers=headers)
     assert export.status_code == 200
     detail = await client.get("/api/v1/me/sessions/legacy-shape-1", headers=headers)


### PR DESCRIPTION
Since #1062 deployed (Aug 19), every `stashai` ≤0.1.366 gets a 422 on all transcript reads: those clients call the legacy `GET /me/transcripts/{session_id}/events` shape with no `limit`, and the legacy alias kept the URL shape but not the no-limit contract. Seen live today: a hackathon user's whole-stash VFS sweep failed with ~2 × 839 requests, every one a 422.

The legacy alias now serves `limit=10000` by default — that lane exists precisely to keep installed clients working until the cutover, and those clients render the response as the whole session. The canonical `/events` route stays strict (a bare request is still a 422), so the disclosure contract from #1062 is unchanged for current callers.

Test: the legacy-shapes test now asserts a bare (no-limit) legacy read serves 200 and the canonical route without limit still 422s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compatibility-only change on a legacy alias; the strict pagination contract on the canonical events route is unchanged. Sessions larger than 10k events could still be truncated for those old clients.
> 
> **Overview**
> Restores old `stashai` clients (≤0.1.366) that call `GET /me/transcripts/{session_id}/events` with no `limit`. Those requests were 422ing after the required-limit change.
> 
> The **legacy alias** now defaults `limit` to `10_000`. The **canonical** `/events` route still requires an explicit limit (bare requests stay 422). Tests cover both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f274e7fdc58473b4ff62a1ab69578611ab6e54e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->