### PR TITLE
First-day curator runs for personal stashes

### DIFF
--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -8,7 +8,7 @@ import asyncio
 import hashlib
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 import numpy as np
@@ -113,6 +113,20 @@ async def _embed_events_batch(event_ids: list[UUID], contents: list[str]) -> Non
 # --- Event CRUD ---
 
 
+async def _rewind_curated_through(owner_user_id: UUID, oldest_event_at: datetime) -> None:
+    """Imported sessions keep their original event times, which can predate a
+    curator's curated_through — its delta runs would never read them. Pull
+    curated_through back so the next run does. A no-op for live events, whose
+    timestamps are newer than any curator's position."""
+    pool = get_pool()
+    await pool.execute(
+        "UPDATE agents SET curated_through = $2 "
+        "WHERE user_id = $1 AND is_curator AND curated_through > $2",
+        owner_user_id,
+        oldest_event_at - timedelta(microseconds=1),
+    )
+
+
 async def push_event(
     owner_user_id: UUID | None,
     agent_name: str,
@@ -159,6 +173,8 @@ async def push_event(
         ts,
     )
     event = dict(row)
+    if owner_user_id is not None:
+        await _rewind_curated_through(owner_user_id, ts)
     if embedding_service.is_configured():
         _schedule_event_embed(event["id"], content, _text_hash(content))
     if owner_user_id is not None and session_id:
@@ -242,6 +258,8 @@ async def push_events_batch(
         timestamps,
     )
     results = [dict(r) for r in rows]
+    if owner_user_id is not None:
+        await _rewind_curated_through(owner_user_id, min(timestamps))
     await _upsert_sessions_for_events(owner_user_id, created_by, events, timestamps)
     if embedding_service.is_configured() and results:
         ids = [r["id"] for r in results]

--- a/backend/tasks/agent_schedules.py
+++ b/backend/tasks/agent_schedules.py
@@ -83,11 +83,11 @@ async def _run_curator_now(
         raise
 
 
-# During a workspace's first day the external wiki updates after every
-# conversation, not just on the nightly tick — a developer who just activated
-# the platform watches the wiki grow while they integrate. Debounced so a
-# stream of event batches coalesces into at most one run per window; the
-# agent's Redis turn lock already prevents overlapping runs.
+# During a scope's first day its wiki updates after every conversation, not
+# just on the nightly tick — a user who just signed up (or a developer who
+# just activated the platform) watches the wiki grow while they get set up.
+# Debounced so a stream of event batches coalesces into at most one run per
+# window; the agent's Redis turn lock already prevents overlapping runs.
 FIRST_DAY_HOURS = 24
 FIRST_DAY_DEBOUNCE = timedelta(minutes=10)
 
@@ -97,16 +97,35 @@ def first_day_curator_tick(scope_user_id: str) -> None:
     run_async(_first_day_curator_tick(UUID(scope_user_id)))
 
 
-async def _first_day_curator_tick(scope_user_id: UUID) -> None:
-    from ..services import agent_auth, agent_service, curation_service, end_user_service
+def _within_first_day(created_at: datetime, now: datetime) -> bool:
+    return created_at >= now - timedelta(hours=FIRST_DAY_HOURS)
 
-    workspace = await end_user_service.workspace_for_scope(scope_user_id)
-    if workspace is None or workspace["external_wiki_folder_id"] is None:
-        return
+
+async def _first_day_curator_tick(scope_user_id: UUID) -> None:
+    from ..services import agent_service, end_user_service, user_service
+
     now = datetime.now(UTC)
-    if workspace["created_at"] < now - timedelta(hours=FIRST_DAY_HOURS):
-        return
-    agent = await agent_service.get_or_create_curator(scope_user_id, wiki="external")
+
+    # Personal (and workspace-internal) Memory wiki, anchored to signup time.
+    scope_user = await user_service.get_user_by_id(scope_user_id)
+    if scope_user is not None and _within_first_day(scope_user["created_at"], now):
+        agent = await agent_service.get_or_create_curator(scope_user_id)
+        await _maybe_dispatch_first_day_run(scope_user_id, agent, now)
+
+    # External cross-user wiki, anchored to developer-platform activation.
+    workspace = await end_user_service.workspace_for_scope(scope_user_id)
+    if (
+        workspace is not None
+        and workspace["external_wiki_folder_id"] is not None
+        and _within_first_day(workspace["created_at"], now)
+    ):
+        agent = await agent_service.get_or_create_curator(scope_user_id, wiki="external")
+        await _maybe_dispatch_first_day_run(scope_user_id, agent, now)
+
+
+async def _maybe_dispatch_first_day_run(scope_user_id: UUID, agent: dict, now: datetime) -> None:
+    from ..services import agent_auth, curation_service
+
     # A curator that has never run skips the debounce: its seeded last_run_at
     # is the backfill point (~account creation), which would otherwise mute
     # the very first conversations after signup.
@@ -125,7 +144,7 @@ async def _first_day_curator_tick(scope_user_id: UUID) -> None:
     ):
         return
     # Unmetered: the platform is the trigger, so the run must not eat the
-    # workspace's free monthly curator allowance.
+    # scope's free monthly curator allowance.
     run_curator_now.delay(str(agent["id"]), metered=False)
 
 

--- a/backend/tests/test_first_day_curator.py
+++ b/backend/tests/test_first_day_curator.py
@@ -1,9 +1,9 @@
-"""The first-day curator: during a workspace's first 24 hours the external
-wiki updates after every conversation, not just on the nightly tick — a
-developer who just activated the platform watches the wiki grow while they
-integrate. The behavior that matters: it only fires for young developer
-workspaces, it debounces so an event stream doesn't stack runs, and personal
-scopes are untouched.
+"""The first-day curator: during a scope's first 24 hours the wiki updates
+after every conversation, not just on the nightly tick — a user who just
+signed up (or a developer who just activated the platform) watches the wiki
+grow while they get set up. The behavior that matters: it only fires for
+young scopes, it debounces so an event stream doesn't stack runs, and it
+never fires with nothing new to curate.
 """
 
 from datetime import UTC, datetime, timedelta
@@ -33,22 +33,51 @@ async def _workspace_with_conversation(client: AsyncClient) -> UUID:
     return UUID(workspace["scope_user_id"])
 
 
+async def _dispatched_wikis(pool, dispatched) -> set[str]:
+    wikis = set()
+    for args, _ in dispatched:
+        wikis.add(
+            await pool.fetchval("SELECT curator_wiki FROM agents WHERE id = $1", UUID(args[0]))
+        )
+    return wikis
+
+
 @pytest.mark.asyncio
-async def test_first_day_conversation_dispatches_an_unmetered_run(client: AsyncClient, dispatched):
+async def test_first_day_conversation_dispatches_unmetered_runs(
+    client: AsyncClient, pool, dispatched
+):
     scope_id = await _workspace_with_conversation(client)
     await _first_day_curator_tick(scope_id)
-    assert len(dispatched) == 1
-    # The platform is the trigger, so the run must not eat the workspace's
+    # Both of the workspace's wikis update eagerly on day one: its own Memory
+    # wiki and the cross-user external wiki.
+    assert await _dispatched_wikis(pool, dispatched) == {"internal", "external"}
+    # The platform is the trigger, so the runs must not eat the workspace's
     # free monthly curator allowance.
-    assert dispatched[0][1] == {"metered": False}
+    assert all(kwargs == {"metered": False} for _, kwargs in dispatched)
 
 
 @pytest.mark.asyncio
-async def test_old_workspace_does_not_dispatch(client: AsyncClient, pool, dispatched):
+async def test_old_workspace_still_curates_its_own_memory(client: AsyncClient, pool, dispatched):
     scope_id = await _workspace_with_conversation(client)
     await pool.execute(
         "UPDATE workspaces SET created_at = now() - interval '2 days' WHERE scope_user_id = $1",
         scope_id,
+    )
+    # The external wiki's first day is over; the scope user itself is still
+    # fresh, so its own Memory wiki keeps updating eagerly.
+    await _first_day_curator_tick(scope_id)
+    assert await _dispatched_wikis(pool, dispatched) == {"internal"}
+
+
+@pytest.mark.asyncio
+async def test_old_scope_does_not_dispatch(client: AsyncClient, pool, dispatched):
+    scope_id = await _workspace_with_conversation(client)
+    await pool.execute(
+        "UPDATE workspaces SET created_at = now() - interval '2 days' WHERE scope_user_id = $1",
+        scope_id,
+    )
+    await pool.execute(
+        "UPDATE users SET created_at = now() - interval '2 days' WHERE id = $1", scope_id
     )
     await _first_day_curator_tick(scope_id)
     assert dispatched == []
@@ -59,7 +88,7 @@ async def test_recent_run_debounces(client: AsyncClient, pool, dispatched):
     scope_id = await _workspace_with_conversation(client)
     await pool.execute(
         "UPDATE agents SET last_run_outcome = 'ran', last_run_at = now() "
-        "WHERE user_id = $1 AND is_curator AND curator_wiki = 'external'",
+        "WHERE user_id = $1 AND is_curator",
         scope_id,
     )
     await _first_day_curator_tick(scope_id)
@@ -67,17 +96,52 @@ async def test_recent_run_debounces(client: AsyncClient, pool, dispatched):
 
     # Once the debounce window has passed, pending changes dispatch again.
     await pool.execute(
-        "UPDATE agents SET last_run_at = $2 "
-        "WHERE user_id = $1 AND is_curator AND curator_wiki = 'external'",
+        "UPDATE agents SET last_run_at = $2 WHERE user_id = $1 AND is_curator",
         scope_id,
         datetime.now(UTC) - timedelta(minutes=11),
     )
     await _first_day_curator_tick(scope_id)
-    assert len(dispatched) == 1
+    assert await _dispatched_wikis(pool, dispatched) == {"internal", "external"}
+
+
+async def _personal_user_with_conversation(client: AsyncClient) -> UUID:
+    api_key, body = await _register_with_email(client, f"{unique_name('solo')}@example.com")
+    resp = await client.post(
+        "/api/v1/me/sessions/events",
+        json={
+            "agent_name": "claude-code",
+            "event_type": "assistant_message",
+            "content": "hello",
+            "session_id": "s-personal-1",
+        },
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    assert resp.status_code == 201
+    return UUID(body["id"])
 
 
 @pytest.mark.asyncio
-async def test_personal_scope_never_dispatches(client: AsyncClient, dispatched):
+async def test_personal_first_day_conversation_dispatches_an_unmetered_run(
+    client: AsyncClient, pool, dispatched
+):
+    user_id = await _personal_user_with_conversation(client)
+    await _first_day_curator_tick(user_id)
+    assert await _dispatched_wikis(pool, dispatched) == {"internal"}
+    assert dispatched[0][1] == {"metered": False}
+
+
+@pytest.mark.asyncio
+async def test_old_personal_account_does_not_dispatch(client: AsyncClient, pool, dispatched):
+    user_id = await _personal_user_with_conversation(client)
+    await pool.execute(
+        "UPDATE users SET created_at = now() - interval '2 days' WHERE id = $1", user_id
+    )
+    await _first_day_curator_tick(user_id)
+    assert dispatched == []
+
+
+@pytest.mark.asyncio
+async def test_personal_scope_with_nothing_new_does_not_dispatch(client: AsyncClient, dispatched):
     _, body = await _register_with_email(client, f"{unique_name('solo')}@example.com")
     await _first_day_curator_tick(UUID(body["id"]))
     assert dispatched == []

--- a/backend/tests/test_first_day_curator.py
+++ b/backend/tests/test_first_day_curator.py
@@ -145,3 +145,64 @@ async def test_personal_scope_with_nothing_new_does_not_dispatch(client: AsyncCl
     _, body = await _register_with_email(client, f"{unique_name('solo')}@example.com")
     await _first_day_curator_tick(UUID(body["id"]))
     assert dispatched == []
+
+
+async def _push_historical_event(client: AsyncClient, api_key: str, created_at: datetime) -> None:
+    resp = await client.post(
+        "/api/v1/me/sessions/events",
+        json={
+            "agent_name": "claude-code",
+            "event_type": "assistant_message",
+            "content": "an old conversation",
+            "session_id": "s-imported-1",
+            "created_at": created_at.isoformat(),
+        },
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    assert resp.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_imported_pre_signup_history_dispatches(client: AsyncClient, pool, dispatched):
+    """Imported sessions keep their original timestamps, which predate the
+    curator's seeded curated_through. The import must pull curated_through
+    back so the first-day run actually reads the history."""
+    api_key, body = await _register_with_email(client, f"{unique_name('solo')}@example.com")
+    user_id = UUID(body["id"])
+    old = datetime.now(UTC) - timedelta(days=10)
+    await _push_historical_event(client, api_key, old)
+    curated_through = await pool.fetchval(
+        "SELECT curated_through FROM agents WHERE user_id = $1 AND is_curator", user_id
+    )
+    assert curated_through < old
+    await _first_day_curator_tick(user_id)
+    assert await _dispatched_wikis(pool, dispatched) == {"internal"}
+
+
+@pytest.mark.asyncio
+async def test_late_import_reopens_curation(client: AsyncClient, pool, dispatched):
+    """A curator that already ran has curated_through at its last run; an
+    import of older sessions after that must still pull it back."""
+    api_key, body = await _register_with_email(client, f"{unique_name('solo')}@example.com")
+    user_id = UUID(body["id"])
+    await pool.execute(
+        "UPDATE users SET created_at = now() - interval '2 days' WHERE id = $1", user_id
+    )
+    await pool.execute(
+        "UPDATE agents SET last_run_outcome = 'ran', last_run_at = now(), curated_through = now() "
+        "WHERE user_id = $1 AND is_curator",
+        user_id,
+    )
+    old = datetime.now(UTC) - timedelta(days=10)
+    await _push_historical_event(client, api_key, old)
+    curated_through = await pool.fetchval(
+        "SELECT curated_through FROM agents WHERE user_id = $1 AND is_curator", user_id
+    )
+    assert curated_through < old
+    # Past the first day nothing dispatches immediately — the nightly run
+    # picks the import up, because the pending-changes gate now sees it.
+    await _first_day_curator_tick(user_id)
+    assert dispatched == []
+    from backend.services import curation_service
+
+    assert await curation_service.has_changes_since(user_id, user_id, curated_through)


### PR DESCRIPTION
## What

A new user who uploads their session history now gets a Memory-wiki curator run within minutes — and the run actually reads the imported history — instead of waiting for the first nightly window and getting nothing.

Two commits:

**1. First-day curator runs for personal stashes** (`ab748aef`)

The first-day curator tick (fired on every transcript upload and event push) previously only served developer workspaces: it bailed unless the scope had `external_wiki_folder_id` set, and only ran the external-wiki curator. Now it checks two curators:

- **The scope's own Memory curator** — fires when the scope user's `created_at` is within the last 24 hours.
- **The external-wiki curator** — unchanged gates: developer platform active + workspace under 24 hours old.

The shared gates moved into one helper (`_maybe_dispatch_first_day_run`): the 10-minute debounce (skipped for a never-run curator), auth resolution, `has_changes_since`, and the unmetered `run_curator_now` dispatch.

**2. Imported history reopens curation** (`65601006`)

A curator's delta runs read only events with `created_at` after its `curated_through`, which seeds to signup time. Imported sessions deliberately keep their original timestamps — for an onboarding history import those predate signup, so the curator never read them: the first-day run fired and saw nothing.

Now every event insert pulls `curated_through` back to just before the oldest inserted event, when older (`_rewind_curated_through` in `memory_service.py` — one `UPDATE`, matching zero rows for live events). The pending-changes gate and the curation feed both key off `curated_through`, so this covers the onboarding import, the multi-request import stream, and a late import after the curator has already run (picked up by the nightly run).

## Behavior notes

- **Intentional side effect:** a developer workspace in its first day now dispatches both its own Memory curator and the external-wiki curator — events land in that scope for both wikis.
- The auth gate still filters out free users with no connected credential (managed runs are Pro-gated), same as their nightly run would be.
- First-day runs stay `metered=False`: platform-paid compute per new signup, bounded by the 24-hour window and the 10-minute debounce. A large import's tail past day one drains on the nightly runs, which stay metered for free accounts.

## Tests

`backend/tests/test_first_day_curator.py` (9 passing): personal first-day conversation dispatches one unmetered internal run; aged accounts and no-new-changes scopes dispatch nothing; workspace tests assert both wikis, including "external wiki's first day over, scope user still fresh → internal only"; an imported 10-day-old event pulls `curated_through` below its timestamp and dispatches; a late import reopens curation for the nightly run. Plus `test_transcripts.py`, `test_developer_platform.py`, and `test_activity.py` (50 tests), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches curator scheduling and watermark updates on event insert, which can trigger extra unmetered LLM runs and change what history gets curated.
> 
> **Overview**
> New signups now get an eager **Memory wiki** curator run in the first 24 hours, not only developer workspaces’ external wiki. The first-day tick checks the scope user’s `created_at` for the internal curator and the workspace’s `created_at` for the external one; shared debounce/auth/`has_changes_since` gates live in `_maybe_dispatch_first_day_run`. Day-one workspaces therefore dispatch **both** wikis (unmetered).
> 
> Event insert also **rewinds** curator `curated_through` when imported events predate the watermark, so historical uploads are included in the next delta instead of being skipped forever.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 656010065ae2aa2309f5ed84753217b2ba9c2323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
