### PR TITLE
Rename notepads to per-user wikis

### DIFF
--- a/backend/migrations/versions/0200_notepads_are_wikis.py
+++ b/backend/migrations/versions/0200_notepads_are_wikis.py
@@ -1,0 +1,47 @@
+"""Rename notepads to per-user wikis.
+
+"Notepad" was planning-era vocabulary for the per-user memory surface. Every
+product surface — the console, the pricing page, the wiki-graph endpoints —
+already calls it the user's own wiki, so the schema catches up: the surface
+is a wiki like the shared one, just scoped to one end user and never
+anonymized. Nothing anywhere says notepad.
+
+Pure rename plus the one user-visible data change: each workspace's
+"User Notepads" folder becomes "User Wikis".
+
+Revision ID: 0200
+Revises: 0199
+"""
+
+from alembic import op
+
+revision = "0200"
+down_revision = "0199"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE end_users RENAME COLUMN notepad_folder_id TO wiki_folder_id")
+    op.execute(
+        "ALTER TABLE workspaces RENAME COLUMN end_user_notepads_folder_id "
+        "TO end_user_wikis_folder_id"
+    )
+    op.execute(
+        "UPDATE folders SET name = 'User Wikis' "
+        "WHERE id IN (SELECT end_user_wikis_folder_id FROM workspaces) "
+        "  AND name = 'User Notepads'"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE folders SET name = 'User Notepads' "
+        "WHERE id IN (SELECT end_user_wikis_folder_id FROM workspaces) "
+        "  AND name = 'User Wikis'"
+    )
+    op.execute(
+        "ALTER TABLE workspaces RENAME COLUMN end_user_wikis_folder_id "
+        "TO end_user_notepads_folder_id"
+    )
+    op.execute("ALTER TABLE end_users RENAME COLUMN wiki_folder_id TO notepad_folder_id")

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -174,7 +174,7 @@ async def list_developer_sessions(scope_user_id: UUID = Depends(get_scope)):
 @router.get("/files")
 async def list_developer_files(scope_user_id: UUID = Depends(get_scope)):
     """The two kinds of files the platform holds: the shared wiki's pages, and
-    each user's own material (notepad pages plus uploaded files)."""
+    each user's own material (their wiki's pages plus uploaded files)."""
     workspace = await _require_active_workspace(scope_user_id)
     return await end_user_service.workspace_files(workspace)
 
@@ -340,12 +340,12 @@ async def get_user_wiki_graph(
     scope_user_id: UUID = Depends(get_scope),
 ):
     """One user's own wiki as a graph — the same rendering the shared wiki
-    gets, rooted at their notepad folder."""
+    gets, rooted at their own wiki folder."""
     from ..services import files_tree_service
 
     end_user = await _end_user_in_scope(user_id, scope_user_id)
     return await files_tree_service.wiki_graph(
-        await files_tree_service.folder_subtree_ids(end_user["notepad_folder_id"])
+        await files_tree_service.folder_subtree_ids(end_user["wiki_folder_id"])
     )
 
 

--- a/backend/routers/files.py
+++ b/backend/routers/files.py
@@ -228,9 +228,9 @@ async def ingest_bytes(
     # and MCP all hit this single path and get the routing for free.
     # An end user's uploads are raw data by definition: markdown that would
     # normally become an editable page stays a file when it belongs to a
-    # customer, since pages are the memory substrate (wiki, notepad) and those
+    # customer, since pages are the memory substrate (shared wiki, per-user wiki) and those
     # are curated, not uploaded. Text a user should *remember* goes to their
-    # notepad folder.
+    # wiki folder.
     page_kind = None if end_user_id else files_tree_service.detect_page_kind(filename, content_type)
     if page_kind is not None:
         if folder_id is not None:

--- a/backend/routers/vfs.py
+++ b/backend/routers/vfs.py
@@ -31,7 +31,7 @@ class VfsRequest(BaseModel):
         None,
         max_length=128,
         description="External Multiplayer: narrow the tree to this end user — "
-        "shared wiki at /memory, the user's notepad and files under /files, "
+        "shared wiki at /memory, the user's own wiki and files under /files, "
         "the user's transcripts under /sessions",
     )
 
@@ -59,8 +59,8 @@ async def _end_user_ctx(current_user: dict, user_id: str | None) -> dict | None:
     if end_user is None:
         return {
             "external_id": user_id,
-            "wiki_folder_id": str(workspace["external_wiki_folder_id"]),
-            "notepad_folder_id": None,
+            "shared_wiki_folder_id": str(workspace["external_wiki_folder_id"]),
+            "wiki_folder_id": None,
             "source_ids": set(),
         }
     connected = await source_service.list_connected_sources(
@@ -68,8 +68,8 @@ async def _end_user_ctx(current_user: dict, user_id: str | None) -> dict | None:
     )
     return {
         "external_id": end_user["external_id"],
-        "wiki_folder_id": str(workspace["external_wiki_folder_id"]),
-        "notepad_folder_id": str(end_user["notepad_folder_id"]),
+        "shared_wiki_folder_id": str(workspace["external_wiki_folder_id"]),
+        "wiki_folder_id": str(end_user["wiki_folder_id"]),
         "source_ids": {s["id"] for s in connected},
     }
 

