### PR TITLE
feat(STAS-127): carry session folder in the curator change feed

### DIFF
--- a/backend/services/curation_service.py
+++ b/backend/services/curation_service.py
@@ -84,6 +84,7 @@ async def changes_since(owner_user_id: UUID, user_id: UUID, since: datetime | No
             "created_at": _iso(e.get("created_at")),
             "user": e.get("user"),
             "user_share_wiki": e.get("user_share_wiki"),
+            "session_folder": e.get("session_folder"),
         }
         for e in events
     ]
@@ -250,7 +251,8 @@ async def _feed_events(
     Each event carries its session's end user (name and wiki opt-out) when it
     has one — the external curator routes by it: every user's material feeds
     that user's own wiki, and only share_wiki users feed the shared anonymized
-    wiki."""
+    wiki. Events also carry the session's folder (name and id) or null — the
+    personal curator attributes learning to that folder's context."""
     pool = get_pool()
     args: list = [owner_user_id]
     where = "he.owner_user_id = $1 AND (he.session_id IS NULL OR he.session_id NOT LIKE 'agent-curate-%')"
@@ -262,11 +264,13 @@ async def _feed_events(
         where += f" AND he.created_at <= ${len(args)}"
     rows = await pool.fetch(
         f"SELECT he.session_id, he.agent_name, he.event_type, he.content, he.created_at, "
-        f"eu.name AS user, eu.share_wiki AS user_share_wiki "
+        f"eu.name AS user, eu.share_wiki AS user_share_wiki, "
+        f"sf.name AS session_folder, sf.id AS session_folder_id "
         f"FROM history_events he "
         f"LEFT JOIN sessions s ON s.owner_user_id = he.owner_user_id "
         f"  AND s.session_id = he.session_id "
         f"LEFT JOIN end_users eu ON eu.id = s.end_user_id "
+        f"LEFT JOIN session_folders sf ON sf.id = s.session_folder_id "
         f"WHERE {where} "
         f"ORDER BY he.created_at, he.id LIMIT {limit + 1}",
         *args,

--- a/backend/tests/test_curator.py
+++ b/backend/tests/test_curator.py
@@ -728,3 +728,111 @@ async def test_memory_tree_nests_folders_and_scopes_to_memory(client: AsyncClien
     files_tree = (await client.get("/api/v1/me/tree", headers=_auth(key))).json()
     assert [p["name"] for p in files_tree["pages"]] == ["Outside"]
     assert all(f["id"] != mem["id"] for f in files_tree["folders"])
+
+
+async def _file_session_into_folder(
+    client: AsyncClient, key: str, uid: UUID, pool, session_id: str
+) -> str:
+    """Create the "Acme Corp" folder, push one event for `session_id`, and
+    file that session into the folder through the production assign route.
+    Returns the folder id."""
+    r = await client.post(
+        "/api/v1/me/session-folders", json={"name": "Acme Corp"}, headers=_auth(key)
+    )
+    assert r.status_code == 200
+    folder = r.json()
+
+    await _push_events(
+        client,
+        key,
+        [
+            {
+                "agent_name": "heavi-chat",
+                "event_type": "user_message",
+                "content": "filing the session",
+                "session_id": session_id,
+                "created_at": datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC).isoformat(),
+            }
+        ],
+    )
+    row_id = await pool.fetchval(
+        "SELECT id FROM sessions WHERE owner_user_id = $1 AND session_id = $2",
+        uid,
+        session_id,
+    )
+    r = await client.post(
+        "/api/v1/me/session-folders/assign",
+        json={"session_row_ids": [str(row_id)], "folder_id": str(folder["id"])},
+        headers=_auth(key),
+    )
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "moved": 1}
+    return folder["id"]
+
+
+@pytest.mark.asyncio
+async def test_feed_carries_session_folder(client: AsyncClient, _db_pool):
+    """The personal curator prompt tells the curator that each history event
+    carries its session's folder — folder placement is the owner's deliberate
+    curation signal. The feed must actually deliver it: a filed session
+    presents its folder name (plus the id at row level), a bare session
+    presents null, and the pre-existing keys stay untouched."""
+    key, uid = await _register(client)
+    old = datetime(2020, 1, 1, tzinfo=UTC)
+
+    folder_id = await _file_session_into_folder(client, key, uid, _db_pool, "conv-folder")
+    await _push_events(
+        client,
+        key,
+        [
+            {
+                "agent_name": "heavi-chat",
+                "event_type": "user_message",
+                "content": "no folder here",
+                "session_id": "conv-bare",
+                "created_at": datetime(2026, 1, 1, 12, 5, 0, tzinfo=UTC).isoformat(),
+            }
+        ],
+    )
+
+    feed = await curation_service.changes_since(uid, uid, old)
+    by_session = {h["session_id"]: h for h in feed["history"]}
+    filed, bare = by_session["conv-folder"], by_session["conv-bare"]
+    assert filed["session_folder"] == "Acme Corp"
+    assert bare["session_folder"] is None
+    # The pre-existing contract is untouched: same keys, same values.
+    for h in (filed, bare):
+        assert h["agent_name"] == "heavi-chat"
+        assert h["event_type"] == "user_message"
+        assert h["content"]
+        assert h["created_at"]
+        assert h["user"] is None
+        assert h["user_share_wiki"] is None
+
+    # Row level carries the id too — 1:1, so no fan-out and no missing row.
+    rows, has_more = await curation_service._feed_events(uid, old, None, 100)
+    assert has_more is False
+    rows_by_session = {r["session_id"]: r for r in rows}
+    assert rows_by_session["conv-folder"]["session_folder"] == "Acme Corp"
+    assert rows_by_session["conv-folder"]["session_folder_id"] == UUID(folder_id)
+    assert rows_by_session["conv-bare"]["session_folder"] is None
+    assert rows_by_session["conv-bare"]["session_folder_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_changes_endpoint_exposes_session_folder(client: AsyncClient, _db_pool):
+    """GET /api/v1/me/changes is the exact JSON `stash changes --json` passes
+    through — the curator's actual input must carry the session's folder,
+    since the prompt's folder rules are dead text without it."""
+    key, uid = await _register(client)
+    old = datetime(2020, 1, 1, tzinfo=UTC)
+
+    await _file_session_into_folder(client, key, uid, _db_pool, "conv-folder")
+
+    r = await client.get(
+        "/api/v1/me/changes", params={"since": old.isoformat()}, headers=_auth(key)
+    )
+    assert r.status_code == 200
+    body = r.json()
+    entry = next(h for h in body["history"] if h["session_id"] == "conv-folder")
+    assert entry["session_folder"] == "Acme Corp"


### PR DESCRIPTION
## What / why

Founder-reported (CEO-verified, 2026-08-24): the personal curator prompt (`render_curator_prompt`)
tells the Memory curator that "Each history event carries its session's `folder`" and that folder
placement is the owner's deliberate curation signal — but the change feed never carried any folder
data, so the instruction was dead text. Sessions filed into per-project folders were still blended
into one undifferentiated wiki on every curator run (the "projects mixing" complaint).

This wires the existing signal through: the feed now carries each session's folder, so the prompt's
folder rules become operational.

## Change (additive only, 2 files)

- `backend/services/curation_service.py`
  - `_feed_events`: one additional `LEFT JOIN session_folders sf ON sf.id = s.session_folder_id`
    (1:1 on the PK — no row fan-out) and two additional selected columns,
    `sf.name AS session_folder, sf.id AS session_folder_id`.
  - `changes_since`: history events gain one key — **`session_folder`** (name string or `null`);
    the folder id stays at row level only (`session_folder_id`), per scope.
  - All pre-existing keys/values, joins, ordering, caps, and both prompt renderers untouched.
- `backend/tests/test_curator.py`: two new tests (+ a shared fixture helper), existing tests untouched:
  - `test_feed_carries_session_folder` — `changes_since` history carries `session_folder == "Acme
    Corp"` for a session filed through the production `POST /api/v1/me/session-folders/assign` route
    and `None` for an unfiled one; all pre-existing keys asserted intact; `_feed_events` rows carry
    `session_folder` + `session_folder_id` (name + uuid) for the filed session, both `None` for the
    bare one.
  - `test_changes_endpoint_exposes_session_folder` — `GET /api/v1/me/changes` (the exact JSON the
    curator consumes) includes `session_folder == "Acme Corp"` for the filed session.

Test summary: both tests were RED pre-implementation (failing specifically on the absent
`session_folder` key, `KeyError`) and GREEN post-implementation. Impacted run
(test_curator + test_first_day_curator + test_local_curator_prompt): 39 passed. Full backend suite
on a fresh pgvector test DB: all green, matching a green pre-change baseline run (no pre-existing
reds; the STAS-113-caveat lineage reds noted in the task do not exist on this base — see note below).
`ruff check backend/ cli/ && ruff format --check backend/ cli/`: clean (CI pin ruff 0.15.6).

## Verified unchanged

- **CLI verified unchanged (pass-through)** — `stash changes --json` passes the
  `/api/v1/me/changes` JSON through verbatim (`cli/main.py` → `cli/client.py get_changes` →
  `output_json`); the new key is additive and the external curator prompt does not reference
  folders, so it stays truthful.
- **No GUI (tracked separately per task)** — session-folder assignment in the GUI is a separate,
  already-tracked task; `session_folders` router/service, migrations, `files_tree.py` route,
  `has_changes_since`, `complete_through`, and both curator prompts are untouched.

## Lineage note

Branch `fusion/stas-127` is based on the origin/main tip **631ff161** (PR #1091 heavi-cutover
merge); it carries exactly one unique commit (`157f5377`, 2 files, additive). The task OD's closing
line "Rebase off local main (NOT origin/main) per the repo convention" is treated as a template
artifact and documented as N/A (see the task delivery document): the OD's own verified facts are
anchored on origin/main, the PR targets Fergana-Labs main, and local main (f346cd00, the STAS-1xx
integration line) is not an ancestor of origin/main — basing off it would put the entire STAS
divergence into the PR. All base anchors were re-verified at 631ff161 before writing code.

## STAS-113 caveat

The caveat class (origin-lineage `sessions.last_event_at` reds) was watched per the OD. On this
base the caveat file (`test_memory_semantic_search.py`) is absent and the full-suite baseline was
fully green, so no caveat reds exist to attribute — the post-change full suite is fully green as
well.
