### PR TITLE
The curator feed excludes end-user material unless asked

### DIFF
--- a/backend/routers/files_tree.py
+++ b/backend/routers/files_tree.py
@@ -219,17 +219,24 @@ async def get_local_curator_prompt(
 @router.get("/changes")
 async def get_changes(
     since: str | None = None,
+    include_end_users: bool = False,
     current_user: dict = Depends(get_current_user),
     scope_user_id: UUID = Depends(get_scope),
 ):
     """The incremental change feed the Memory curator reads: history, changed
-    pages (excl. Memory), new files, and connected sources since `since`."""
+    pages (excl. Memory), new files, and connected sources since `since`.
+
+    End-user material (a developer's customers' sessions, pages, files, and
+    per-user Drive documents) is excluded by default — only the external
+    curator reads customer content, and it opts in with include_end_users."""
     from datetime import datetime
 
     from ..services import curation_service
 
     since_dt = datetime.fromisoformat(since) if since else None
-    return await curation_service.changes_since(scope_user_id, current_user["id"], since_dt)
+    return await curation_service.changes_since(
+        scope_user_id, current_user["id"], since_dt, include_end_users=include_end_users
+    )
 
 
 @router.post("/memory/recompute", status_code=202)

--- a/backend/services/curation_service.py
+++ b/backend/services/curation_service.py
@@ -7,6 +7,12 @@ and the user's connected sources as pointers (the agent pulls source
 specifics with `stash search`) — the curator never sees its own output.
 `has_changes_since` is the cheap EXISTS the beat task uses to skip idle users
 without waking a sprite.
+
+End-user material — sessions, pages, files, and Drive documents belonging to
+a developer's customers — is excluded unless the caller passes
+`include_end_users`: only the external curator reads customer content, and
+it opts in explicitly. Everything else (the internal curator foremost) never
+receives it at all.
 """
 
 from __future__ import annotations
@@ -29,28 +35,52 @@ _MAX_SOURCE_DOCS = 100
 _SNIPPET = 280
 
 
-async def has_changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | None) -> bool:
+async def has_changes_since(
+    owner_user_id: UUID,
+    user_id: UUID,
+    since: datetime | None,
+    include_end_users: bool = False,
+) -> bool:
     """True if anything the curator cares about changed after `since`. A cheap
     gate — the beat task skips a curator run (and the sprite wake) when False."""
     if since is None:
         return True  # never curated → bootstrap.
     pool = get_pool()
     memory_ids = await files_tree_service.memory_subtree_folder_ids(owner_user_id)
+    end_user_events = (
+        ""
+        if include_end_users
+        else (
+            " AND NOT EXISTS (SELECT 1 FROM sessions s"
+            "                 WHERE s.owner_user_id = he.owner_user_id"
+            "                   AND s.session_id = he.session_id"
+            "                   AND s.end_user_id IS NOT NULL)"
+        )
+    )
+    own = "" if include_end_users else " AND end_user_id IS NULL"
+    end_user_docs = (
+        ""
+        if include_end_users
+        else (
+            " AND NOT EXISTS (SELECT 1 FROM user_sources us"
+            "                 WHERE us.id = dd.source_id AND us.end_user_id IS NOT NULL)"
+        )
+    )
     exists = await pool.fetchval(
-        """
+        f"""
         SELECT
-          EXISTS (SELECT 1 FROM history_events
+          EXISTS (SELECT 1 FROM history_events he
                   WHERE owner_user_id = $1 AND created_at > $2
-                    AND (session_id IS NULL OR session_id NOT LIKE 'agent-curate-%'))
+                    AND (session_id IS NULL OR session_id NOT LIKE 'agent-curate-%'){end_user_events})
           OR EXISTS (SELECT 1 FROM pages
                      WHERE owner_user_id = $1 AND updated_at > $2
                        AND ($3::uuid[] IS NULL OR folder_id IS NULL
-                            OR folder_id <> ALL($3)))
+                            OR folder_id <> ALL($3)){own})
           OR EXISTS (SELECT 1 FROM files
-                     WHERE owner_user_id = $1 AND created_at > $2)
-          OR EXISTS (SELECT 1 FROM drive_documents
+                     WHERE owner_user_id = $1 AND created_at > $2{own})
+          OR EXISTS (SELECT 1 FROM drive_documents dd
                      WHERE owner_user_id = $1 AND updated_at > $2
-                       AND extraction_status = 'done' AND deleted_at IS NULL)
+                       AND extraction_status = 'done' AND deleted_at IS NULL{end_user_docs})
           OR EXISTS (SELECT 1 FROM x_save_docs
                      WHERE owner_user_id = $1 AND updated_at > $2
                        AND hydration_status = 'done' AND deleted_at IS NULL)