--- a/backend/services/curation_service.py
+++ b/backend/services/curation_service.py
@@ -249,7 +249,7 @@ async def _feed_events(
 
     Each event carries its session's end user (name and wiki opt-out) when it
     has one — the external curator routes by it: every user's material feeds
-    that user's notepad, and only share_wiki users feed the shared anonymized
+    that user's own wiki, and only share_wiki users feed the shared anonymized
     wiki."""
     pool = get_pool()
     args: list = [owner_user_id]

--- a/backend/services/end_user_service.py
+++ b/backend/services/end_user_service.py
@@ -14,11 +14,11 @@ this module say end_user. Nothing anywhere says tenant.
 Two memory surfaces hang off this table:
 - the workspace's external wiki (`workspaces.external_wiki_folder_id`) —
   cross-user, anonymized by the curator, opt-out per user via `share_wiki`;
-- a per-user notepad folder (`end_users.notepad_folder_id`) — non-anonymized,
+- a per-user wiki folder (`end_users.wiki_folder_id`) — non-anonymized,
   visible only through that user's own reads and the developer console.
 
 Activating the developer platform on a workspace creates the wiki and
-notepads folders; `external_wiki_folder_id IS NOT NULL` is the "developer
+user-wikis folders; `external_wiki_folder_id IS NOT NULL` is the "developer
 platform is active" marker.
 """
 
@@ -27,18 +27,16 @@ from uuid import UUID
 from ..database import get_pool
 from . import files_tree_service, source_service, workspace_service
 
-_END_USER_COLS_PLAIN = (
-    "id, workspace_id, external_id, name, share_wiki, notepad_folder_id, created_at"
-)
+_END_USER_COLS_PLAIN = "id, workspace_id, external_id, name, share_wiki, wiki_folder_id, created_at"
 _END_USER_COLS = (
     "eu.id, eu.workspace_id, eu.external_id, eu.name, eu.share_wiki, "
-    "eu.notepad_folder_id, eu.created_at"
+    "eu.wiki_folder_id, eu.created_at"
 )
 
 
 async def activate(workspace_id: UUID, created_by: UUID) -> dict:
     """Turn on the developer platform for a workspace: create the external
-    wiki and user-notepads folders and stamp them on the row. Idempotent."""
+    wiki and user-wikis folders and stamp them on the row. Idempotent."""
     pool = get_pool()
     workspace = await workspace_service.get_workspace(workspace_id)
     if workspace is None:
@@ -49,18 +47,18 @@ async def activate(workspace_id: UUID, created_by: UUID) -> dict:
     wiki = await files_tree_service.create_folder(
         owner, "External Wiki", created_by, protected=True
     )
-    notepads = await files_tree_service.create_folder(
-        owner, "User Notepads", created_by, protected=True
+    user_wikis = await files_tree_service.create_folder(
+        owner, "User Wikis", created_by, protected=True
     )
     row = await pool.fetchrow(
         "UPDATE workspaces "
-        "SET external_wiki_folder_id = $2, end_user_notepads_folder_id = $3 "
+        "SET external_wiki_folder_id = $2, end_user_wikis_folder_id = $3 "
         "WHERE id = $1 AND external_wiki_folder_id IS NULL "
         "RETURNING id, name, domain, scope_user_id, created_by, "
-        "         external_wiki_folder_id, end_user_notepads_folder_id, created_at",
+        "         external_wiki_folder_id, end_user_wikis_folder_id, created_at",
         workspace_id,
         wiki["id"],
-        notepads["id"],
+        user_wikis["id"],
     )
     if row is None:
         # Lost an activation race — the other winner's folders stand.
@@ -77,7 +75,7 @@ async def workspace_for_scope(scope_user_id: UUID) -> dict | None:
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT id, name, domain, scope_user_id, created_by, "
-        "       external_wiki_folder_id, end_user_notepads_folder_id, created_at "
+        "       external_wiki_folder_id, end_user_wikis_folder_id, created_at "
         "FROM workspaces WHERE scope_user_id = $1",
         scope_user_id,
     )
@@ -88,7 +86,7 @@ async def get_or_create_end_user(
     workspace: dict, external_id: str, name: str | None = None
 ) -> dict:
     """Resolve an end user by the developer's own id, creating them (and their
-    notepad folder) on first sight. The name defaults to the external id and is
+    wiki folder) on first sight. The name defaults to the external id and is
     only a display label — identity lives on (workspace_id, external_id)."""
     if workspace["external_wiki_folder_id"] is None:
         raise ValueError("developer platform is not active on this workspace — activate it first")
@@ -118,24 +116,24 @@ async def get_or_create_end_user(
             # The folder is named by external_id, not the display name: folders
             # are unique on (owner, parent, name), and two of a developer's
             # users may well share a display name.
-            notepad = await conn.fetchrow(
+            wiki_folder = await conn.fetchrow(
                 "INSERT INTO folders "
                 "  (owner_user_id, parent_folder_id, name, created_by, is_protected) "
                 "VALUES ($1, $2, $3, $4, true) RETURNING id",
                 workspace["scope_user_id"],
-                workspace["end_user_notepads_folder_id"],
+                workspace["end_user_wikis_folder_id"],
                 external_id,
                 workspace["scope_user_id"],
             )
             row = await conn.fetchrow(
                 f"INSERT INTO end_users "
-                "  (workspace_id, external_id, name, notepad_folder_id) "
+                "  (workspace_id, external_id, name, wiki_folder_id) "
                 "VALUES ($1, $2, $3, $4) "
                 f"RETURNING {_END_USER_COLS_PLAIN}",
                 workspace["id"],
                 external_id,
                 name or external_id,
-                notepad["id"],
+                wiki_folder["id"],
             )
             return dict(row)
 
@@ -232,7 +230,7 @@ async def external_curator_prompt(workspace: dict, since) -> str:
         [
             {
                 "name": end_user["name"],
-                "notepad_folder_id": str(end_user["notepad_folder_id"]),
+                "wiki_folder_id": str(end_user["wiki_folder_id"]),
                 "share_wiki": end_user["share_wiki"],
             }
             for end_user in end_users
@@ -288,7 +286,7 @@ async def workspace_sessions(workspace: dict, limit: int = 200) -> list[dict]:
 
 async def workspace_files(workspace: dict) -> dict:
     """The console's files view: the shared wiki's pages and files, and each
