### PR TITLE
fix(STAS-129): give harness agent tasks 90/95-min per-task celery time limits

### DIFF
--- a/backend/tasks/agent_schedules.py
+++ b/backend/tasks/agent_schedules.py
@@ -21,6 +21,16 @@ from ._celery_helpers import run_async
 
 logger = logging.getLogger(__name__)
 
+# A harness agent run (PI curation) routinely takes 13+ minutes and can
+# exceed 25 minutes on a large delta — the global 1500s soft / 1800s hard
+# ceiling (celery_app.py) was killing them mid-run: partial wiki writes
+# survive, but the run is marked failed and the watermark does not advance,
+# so the next run re-reads the same delta. These two tasks are the only
+# Celery tasks that run a harness agent; they carry their own limits so the
+# global stays the ceiling for everything else.
+HARNESS_SOFT_TIME_LIMIT = 5400  # 90 min
+HARNESS_TIME_LIMIT = 5700  # 95 min
+
 
 def _is_due(cron: str, last_run: datetime | None, now: datetime) -> bool:
     """True if a cron tick falls in (last_run, now]. Never fires on the very
@@ -39,12 +49,20 @@ def run_due() -> int:
     return run_async(_run_due())
 
 
-@celery.task(name="backend.tasks.agent_schedules.run_scheduled_agent")
+@celery.task(
+    name="backend.tasks.agent_schedules.run_scheduled_agent",
+    soft_time_limit=HARNESS_SOFT_TIME_LIMIT,
+    time_limit=HARNESS_TIME_LIMIT,
+)
 def run_scheduled_agent(agent_id: str, stamp: str) -> None:
     run_async(_run_scheduled_agent(UUID(agent_id), stamp))
 
 
-@celery.task(name="backend.tasks.agent_schedules.run_curator_now")
+@celery.task(
+    name="backend.tasks.agent_schedules.run_curator_now",
+    soft_time_limit=HARNESS_SOFT_TIME_LIMIT,
+    time_limit=HARNESS_TIME_LIMIT,
+)
 def run_curator_now(agent_id: str, full_history: bool = False, metered: bool = True) -> None:
     run_async(_run_curator_now(UUID(agent_id), full_history, metered))
 

--- a/backend/tests/test_celery_time_limits.py
+++ b/backend/tests/test_celery_time_limits.py
@@ -1,0 +1,53 @@
+"""Per-task time limits for the harness-execution tasks.
+
+PI curation runs routinely take 13+ minutes and exceed 25 minutes on large
+deltas. The global 1500s soft / 1800s hard ceiling (celery_app.py) killed
+them mid-run on 2026-08-24: the run was marked failed, the curated_through
+watermark did not advance, and the next run re-read the same delta. The two
+tasks that actually run a harness agent therefore carry their own limits,
+while the global stays the ceiling for everything else and the cheap beat
+dispatchers keep the global fallback so a sweep never holds a slot for 95
+minutes.
+"""
+
+from backend.celery_app import celery
+from backend.tasks.agent_schedules import (
+    alert_stale_curators,
+    first_day_curator_tick,
+    run_curator_now,
+    run_due,
+    run_scheduled_agent,
+)
+
+HARNESS_TASKS = [run_curator_now, run_scheduled_agent]
+DISPATCHER_TASKS = [run_due, first_day_curator_tick, alert_stale_curators]
+
+
+def test_harness_tasks_carry_extended_limits():
+    # 90 min soft / 95 min hard, comfortably above observed PI run durations
+    # (13–40+ min) while still bounding a runaway loop.
+    for task in HARNESS_TASKS:
+        assert task.soft_time_limit == 5400, task.name
+        assert task.time_limit == 5700, task.name
+
+
+def test_harness_limits_stay_ordered():
+    # Celery rejects soft > hard at dispatch time (celery/app/task.py), so a
+    # soft limit equal to or above the hard limit would kill runs at the
+    # wrong boundary.
+    for task in HARNESS_TASKS:
+        assert 0 < task.soft_time_limit < task.time_limit, task.name
+
+
+def test_dispatcher_tasks_keep_global_fallback():
+    # No per-task override: the worker pool applies the global conf defaults.
+    # A beat sweep must never hold a worker slot for 95 minutes.
+    for task in DISPATCHER_TASKS:
+        assert task.time_limit is None, task.name
+        assert task.soft_time_limit is None, task.name
+
+
+def test_global_limits_unchanged():
+    # The global ceiling stays as-is; only the harness tasks opt out.
+    assert celery.conf.task_time_limit == 1800
+    assert celery.conf.task_soft_time_limit == 1500


### PR DESCRIPTION
## STAS-129: Curator runs (PI harness) are being soft-killed

Global Celery soft time limit (1500s) kills PI harness curator runs mid-work (2 of 4 runs on 2026-08-24 in preview died at exactly 1500s). The run is marked failed, the curated_through watermark does not advance, and the next run re-reads the same delta.

### Change (surgical, per-task)
- backend/tasks/agent_schedules.py: module constants HARNESS_SOFT_TIME_LIMIT=5400 / HARNESS_TIME_LIMIT=5700, applied via soft_time_limit= / time_limit= on exactly two task decorators:
  - run_curator_now (manual + first-day curator runs)
  - run_scheduled_agent (nightly scheduled path — run_due hands off to it)
- backend/tests/test_celery_time_limits.py (new): 4 tests pinning (1) 5400/5700 on both harness tasks, (2) soft < hard ordering, (3) dispatcher tasks (run_due, first_day_curator_tick, alert_stale_curators) keep the global fallback (None attrs), (4) global conf unchanged (1800/1500).

### Verification
- Red baseline: with the fix reverted, the two harness tests fail (attrs None) and the two invariant tests pass — recorded.
- Green: 4/4 new tests pass; impacted suites 54/54 (test_celery_routing, test_curator, test_first_day_curator, test_plan_gate, test_agent_schedule_alerts); full backend suite 1436 tests, exit 0.
- Lint: ruff check + ruff format --check clean (CI-exact).
- Global limits in backend/celery_app.py unchanged (pinned by test).

### Acceptance still pending (operator-gated)
One preview re-run of a large delta completing past the old 25-min mark: worker log line Task backend.tasks.agent_schedules.run_curator_now[<id>] succeeded in Ns with N > 1500, no SoftTimeLimitExceeded in that run's window. Requires preview deploy + Render worker-log access.

Co-authored-by: Fusion <noreply@runfusion.ai>