@@ -66,15 +96,23 @@ async def has_changes_since(owner_user_id: UUID, user_id: UUID, since: datetime 
     return bool(exists)
 
 
-async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | None) -> dict:
+async def changes_since(
+    owner_user_id: UUID,
+    user_id: UUID,
+    since: datetime | None,
+    include_end_users: bool = False,
+) -> dict:
     """The delta the curator reads: history events, changed pages (excl. Memory),
     new files, changed Drive-folder documents, newly hydrated X/Instagram
     saves, and connected-source pointers."""
     pool = get_pool()
     memory_ids = await files_tree_service.memory_subtree_folder_ids(owner_user_id)
     exclude = list(memory_ids) or None
+    own = "" if include_end_users else " AND end_user_id IS NULL"
 
-    events, history_has_more = await _feed_events(owner_user_id, since, None, _MAX_EVENTS)
+    events, history_has_more = await _feed_events(
+        owner_user_id, since, None, _MAX_EVENTS, include_end_users=include_end_users
+    )
     history = [
         {
             "session_id": e.get("session_id"),
@@ -89,13 +127,13 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
     ]
 
     page_rows = await pool.fetch(
-        """
+        f"""
         SELECT id, name, folder_id, updated_at,
                left(coalesce(content_markdown, ''), $4) AS snippet
         FROM pages
         WHERE owner_user_id = $1
           AND ($5::uuid[] IS NULL OR folder_id IS NULL OR folder_id <> ALL($5))
-          AND ($2::timestamptz IS NULL OR updated_at > $2)
+          AND ($2::timestamptz IS NULL OR updated_at > $2){own}
         ORDER BY updated_at DESC LIMIT $3
         """,
         owner_user_id,
@@ -116,10 +154,10 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
     ]
 
     file_rows = await pool.fetch(
-        """
+        f"""
         SELECT id, name, created_at, left(coalesce(extracted_text, ''), $4) AS snippet
         FROM files
-        WHERE owner_user_id = $1 AND ($2::timestamptz IS NULL OR created_at > $2)
+        WHERE owner_user_id = $1 AND ($2::timestamptz IS NULL OR created_at > $2){own}
         ORDER BY created_at DESC LIMIT $3
         """,
         owner_user_id,
@@ -143,13 +181,21 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
     # `updated_at` moves only on a real change: the sync upsert bumps it when
     # Drive's modifiedTime differs, and extraction bumps it when the new body
     # lands. Gating on 'done' presents a doc only once its text is readable.
+    end_user_docs = (
+        ""
+        if include_end_users
+        else (
+            " AND NOT EXISTS (SELECT 1 FROM user_sources us"
+            "                 WHERE us.id = dd.source_id AND us.end_user_id IS NOT NULL)"
+        )
+    )
     source_doc_rows = await pool.fetch(
-        """
+        f"""
         SELECT path, name, updated_at, left(coalesce(content, ''), $4) AS snippet
-        FROM drive_documents
+        FROM drive_documents dd
         WHERE owner_user_id = $1
           AND ($2::timestamptz IS NULL OR updated_at > $2)
-          AND extraction_status = 'done' AND deleted_at IS NULL
+          AND extraction_status = 'done' AND deleted_at IS NULL{end_user_docs}
         ORDER BY updated_at DESC LIMIT $3
         """,
         owner_user_id,
@@ -212,6 +258,7 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
         {"source": s.get("source"), "type": s.get("type"), "display_name": s.get("display_name")}
         for s in all_sources
         if not str(s.get("type", "")).startswith("native_")
+        and (include_end_users or not s.get("end_user_id"))
     ]
 
     return {
@@ -239,6 +286,7 @@ async def _feed_events(
     since: datetime | None,
     until: datetime | None,
     limit: int,
+    include_end_users: bool = False,
 ) -> tuple[list[dict], bool]:
     """The curator's event feed, oldest first. Returns (events, has_more).
 
@@ -254,6 +302,8 @@ async def _feed_events(
     pool = get_pool()
     args: list = [owner_user_id]
     where = "he.owner_user_id = $1 AND (he.session_id IS NULL OR he.session_id NOT LIKE 'agent-curate-%')"
+    if not include_end_users:
+        where += " AND s.end_user_id IS NULL"
     if since is not None:
         args.append(since)
         where += f" AND he.created_at > ${len(args)}"
@@ -276,7 +326,10 @@ async def _feed_events(
 
 
 async def complete_through(
-    owner_user_id: UUID, since: datetime | None, until: datetime
+    owner_user_id: UUID,
+    since: datetime | None,
+    until: datetime,
+    include_end_users: bool = False,
 ) -> datetime:
     """How far the curator's watermark may advance after a successful run.
 
@@ -285,7 +338,9 @@ async def complete_through(
     microsecond, so events sharing that exact timestamp are re-presented next
     run rather than skipped. Overflow therefore drains run by run and no event
     is ever silently dropped from curation."""
-    events, has_more = await _feed_events(owner_user_id, since, until, _MAX_EVENTS)
+    events, has_more = await _feed_events(
+        owner_user_id, since, until, _MAX_EVENTS, include_end_users=include_end_users
+    )
     if not has_more:
         return until
     return events[-1]["created_at"] - timedelta(microseconds=1)

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -196,10 +196,6 @@ Use the `stash` CLI for everything — every subcommand supports `--json`.
 - `history_has_more: true` means the history overflowed this run's cap. The
   remainder is already queued for your next run (the watermark only advances
   through what you were shown) — curate what's present, don't try to page.
-- An event carrying a `user` is External Multiplayer material: a customer of
-  the owner's product, curated by the external curator into that customer's
-  own wiki and the shared external wiki. Skip those events entirely —
-  customer material never feeds this internal Memory wiki.
 - Each history event carries its session's `folder`. Folder placement is the
   owner's deliberate curation signal: sessions filed into a named folder share
   a context (a customer, a team, a project) — attribute what you learn to that
@@ -335,7 +331,13 @@ def render_external_curator_prompt(
         if since
         else "the full history (this is the first run — bootstrap both artifacts)"
     )
-    changes_cmd = f"stash changes --since {since} --json" if since else "stash changes --json"
+    # The feed excludes end-user material by default; this curator is the one
+    # reader that legitimately wants it.
+    changes_cmd = (
+        f"stash changes --since {since} --include-end-users --json"
+        if since
+        else "stash changes --include-end-users --json"
+    )
     user_lines = "\n".join(
         f"- `{end_user['name']}` — wiki folder id `{end_user['wiki_folder_id']}`"
         + ("" if end_user["share_wiki"] else " — **opted out of the shared wiki**")

--- a/backend/tasks/agent_schedules.py
+++ b/backend/tasks/agent_schedules.py
@@ -74,7 +74,10 @@ async def _run_curator_now(
         # the beat's minute-stamped run.
         await sprite_agent_service.run_scheduled(agent, now.strftime("%Y%m%d%H%M%S"))
         through = await curation_service.complete_through(
-            UUID(str(agent["user_id"])), agent["curated_through"], now
+            UUID(str(agent["user_id"])),
+            agent["curated_through"],
+            now,
+            include_end_users=agent.get("curator_wiki") == "external",
         )
         await agent_service.mark_curated(agent_id, through)
         await agent_service.mark_run_succeeded(agent_id)
@@ -140,7 +143,10 @@ async def _maybe_dispatch_first_day_run(scope_user_id: UUID, agent: dict, now: d
     except (agent_auth.NeedsAuth, agent_auth.ProviderNotConfigured):
         return
     if not await curation_service.has_changes_since(
-        scope_user_id, scope_user_id, agent["curated_through"]
+        scope_user_id,
+        scope_user_id,
+        agent["curated_through"],
+        include_end_users=agent.get("curator_wiki") == "external",
     ):
         return
     # Unmetered: the platform is the trigger, so the run must not eat the
@@ -184,7 +190,10 @@ async def _run_due() -> int:
         # Cost gate: skip the curator (and the sprite wake) when nothing changed
         # since its watermark. Idle users cost one EXISTS per day.
         if agent["is_curator"] and not await curation_service.has_changes_since(
-            user_id, user_id, agent["curated_through"]
+            user_id,
+            user_id,
+            agent["curated_through"],
+            include_end_users=agent.get("curator_wiki") == "external",
         ):
             await agent_service.mark_run_skipped(agent["id"], "no_changes")
             continue
@@ -216,7 +225,10 @@ async def _run_scheduled_agent(agent_id: UUID, stamp: str) -> None:
             # failures share the run's try so they also record last_run_error
             # and alert, instead of dying as a bare task error.
             through = await curation_service.complete_through(
-                user_id, agent["curated_through"], now
+                user_id,
+                agent["curated_through"],
+                now,
+                include_end_users=agent.get("curator_wiki") == "external",
             )
             await agent_service.mark_curated(agent_id, through)
         await agent_service.mark_run_succeeded(agent_id)
@@ -252,7 +264,8 @@ async def _alert_stale_curators() -> int:
     cutoff = datetime.now(UTC) - timedelta(hours=STALE_CURATOR_HOURS)
     rows = await get_pool().fetch(
         """
-        SELECT a.user_id, a.curated_through, a.last_run_error, a.last_run_outcome, u.email
+        SELECT a.user_id, a.curated_through, a.last_run_error, a.last_run_outcome,
+               a.curator_wiki, u.email
         FROM agents a JOIN users u ON u.id = a.user_id
         WHERE a.is_curator AND a.run_mode = 'scheduled'
           AND a.curated_through IS NOT NULL AND a.curated_through < $1
@@ -264,7 +277,10 @@ async def _alert_stale_curators() -> int:
         r
         for r in rows
         if await curation_service.has_changes_since(
-            r["user_id"], r["user_id"], r["curated_through"]
+            r["user_id"],
+            r["user_id"],
+            r["curated_through"],
+            include_end_users=r["curator_wiki"] == "external",
         )
     ]
     if not stale:

--- a/backend/tests/test_agent_schedule_alerts.py
+++ b/backend/tests/test_agent_schedule_alerts.py
@@ -183,7 +183,7 @@ async def test_run_bookkeeping_failure_sends_alert(client: AsyncClient, monkeypa
     async def fake_run_scheduled(agent, stamp):
         return ""
 
-    async def boom(user_id, curated_through, now):
+    async def boom(user_id, curated_through, now, include_end_users=False):
         raise RuntimeError("watermark write failed")
 
     monkeypatch.setattr(sprite_agent_service, "run_scheduled", fake_run_scheduled)
@@ -215,7 +215,7 @@ async def test_run_due_records_no_changes_skip(client: AsyncClient, monkeypatch)
     async def fake_resolve(user_id, prefer_provider=None):
         return None
 
-    async def no_changes(owner_user_id, user_id, since):
+    async def no_changes(owner_user_id, user_id, since, include_end_users=False):
         return False
 
     monkeypatch.setattr(agent_auth, "resolve", fake_resolve)

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -600,7 +600,7 @@ async def test_manual_recompute_bookkeeping_failure_records_failed_outcome(
     _key, uid = await _register(client)
     curator = await agent_service.get_or_create_curator(uid)
 
-    async def boom(user_id, curated_through, now):
+    async def boom(user_id, curated_through, now, include_end_users=False):
         raise RuntimeError("watermark write failed")
 
     monkeypatch.setattr(curation_service, "complete_through", boom)

--- a/backend/tests/test_developer_platform.py
+++ b/backend/tests/test_developer_platform.py
@@ -260,6 +260,52 @@ async def test_new_user_reads_the_shared_wiki_before_they_have_written(client: A
 
 
 @pytest.mark.asyncio
+async def test_change_feed_excludes_end_user_material_by_default(client: AsyncClient, pool):
+    """The internal curator (and any bare `stash changes` caller) must never
+    receive customer material — exclusion happens in the feed, not by asking
+    a model to ignore what it was shown. Only the external curator opts in
+    with include_end_users."""
+    api_key, _, workspace = await _developer(client)
+    machine_key = await _mint_workspace_key(client, api_key, workspace)
+    scope = {**_auth(api_key), "X-Stash-Scope": workspace["scope_user_id"]}
+
+    await _push(
+        client,
+        machine_key,
+        [
+            _event("sess-cust-1", user_id="org_acme", user_name="Acme"),
+            _event("sess-own-1"),
+        ],
+    )
+    # A page in the customer's own wiki — end-user material too.
+    end_user = await pool.fetchrow(
+        "SELECT id, wiki_folder_id FROM end_users WHERE workspace_id = $1",
+        uuid.UUID(workspace["id"]),
+    )
+    await pool.execute(
+        "INSERT INTO pages (owner_user_id, name, content_markdown, folder_id, "
+        "                   created_by, end_user_id) "
+        "VALUES ($1, 'Acme secrets', 'body', $2, $1, $3)",
+        uuid.UUID(workspace["scope_user_id"]),
+        end_user["wiki_folder_id"],
+        end_user["id"],
+    )
+
+    resp = await client.get("/api/v1/me/changes", headers=scope)
+    assert resp.status_code == 200, resp.text
+    feed = resp.json()
+    assert "sess-own-1" in str(feed["history"])
+    assert "sess-cust-1" not in str(feed)
+    assert "Acme secrets" not in str(feed)
+
+    resp = await client.get("/api/v1/me/changes?include_end_users=true", headers=scope)
+    assert resp.status_code == 200
+    feed = resp.json()
+    assert "sess-cust-1" in str(feed["history"])
+    assert "Acme secrets" in str(feed["pages"])
+
+
+@pytest.mark.asyncio
 async def test_user_scoped_source_is_visible_to_that_user_only(client: AsyncClient, pool):
     """A developer can connect a source (e.g. a customer's Drive folder) FOR
     one end user: `user_id` on the connect call stamps the source, that user's

--- a/backend/tests/test_first_day_curator.py
+++ b/backend/tests/test_first_day_curator.py
@@ -27,10 +27,31 @@ def dispatched(monkeypatch):
 
 
 async def _workspace_with_conversation(client: AsyncClient) -> UUID:
+    """A fresh developer workspace with both kinds of day-one activity: a
+    customer conversation (external material) and the developer's own
+    session (internal material)."""
+    api_key, _, workspace = await _developer(client)
+    ws_key = await _mint_workspace_key(client, api_key, workspace)
+    await _push(
+        client,
+        ws_key,
+        [_event("s-1", user_id="cust-1", user_name="Cust"), _event("s-own")],
+    )
+    return UUID(workspace["scope_user_id"])
+
+
+@pytest.mark.asyncio
+async def test_customer_only_activity_feeds_only_the_external_curator(
+    client: AsyncClient, pool, dispatched
+):
+    """Customer material never reaches the internal curator — its gate, like
+    its feed, excludes end-user activity, so a workspace whose only day-one
+    events are customers' dispatches the external pass alone."""
     api_key, _, workspace = await _developer(client)
     ws_key = await _mint_workspace_key(client, api_key, workspace)
     await _push(client, ws_key, [_event("s-1", user_id="cust-1", user_name="Cust")])
-    return UUID(workspace["scope_user_id"])
+    await _first_day_curator_tick(UUID(workspace["scope_user_id"]))
+    assert await _dispatched_wikis(pool, dispatched) == {"external"}
 
 
 async def _dispatched_wikis(pool, dispatched) -> set[str]:

--- a/cli/client.py
+++ b/cli/client.py
@@ -380,8 +380,10 @@ class StashClient:
         Returns {stdout, stderr, exit_code} like a shell would."""
         return self._post("/api/v1/me/vfs", json={"script": script, "cwd": cwd})
 
-    def get_changes(self, since: str | None = None) -> dict:
-        params = {"since": since} if since else {}
+    def get_changes(self, since: str | None = None, include_end_users: bool = False) -> dict:
+        params: dict = {"since": since} if since else {}
+        if include_end_users:
+            params["include_end_users"] = "true"
         return self._get("/api/v1/me/changes", **params)
 
     def recompute_memory(self) -> dict:

--- a/cli/main.py
+++ b/cli/main.py
@@ -3447,12 +3447,18 @@ def memory_ls(as_json: bool = typer.Option(False, "--json")):
 @app.command("changes")
 def changes(
     since: str = typer.Option(None, "--since", help="ISO timestamp; omit for everything."),
+    include_end_users: bool = typer.Option(
+        False,
+        "--include-end-users",
+        help="Include end-user material (External Multiplayer customers' "
+        "sessions, pages, files). Only the external curator wants this.",
+    ),
     as_json: bool = typer.Option(False, "--json"),
 ):
     """What changed since a timestamp — history, pages, files, saves, sources.
     Feeds the Memory curator's incremental pass."""
     with _client() as c:
-        data = c.get_changes(since or None)
+        data = c.get_changes(since or None, include_end_users=include_end_users)
     if _use_json(as_json):
         output_json(data)
         return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.367"
+version = "0.1.368"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Stacks on #1091 (which stacks on #1090); merge those first — GitHub retargets automatically. This is the platform-behavior change pulled out of #1091 per review feedback: data-plane separation between the internal and external curators.

## What's here

Not two separate feeds — one feed with two shapes. `GET /me/changes` (i.e. `stash changes`) now **excludes end-user material by default, in SQL**: customer sessions' events, per-user wiki pages, per-user files, and documents from per-user Drive sources are absent from the response. The external curator is the one caller that opts in, via `stash changes --include-end-users` baked into its server-rendered prompt. The internal curator never sees customer content at all — the previous prompt-level "skip these events" instruction is deleted, since asking a model to ignore data it was shown is not isolation.

The scheduling gate and watermark bookkeeping honor the same split, so a workspace with customer-only activity never even wakes its internal curator.

## Why exclude-by-default, with the external curator opting in

Deployment: sprites install the CLI only when it's missing, so a new flag required by every internal curator would break curator runs fleet-wide until CLIs updated. Inverted, bare calls keep working unchanged everywhere; only external curators (a handful, on fresh machines) need CLI 0.1.368 — the version bump rides in this PR and publishes on merge. Side effect: any ad-hoc `stash changes` call is privacy-safe by default.

## Verification

- New test: an end-user session and a customer's wiki page are absent from the default feed, present with the flag.
- New test: a workspace with customer-only day-one activity dispatches the external curator alone.
- First-day curator tests re-premised (their old premise — customer conversations trigger the internal wiki — is the behavior being removed).
- Full backend + CLI suite: 1706 passed. Ruff clean.

A Review Desktop walkthrough of this change exists: "One curator feed, two shapes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes privacy boundaries and curator scheduling gates for developer workspaces; incorrect SQL filters could leak customer data to the internal curator or skip external curation.
> 
> **Overview**
> **One curator feed, two shapes:** `GET /me/changes` and `stash changes` gain `include_end_users` (default **off**). Customer sessions, per-user wiki pages/files, per-user Drive docs, and end-user sources are **filtered in SQL**, not left for the model to ignore.
> 
> The **internal Memory curator** never opts in; the prompt instruction to skip events with a `user` field is removed. The **external multiplayer curator** opts in via `stash changes --include-end-users` baked into its server-rendered prompt.
> 
> **Scheduling stays aligned:** `has_changes_since`, `changes_since`, and `complete_through` all take the same flag. Beat tasks, first-day curator, stale-curator alerts, and watermark advancement pass `include_end_users` when `curator_wiki == "external"`, so customer-only activity does not wake or advance the internal curator.
> 
> CLI **0.1.368** adds `--include-end-users` so existing internal curator installs keep working without a forced upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a101332fe850ea7fdbbbc989a2794c19e9704853. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->