-    user's own material (notepad pages plus uploaded files)."""
+    user's own material (their wiki's pages plus uploaded files)."""
     pool = get_pool()
     wiki_ids = list(
         await files_tree_service.folder_subtree_ids(workspace["external_wiki_folder_id"])
@@ -305,13 +303,13 @@ async def workspace_files(workspace: dict) -> dict:
     )
     users = []
     for end_user in await list_end_users(workspace["id"]):
-        notepad_ids = list(
-            await files_tree_service.folder_subtree_ids(end_user["notepad_folder_id"])
+        user_wiki_ids = list(
+            await files_tree_service.folder_subtree_ids(end_user["wiki_folder_id"])
         )
-        notepad_pages = await pool.fetch(
+        user_wiki_pages = await pool.fetch(
             "SELECT id, name, updated_at FROM pages "
             "WHERE folder_id = ANY($1) AND deleted_at IS NULL ORDER BY updated_at DESC",
-            notepad_ids,
+            user_wiki_ids,
         )
         files = await pool.fetch(
             "SELECT id, name, size_bytes, created_at FROM files "
@@ -323,8 +321,8 @@ async def workspace_files(workspace: dict) -> dict:
                 "id": str(end_user["id"]),
                 "name": end_user["name"],
                 "external_id": end_user["external_id"],
-                "notepad_folder_id": str(end_user["notepad_folder_id"]),
-                "notepad_pages": [dict(r) for r in notepad_pages],
+                "wiki_folder_id": str(end_user["wiki_folder_id"]),
+                "wiki_pages": [dict(r) for r in user_wiki_pages],
                 "files": [dict(r) for r in files],
             }
         )
@@ -364,7 +362,7 @@ async def update_end_user(
 
 async def end_user_detail(end_user: dict) -> dict:
     """Everything the console shows about one user: their transcripts, the
-    files their uploads carried, and the notepad the curator writes for them."""
+    files their uploads carried, and the wiki the curator writes for them."""
     pool = get_pool()
     sessions = await pool.fetch(
         "SELECT s.session_id, s.agent_name, s.started_at, s.title, "
@@ -384,10 +382,10 @@ async def end_user_detail(end_user: dict) -> dict:
         "ORDER BY created_at DESC",
         end_user["id"],
     )
-    notepad_pages = await pool.fetch(
+    wiki_pages = await pool.fetch(
         "SELECT id, name, updated_at FROM pages "
         "WHERE folder_id = ANY($1) AND deleted_at IS NULL ORDER BY updated_at DESC",
-        list(await files_tree_service.folder_subtree_ids(end_user["notepad_folder_id"])),
+        list(await files_tree_service.folder_subtree_ids(end_user["wiki_folder_id"])),
     )
     workspace = await workspace_service.get_workspace(end_user["workspace_id"])
     sources = await source_service.list_connected_sources(
@@ -397,6 +395,6 @@ async def end_user_detail(end_user: dict) -> dict:
         "user": end_user,
         "sessions": [dict(r) for r in sessions],
         "files": [dict(r) for r in files],
-        "notepad_pages": [dict(r) for r in notepad_pages],
+        "wiki_pages": [dict(r) for r in wiki_pages],
         "sources": sources,
     }

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -309,7 +309,7 @@ Begin now.
 
 
 # ---------------------------------------------------------------------------
-# External Multiplayer curator (developer workspaces: cross-user wiki + notepads)
+# External Multiplayer curator (developer workspaces: shared wiki + per-user wikis)
 # ---------------------------------------------------------------------------
 
 
@@ -321,10 +321,10 @@ def render_external_curator_prompt(
     A developer workspace serves many end users — one user of the developer's
     product each, whether that is a repair shop or one person. This prompt
     compiles the same delta feed into two artifacts with opposite privacy
-    rules: a per-user notepad (non-anonymized, one folder per user) and the
+    rules: a per-user wiki (non-anonymized, one folder per user) and the
     shared external wiki (cross-user, anonymized — user identities never
-    appear). Users opt out of the wiki with share_wiki=false; their material
-    still feeds their own notepad.
+    appear). Users opt out of the shared wiki with share_wiki=false; their
+    material still feeds their own wiki.
     """
     window = (
         f"the changes since {since}"
@@ -333,7 +333,7 @@ def render_external_curator_prompt(
     )
     changes_cmd = f"stash changes --since {since} --json" if since else "stash changes --json"
     user_lines = "\n".join(
-        f"- `{end_user['name']}` — notepad folder id `{end_user['notepad_folder_id']}`"
+        f"- `{end_user['name']}` — wiki folder id `{end_user['wiki_folder_id']}`"
         + ("" if end_user["share_wiki"] else " — **opted out of the shared wiki**")
         for end_user in end_users
     )
@@ -344,7 +344,7 @@ each end **user** of it is a company, or one person. You compile
 {window} into two
 artifacts with opposite privacy rules:
 
-1. **Per-user notepads** — one folder per user (ids below). Non-anonymized
+1. **Per-user wikis** — one folder per user (ids below). Non-anonymized
    working memory for that user alone: their machines, their part numbers,
    their people, their history. Detail is the point.
 2. **The shared external wiki** (folder id `{wiki_folder_id}`) — general
@@ -352,7 +352,7 @@ artifacts with opposite privacy rules:
    must never appear here: no user names, no customer names, no people, no
    identifiable specifics (a one-of-a-kind machine identifies its owner).
    Cite anonymously: "a peer user found...". When in doubt whether a detail
-   identifies a user, it goes in the notepad, not the wiki.
+   identifies a user, it goes in that user's own wiki, not the shared wiki.
 
 ## The users
 {user_lines}
@@ -360,37 +360,37 @@ artifacts with opposite privacy rules:
 ## Read the inputs
 - `{changes_cmd}` — the delta. Each history event carries its session's
   `user` (name) and `user_share_wiki`. Events with no user are the developer's
-  own activity — wiki-eligible, never notepad material.
+  own activity — eligible for the shared wiki, never for any user's own wiki.
 - `history_has_more: true` means the feed overflowed this run's cap; curate
   what's present, the remainder is queued for your next run.
 - `stash ls /files --json` and `stash files read-page <page_id>` to inspect
   what's already written.
 
 ## Routing rules (hard)
-- Every user's material feeds THAT user's notepad, never another user's.
-- Only events from users WITHOUT the opt-out marker may inform the wiki.
-  Opted-out users' material goes in their notepad and stops there.
-- The wiki gets the anonymized general lesson; the notepad gets the specifics.
-  One event routinely produces both: "User X's Cascadia needed part P for
-  fault F" → notepad line for user X verbatim; wiki page on fault F → part P
-  with no mention of X.
-- Files in the delta already inside the wiki folder are developer-curated
-  raw material for the wiki — fold them in like any source, they are already
-  cleared for cross-user use.
+- Every user's material feeds THAT user's wiki, never another user's.
+- Only events from users WITHOUT the opt-out marker may inform the shared
+  wiki. Opted-out users' material goes in their own wiki and stops there.
+- The shared wiki gets the anonymized general lesson; the user's own wiki
+  gets the specifics. One event routinely produces both: "User X's Cascadia
+  needed part P for fault F" → a line in user X's wiki verbatim; shared-wiki
+  page on fault F → part P with no mention of X.
+- Files in the delta already inside the shared wiki folder are
+  developer-curated raw material for it — fold them in like any source, they
+  are already cleared for cross-user use.
 
 ## Write
 - Create a page: `stash files add-page "<Title>" --folder <folder_id> --content "<markdown>" --json`
 - Update a page: `stash files edit-page <page_id> --content "<markdown>"`
 - Create structure: `stash files create-folder "<Name>" --parent <folder_id> --json`
-- The wiki keeps a root `Wiki Index` page cataloging every page with a
-  one-line summary, and an append-only `Log` page:
+- The shared wiki keeps a root `Wiki Index` page cataloging every page with
+  a one-line summary, and an append-only `Log` page:
   `- [YYYY-MM-DD] created|updated|merged|skipped <page> — <detail>` per action.
-- There is exactly ONE `Wiki Index` and ONE `Log` in the whole wiki. Find and
-  edit the existing pages (`stash ls`); creating a second of either is always
-  wrong, even on a bootstrap run over history that already has them.
-- Each notepad is a small set of topic pages plus a `Notes` page for
-  everything else — notepads are working memory, not wikis: favor updating
-  one page over minting many.
+- There is exactly ONE `Wiki Index` and ONE `Log` in the whole shared wiki.
+  Find and edit the existing pages (`stash ls`); creating a second of either
+  is always wrong, even on a bootstrap run over history that already has them.
+- Each user's wiki is a small set of topic pages plus a `Notes` page for
+  everything else — user wikis are working memory: favor updating one page
+  over minting many.
 
 ## Ingest principles
 - Maintain, don't regenerate. Scope by diff, not by corpus.

--- a/backend/services/sprite_agent_service.py
+++ b/backend/services/sprite_agent_service.py
@@ -383,7 +383,7 @@ async def build_scheduled_turn(agent: dict, run_stamp: str) -> tuple[str, str]:
         since = agent["curated_through"].isoformat() if agent.get("curated_through") else None
         # Which wiki this curator writes decides its prompt. A developer
         # workspace runs both: the internal pass over its own Memory wiki, and
-        # the external pass compiling the cross-user wiki plus per-user notepads.
+        # the external pass compiling the cross-user wiki plus per-user wikis.
         if agent.get("curator_wiki") == "external":
             workspace = await end_user_service.workspace_for_scope(user_id)
             if workspace is None or workspace["external_wiki_folder_id"] is None:

--- a/backend/services/vfs_service.py
+++ b/backend/services/vfs_service.py
@@ -227,7 +227,7 @@ class EndUserVfsClient(InProcessVfsClient):
 
     `/memory` becomes the workspace's shared external wiki (the memory-folder
     call answers with the wiki folder, and the model re-roots whatever that
-    returns), `/files` holds the user's notepad and the user's own uploads,
+    returns), `/files` holds the user's own wiki and the user's own uploads,
     `/sessions` only the user's transcripts, and `/sources` the sources
     connected for this user. Skills and tables are developer-side surfaces and
     don't exist in a user's view.
@@ -238,7 +238,7 @@ class EndUserVfsClient(InProcessVfsClient):
         self._end_user = end_user_ctx
 
     def get_memory_folder(self) -> dict:
-        return {"id": self._end_user["wiki_folder_id"]}
+        return {"id": self._end_user["shared_wiki_folder_id"]}
 
     def list_tables(self) -> list:
         return []
@@ -255,17 +255,17 @@ class EndUserVfsClient(InProcessVfsClient):
         tree = overview.get("files", {})
         folders = tree.get("folders", [])
 
-        # Descendant closure of the wiki and notepad roots. Everything else in
-        # the workspace — other users' notepads included — is invisible.
+        # Descendant closure of the shared-wiki and user-wiki roots. Everything
+        # else in the workspace — other users' wikis included — is invisible.
         children: dict[str | None, list[dict]] = {}
         for folder in folders:
             children.setdefault(folder["parent_folder_id"], []).append(folder)
         kept_ids: set[str] = set()
-        # A customer with no notepad yet has not been written for — they still
+        # A customer with no wiki folder yet has not been written for — they still
         # read the shared wiki, they just own nothing.
-        frontier = [self._end_user["wiki_folder_id"]]
-        if self._end_user["notepad_folder_id"]:
-            frontier.append(self._end_user["notepad_folder_id"])
+        frontier = [self._end_user["shared_wiki_folder_id"]]
+        if self._end_user["wiki_folder_id"]:
+            frontier.append(self._end_user["wiki_folder_id"])
         while frontier:
             folder_id = frontier.pop()
             if folder_id in kept_ids:
@@ -277,10 +277,10 @@ class EndUserVfsClient(InProcessVfsClient):
         for folder in folders:
             if folder["id"] not in kept_ids:
                 continue
-            if folder["id"] == self._end_user["notepad_folder_id"]:
-                # The notepad root's parent (the workspace's "User Notepads"
-                # container) is filtered out, so mount it at /files/notepad.
-                folder = {**folder, "parent_folder_id": None, "name": "notepad"}
+            if folder["id"] == self._end_user["wiki_folder_id"]:
+                # The user-wiki root's parent (the workspace's "User Wikis"
+                # container) is filtered out, so mount it at /files/wiki.
+                folder = {**folder, "parent_folder_id": None, "name": "wiki"}
             kept_folders.append(folder)
 
         return {

--- a/backend/services/workspace_service.py
+++ b/backend/services/workspace_service.py
@@ -64,7 +64,7 @@ async def create_workspace(name: str, domain: str | None, created_by: UUID | Non
         "INSERT INTO workspaces (name, domain, scope_user_id, created_by) "
         "VALUES ($1, $2, $3, $4) "
         "RETURNING id, name, domain, scope_user_id, created_by, "
-        "         external_wiki_folder_id, end_user_notepads_folder_id, created_at",
+        "         external_wiki_folder_id, end_user_wikis_folder_id, created_at",
         name,
         domain,
         scope_user["id"],
@@ -82,7 +82,7 @@ async def get_workspace(workspace_id: UUID) -> dict | None:
     pool = get_pool()
     row = await pool.fetchrow(
         "SELECT id, name, domain, scope_user_id, created_by, "
-        "       external_wiki_folder_id, end_user_notepads_folder_id, created_at "
+        "       external_wiki_folder_id, end_user_wikis_folder_id, created_at "
         "FROM workspaces WHERE id = $1",
         workspace_id,
     )

--- a/backend/tests/test_developer_platform.py
+++ b/backend/tests/test_developer_platform.py
@@ -2,16 +2,16 @@
 
 What matters here:
 - Activation is self-serve and idempotent: a solo developer gets a one-man,
-  invite-only (NULL-domain) workspace with the wiki and notepads folders; the
+  invite-only (NULL-domain) workspace with the wiki and user-wikis folders; the
   creator is an explicit member, since no domain rule will ever cover them.
 - The user contract: `user_id` on an events upload names the developer's own
-  id for their end user. First sight creates the user and their notepad folder;
+  id for their end user. First sight creates the user and their wiki folder;
   the session row is stamped set-once, so a user's session can never migrate to
   another user later.
 - User ids only work on developer workspace scopes — a personal upload
   carrying user_id fails loud, it never silently drops the user.
 - The user-scoped VFS shows one user's world and nothing else's: the shared
-  wiki at /memory, that user's notepad and files under /files, that user's
+  wiki at /memory, that user's own wiki and files under /files, that user's
   transcripts under /sessions. Another user's material must be invisible —
   that is the entire product promise to the developer's customers.
 """
@@ -75,7 +75,7 @@ async def test_activate_creates_one_man_workspace(client: AsyncClient, pool):
 
     assert workspace["domain"] is None
     assert workspace["external_wiki_folder_id"] is not None
-    assert workspace["end_user_notepads_folder_id"] is not None
+    assert workspace["end_user_wikis_folder_id"] is not None
 
     # The creator is an explicit member: the workspace scope works for them.
     resp = await client.get(
@@ -127,7 +127,7 @@ async def test_user_upload_creates_end_user_and_stamps_session(client: AsyncClie
     assert end_user is not None
     assert end_user["name"] == "Riverside Truck"
     assert end_user["share_wiki"] is True
-    assert end_user["notepad_folder_id"] is not None
+    assert end_user["wiki_folder_id"] is not None
 
     session = await pool.fetchrow(
         "SELECT end_user_id FROM sessions WHERE owner_user_id = $1 AND session_id = 'sess-riverside-1'",
@@ -190,19 +190,19 @@ async def test_user_vfs_isolates_users(client: AsyncClient, pool):
         ],
     )
 
-    # Seed a wiki page (shared) and a page in each user's notepad.
+    # Seed a wiki page (shared) and a page in each user's own wiki.
     end_users = {
         r["external_id"]: r
         for r in await pool.fetch(
-            "SELECT external_id, notepad_folder_id FROM end_users WHERE workspace_id = $1",
+            "SELECT external_id, wiki_folder_id FROM end_users WHERE workspace_id = $1",
             uuid.UUID(workspace["id"]),
         )
     }
     scope_id = uuid.UUID(workspace["scope_user_id"])
     for name, folder_id in [
         ("Fault codes", uuid.UUID(workspace["external_wiki_folder_id"])),
-        ("Acme notes", end_users["org_acme"]["notepad_folder_id"]),
-        ("Beta notes", end_users["org_beta"]["notepad_folder_id"]),
+        ("Acme notes", end_users["org_acme"]["wiki_folder_id"]),
+        ("Beta notes", end_users["org_beta"]["wiki_folder_id"]),
     ]:
         await pool.execute(
             "INSERT INTO pages (owner_user_id, name, content_markdown, folder_id, created_by) "
@@ -220,7 +220,7 @@ async def test_user_vfs_isolates_users(client: AsyncClient, pool):
     assert resp.status_code == 200, resp.text
     listing = resp.json()["stdout"]
 
-    # Acme's world: the shared wiki, its own notepad, its own session.
+    # Acme's world: the shared wiki, its own wiki, its own session.
     assert "Fault codes" in listing
     assert "Acme notes" in listing
     assert "sess-acme-1" in listing or "hello from sess-acme-1" in listing
@@ -255,8 +255,8 @@ async def test_new_user_reads_the_shared_wiki_before_they_have_written(client: A
     assert resp.status_code == 200, resp.text
     listing = resp.json()["stdout"]
     assert "Fault codes" in listing
-    # It owns nothing yet — no notepad, no sessions of its own.
-    assert "notepad" not in listing
+    # It owns nothing yet — no wiki folder, no sessions of its own.
+    assert "wiki" not in listing
 
 
 @pytest.mark.asyncio
@@ -453,14 +453,14 @@ async def test_console_files_split_by_wiki_and_user(client: AsyncClient, pool):
     end_users = {
         r["external_id"]: r
         for r in await pool.fetch(
-            "SELECT external_id, notepad_folder_id FROM end_users WHERE workspace_id = $1",
+            "SELECT external_id, wiki_folder_id FROM end_users WHERE workspace_id = $1",
             uuid.UUID(workspace["id"]),
         )
     }
     scope_id = uuid.UUID(workspace["scope_user_id"])
     for name, folder_id in [
         ("Fault codes", uuid.UUID(workspace["external_wiki_folder_id"])),
-        ("Acme notes", end_users["org_acme"]["notepad_folder_id"]),
+        ("Acme notes", end_users["org_acme"]["wiki_folder_id"]),
     ]:
         await pool.execute(
             "INSERT INTO pages (owner_user_id, name, content_markdown, folder_id, created_by) "
@@ -478,8 +478,8 @@ async def test_console_files_split_by_wiki_and_user(client: AsyncClient, pool):
     body = resp.json()
     assert [p["name"] for p in body["wiki_pages"]] == ["Fault codes"]
     by_user = {u["external_id"]: u for u in body["users"]}
-    assert [p["name"] for p in by_user["org_acme"]["notepad_pages"]] == ["Acme notes"]
-    assert by_user["org_beta"]["notepad_pages"] == []
+    assert [p["name"] for p in by_user["org_acme"]["wiki_pages"]] == ["Acme notes"]
+    assert by_user["org_beta"]["wiki_pages"] == []
 
 
 @pytest.mark.asyncio
@@ -564,14 +564,14 @@ async def test_user_wiki_graph(client: AsyncClient, pool):
     end_users = {
         r["external_id"]: r
         for r in await pool.fetch(
-            "SELECT id, external_id, notepad_folder_id FROM end_users WHERE workspace_id = $1",
+            "SELECT id, external_id, wiki_folder_id FROM end_users WHERE workspace_id = $1",
             uuid.UUID(workspace["id"]),
         )
     }
     scope_id = uuid.UUID(workspace["scope_user_id"])
     for name, folder_id in [
-        ("Acme notes", end_users["org_acme"]["notepad_folder_id"]),
-        ("Beta notes", end_users["org_beta"]["notepad_folder_id"]),
+        ("Acme notes", end_users["org_acme"]["wiki_folder_id"]),
+        ("Beta notes", end_users["org_beta"]["wiki_folder_id"]),
     ]:
         await pool.execute(
             "INSERT INTO pages (owner_user_id, name, content_markdown, folder_id, created_by) "

--- a/examples/external-multiplayer/README.md
+++ b/examples/external-multiplayer/README.md
@@ -42,7 +42,7 @@ the lesson without learning that Acme exists.
 
 ## What to look at in the console
 
-- **Users** — each customer, their sessions, files, connected sources, notepad.
+- **Users** — each customer, their sessions, files, connected sources, their own wiki.
 - **Curator** — when it next runs, the exact prompt it will send, and which
   users feed the shared wiki.
 - **Shared Wiki** — what every customer's agent reads. No user named anywhere.

--- a/examples/external-multiplayer/agent.py
+++ b/examples/external-multiplayer/agent.py
@@ -17,7 +17,7 @@ name — you do not know who they are."""
 
 def answer(stash, anthropic_key: str, org: str, org_name: str, session: str, question: str) -> str:
     # Read this customer's world before answering: the shared wiki everyone's
-    # agent reads, plus this customer's own notepad.
+    # agent reads, plus this customer's own wiki.
     context = _context(stash, org)
     reply = _claude(anthropic_key, context, question)
     stash.record(org, org_name, session, [("user_message", question), ("assistant_message", reply)])
@@ -26,11 +26,11 @@ def answer(stash, anthropic_key: str, org: str, org_name: str, session: str, que
 
 def _context(stash, org: str) -> str:
     """Everything this customer is allowed to know: the shared wiki, and their
-    own notepad. `find` lists every page in the tree (wiki categories are
+    own wiki. `find` lists every page in the tree (shared-wiki categories are
     subfolders, so a root glob would miss them); each page is cat'd on its
     own because the VFS cat fails the whole command on any bad path."""
     parts = []
-    for root in ("/memory", "/files/notepad"):
+    for root in ("/memory", "/files/wiki"):
         listing = stash.read(org, f"find {root} -type f -name '*.md'").strip()
         for path in listing.splitlines():
             parts.append(stash.read(org, f"cat '{path}'"))

--- a/examples/external-multiplayer/stash.py
+++ b/examples/external-multiplayer/stash.py
@@ -2,7 +2,7 @@
 
 Write a turn with your own id for the user; read back with the same id.
 That is the entire External Multiplayer contract — everything else (per-user
-notepads, the anonymized cross-user wiki, isolation) is Stash's job.
+wikis, the anonymized cross-user wiki, isolation) is Stash's job.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -20,7 +20,7 @@ class Stash:
 
     def read(self, user: str, script: str) -> str:
         """Run a read against this user's view of the stash. They see the
-        shared wiki at /memory, their own notepad and files under /files, and
+        shared wiki at /memory, their own wiki and files under /files, and
         only their own transcripts under /sessions."""
         resp = self._http.post("/api/v1/me/vfs", json={"script": script, "user_id": user})
         resp.raise_for_status()

--- a/frontend/src/app/(app)/developer/files/page.tsx
+++ b/frontend/src/app/(app)/developer/files/page.tsx
@@ -89,7 +89,7 @@ function Files() {
 }
 
 function UserFiles({ user }: { user: DeveloperUserFiles }) {
-  const empty = user.notepad_pages.length === 0 && user.files.length === 0;
+  const empty = user.wiki_pages.length === 0 && user.files.length === 0;
   return (
     <div className="mt-6">
       <Link
@@ -107,7 +107,7 @@ function UserFiles({ user }: { user: DeveloperUserFiles }) {
         </p>
       ) : (
         <div className="mt-2 overflow-hidden rounded border border-border bg-surface">
-          {user.notepad_pages.map((page) => (
+          {user.wiki_pages.map((page) => (
             <PageLine key={page.id} page={page} />
           ))}
           {user.files.map((file) => (

--- a/frontend/src/app/(app)/developer/users/[userId]/page.tsx
+++ b/frontend/src/app/(app)/developer/users/[userId]/page.tsx
@@ -45,7 +45,7 @@ function UserDetail() {
         setUser(res.user);
         setSessions(res.sessions);
         setFiles(res.files);
-        setWikiPages(res.notepad_pages);
+        setWikiPages(res.wiki_pages);
         setSources(res.sources);
       })
       .catch((e) => setError(e instanceof Error ? e.message : "Failed to load the user"));
@@ -104,7 +104,7 @@ function UserDetail() {
         <div className="flex items-baseline justify-between gap-4">
           <SectionHeading>This user&apos;s wiki</SectionHeading>
           <Link
-            href={`/folders/${user.notepad_folder_id}`}
+            href={`/folders/${user.wiki_folder_id}`}
             className="text-[13px] text-muted-foreground transition-colors hover:text-foreground"
           >
             Open folder

--- a/frontend/src/app/(app)/developer/wiki/page.tsx
+++ b/frontend/src/app/(app)/developer/wiki/page.tsx
@@ -174,7 +174,7 @@ function UserWikiCard({ user }: { user: EndUser }) {
           {user.external_id}
         </span>
         <Link
-          href={`/folders/${user.notepad_folder_id}`}
+          href={`/folders/${user.wiki_folder_id}`}
           className="shrink-0 text-[13px] text-muted-foreground transition-colors hover:text-foreground"
         >
           Open wiki

--- a/frontend/src/components/developer/agentPrompts.ts
+++ b/frontend/src/components/developer/agentPrompts.ts
@@ -35,7 +35,7 @@ user's memory and put it in the system prompt:
    stdout is markdown: the shared wiki every user's agent reads. Wiki
    categories are subfolders — "ls /memory" lists them,
    "cat /memory/<category>/*.md" reads one.
-   Also on the same call: "cat /files/notepad/*.md" (this user's own
+   Also on the same call: "cat /files/wiki/*.md" (this user's own
    wiki — it exists once the curator has run over their sessions),
    "ls /sessions" and raw transcripts under /sessions. Reading has
    nothing to do with which conversation you are in — no session id

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -297,8 +297,8 @@ export interface DeveloperUserFiles {
   id: string;
   name: string;
   external_id: string;
-  notepad_folder_id: string;
-  notepad_pages: DeveloperPageRow[];
+  wiki_folder_id: string;
+  wiki_pages: DeveloperPageRow[];
   files: DeveloperFileRow[];
 }
 
@@ -400,7 +400,7 @@ export async function getUser(userId: string): Promise<{
   user: EndUser;
   sessions: EndUserSession[];
   files: EndUserFile[];
-  notepad_pages: EndUserWikiPage[];
+  wiki_pages: EndUserWikiPage[];
   sources: EndUserSource[];
 }> {
   return apiFetch(`${ME}/users/${userId}`);

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -349,7 +349,7 @@ export interface EndUser {
   external_id: string;
   name: string;
   share_wiki: boolean;
-  notepad_folder_id: string;
+  wiki_folder_id: string;
   created_at: string;
   session_count: number;
   last_session_at: string | null;


### PR DESCRIPTION
we had this concept of per-user notepads that we were using as part of our vocab when planning, but we want the user-specific memory store to be referred to as a wiki.



# Slop
Planning-era vocabulary retired. The per-user memory surface of External Multiplayer is the user's own wiki — the console copy, the pricing page, and the wiki-graph endpoints already said so; this makes the schema and every remaining surface say it too.

- **Migration 0200**: `end_users.notepad_folder_id` → `wiki_folder_id`, `workspaces.end_user_notepads_folder_id` → `end_user_wikis_folder_id`, each workspace's "User Notepads" folder → "User Wikis" (same pattern as the 0196 tenant→user rename; prod's existing developer workspaces are carried forward).
- **API fields**: `notepad_pages` → `wiki_pages`, `notepad_folder_id` → `wiki_folder_id`.
- **End-user VFS mount**: `/files/notepad` → `/files/wiki`; install prompt and example client follow.
- **External curator prompt**: reworked around "per-user wikis" vs "the shared wiki" — every formerly bare "wiki" now says which one it means.
- Where one context holds both surfaces, the shared one is explicitly `shared_wiki_folder_id` — a naive rename collided keys in the end-user VFS context and shadowed the shared list in the console files endpoint (one caught by ruff, one by the existing console-files test).

The word survives only in already-shipped migrations 0189–0196 (immutable history; 0200 renames what they create) and in 0200 itself.

Deploy note: a column rename has the usual brief old-code/new-schema window during the deploy, touching only developer-platform endpoints — same as 0194/0196.

Tested: full backend suite, frontend vitest, ruff. The Heavi cutover PR stacks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Column renames need a coordinated deploy (brief old-code/new-schema window on developer-platform paths), and integrators must adopt new JSON fields and `/files/wiki` instead of `/files/notepad`.
> 
> **Overview**
> Retires **notepad** naming for External Multiplayer’s per-customer memory surface and aligns schema, APIs, VFS, curator prompts, console, and examples with **per-user wiki** vs **shared wiki**.
> 
> **Migration 0200** renames `end_users.notepad_folder_id` → `wiki_folder_id`, `workspaces.end_user_notepads_folder_id` → `end_user_wikis_folder_id`, and renames each workspace’s **User Notepads** container folder to **User Wikis** (reversible downgrade).
> 
> **Developer API** responses and types use `wiki_folder_id` and `wiki_pages` instead of `notepad_folder_id` / `notepad_pages`. New workspaces get a **User Wikis** folder on activation; new end users still get a folder under that container.
> 
> **End-user VFS** moves the private tree from `/files/notepad` to `/files/wiki`. The scoped context now uses **`shared_wiki_folder_id`** for `/memory` and **`wiki_folder_id`** for the user’s own wiki so the two surfaces don’t collide in one dict.
> 
> External curator copy and routing language are updated to **per-user wikis** and **shared wiki**; behavior is unchanged aside from naming and mounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 620429cb6c6ec0eb89dcee65bfeefc5d30ae428a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->