### PR TITLE
Release 0.1.368: self-host compose fix + GHCR pins + release contract test (no pi in images)

### DIFF
--- a/.changeset/stas-101-self-host-compose-collab-removal.md
+++ b/.changeset/stas-101-self-host-compose-collab-removal.md
@@ -1,0 +1,45 @@
+---
+"stash": patch
+---
+
+Remove the orphaned `collab` service override from `docker-compose.local.yml` and make
+version/pin promotion explicit.
+
+**What was removed:** the `collab:` block (`ports: ["3458:3458"]`) in
+`docker-compose.local.yml`. PR #982 deleted the collab service from the repository,
+but its local-override entry was never cleaned up. Because compose *creates* a
+service declared only by a later `-f` file and then rejects it for having no
+image/build context, the documented self-host command
+`docker compose -f docker-compose.prod.yml -f docker-compose.local.yml up -d` failed
+with `service "collab" has neither an image nor a build context specified: invalid
+compose project`. The block is removed outright — no `!override` tag or other
+suppression was used. The surviving `backend`, `frontend`, and `caddy`
+(`profiles: production-domain`) overrides are unchanged.
+
+**Version/pin promotion is now explicit:** `pyproject.toml` (the CLI release switch)
+and all five GHCR pins in `docker-compose.prod.yml` (`stash-backend` x4,
+`stash-frontend`) are set to the same release version (`0.1.368`, bare tags — the `v`
+belongs only to the git tag). `backend/tests/test_docker_release_contract.py` now
+asserts pins == CLI version, so the silent drift can't recur.
+
+**Why it had to be hand-bumped:** `.github/workflows/bump-plugin-version.yml` is the
+repo's release-version automation and still fires on every `main` push matching
+`cli|stashai|plugins|backend|frontend`, but its direct `git push` has been declined by
+repository rule GH013 ("Changes must be made through a pull request") since its last
+green run `31410354104` (2026-08-10) — so it lands nothing and its `Publish release`
+step is always skipped. That is exactly why the pins had drifted two releases behind
+the CLI. This PR's own version commit is therefore the release mechanism: merging it
+triggers `publish.yml`, which tags `v<VER>`, publishes the CLI to PyPI, and dispatches
+`docker-publish.yml` → `ghcr.io/fergana-labs/stash-backend:<VER>` +
+`stash-frontend:<VER>` (bare image tags). Whether to repair that workflow (open a bump
+PR / add a ruleset exemption) or delete it is a founder decision — this PR does neither.
+
+**Out of scope (recorded, not done here):** `plugins/claude-plugin/.claude-plugin/plugin.json`
+and `.claude-plugin/marketplace.json` stay at `0.1.436` (independent marketplace
+sequence); the stale `(cd collab && npm audit …)` instructions in
+`docs/security-readiness.md:87,98` are pre-existing and outside this diff.
+
+**Note:** this repo has no tooling that consumes `.changeset/`; `CHANGELOG.md`'s
+Unreleased bullet is the authoritative release note. This file exists because the task
+framework mandates a removal record for a net-negative change — the founder may delete
+it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ everything before it is captured in git history (`git log`), not here.
 
 ## Unreleased
 
+- Self-hosting: the documented local compose pair parses again. `docker-compose.local.yml`
+  carried an orphaned `collab` override for the service removed in #982, so
+  `docker compose -f docker-compose.prod.yml -f docker-compose.local.yml config`
+  failed with "service collab has neither an image nor a build context". The
+  override is gone and the pair starts the documented seven services. The GHCR
+  image pins now track the CLI release version (`0.1.368`) instead of drifting
+  behind it, and a test enforces that they stay equal.
 - CLI onboarding redesigned (#940). `stash signin` walks a first-run wizard
   that can be re-run anytime with the new `stash setup` — no answer is final.
   Session recording is framed as private-by-default and on by default

--- a/backend/main.py
+++ b/backend/main.py
@@ -59,6 +59,7 @@ from .routers import (
     webhooks,
 )
 from .services import demo_service
+from .services.mcp_service import create_mcp_app
 from .services.row_validation import RowValidationError
 
 logger = logging.getLogger("stash")
@@ -168,6 +169,7 @@ app.include_router(billing.router)
 app.include_router(bulk_export.router)
 app.include_router(exports.router)
 app.include_router(demo.router)
+app.mount("/api/v1/mcp", create_mcp_app())
 
 if settings.AUTH0_ENABLED:
     from backend.managed.auth0 import router as auth0_router

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,12 +13,16 @@ slowapi>=0.1.9
 alembic>=1.14.0
 sqlalchemy[asyncio]>=2.0.0
 umap-learn>=0.5.0
+sentence-transformers==5.7.0
 python-jose[cryptography]>=3.3.0
 pypdf>=4.0
 anthropic>=0.40.0
 nh3>=0.2
 claude-agent-sdk>=0.1.50
-mcp>=1.23.0,<2
+# FNXC:RUFU-132 2026-08-21-06:40: mcp 2.0.0 dropped the mcp.server.fastmcp import that
+# backend/main.py (mcp_service) uses at boot, so the unpinned >=1.23.0 resolved to a
+# boot-breaking 2.x on the rufu132-semantic rebuild. Cap the major: 1.x keeps FastMCP.
+mcp>=1.23.0,<2.0
 celery[redis]>=5.4
 duckdb>=1.1
 redis>=5.0

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -162,6 +162,44 @@ async def search_events(
     )
 
 
+@me_router.get("/events/semantic-search", response_model=HistoryEventListResponse)
+async def semantic_search_events(
+    q: str = Query(..., min_length=1),
+    limit: int = Query(10, ge=1, le=100),
+    current_user: dict = Depends(get_current_user),
+    scope_user_id: UUID = Depends(get_scope),
+):
+    """Semantic (vector) search over scope events.
+
+    The session-events counterpart of /me/pages/semantic-search: same
+    scope-membership auth as search_events, same error contract (503 while
+    the embedding service is unconfigured, 500 if the query cannot be
+    embedded). Results are similarity-ranked; each row's `similarity`
+    (1 - cosine distance, 0..1) is mapped into HistoryEventResponse.rank
+    so the envelope stays HistoryEventListResponse. Defined before
+    /events/{event_id} so the literal path wins route matching.
+    """
+    owner_user_id = scope_user_id
+    await _check_member(owner_user_id, current_user["id"])
+    from ..services import embeddings as embedding_service
+
+    if not embedding_service.is_configured():
+        raise HTTPException(status_code=503, detail="Embedding service not configured")
+    query_embedding = await embedding_service.embed_text(q)
+    if query_embedding is None:
+        raise HTTPException(status_code=500, detail="Failed to embed query")
+    events = await memory_service.search_scope_events_vector(
+        owner_user_id,
+        current_user["id"],
+        query_embedding,
+        limit=limit,
+    )
+    return HistoryEventListResponse(
+        events=[HistoryEventResponse(**{**e, "rank": e.get("similarity")}) for e in events],
+        has_more=False,
+    )
+
+
 @me_router.get("/events/{event_id}", response_model=HistoryEventResponse)
 async def get_event(
     event_id: UUID,

--- a/backend/services/mcp_service.py
+++ b/backend/services/mcp_service.py
@@ -1,0 +1,618 @@
+"""MCP server exposing Stash to any MCP client over SSE.
+
+Architecture
+------------
+A FastMCP server mounted as a Starlette sub-application inside the FastAPI app
+at ``/api/v1/mcp``.  Authentication uses the MCP SDK's ``BearerAuthBackend``
++ ``TokenVerifier``: API keys (``st_`` / ``mc_`` prefixes) are resolved against
+the database via ``authenticate_token`` from ``backend.auth``.
+
+Mount note
+----------
+``sse_app()`` returns a standalone Starlette ASGI application, not an APIRouter.
+It must be mounted with ``app.mount()``, not ``app.include_router()``.
+The SSE endpoint lives at ``/api/v1/mcp/sse`` and the messages POST endpoint at
+``/api/v1/mcp/messages/``.
+
+Follow-on tools
+---------------
+- ``stash_vfs_ls`` — list VFS directory contents.
+- ``stash_vfs_cat`` — read VFS file contents.
+- ``stash_session_upload`` — upload a session transcript to Stash.
+- ``stash_memory_search`` — search Memory wiki pages by keyword.
+
+Add new tools by decorating functions with ``@mcp.tool()`` in this module.
+The auth layer is already wired — tool handlers access the authenticated user
+via ``get_access_token()`` from ``mcp.server.auth.middleware.auth_context``.
+"""
+
+import json
+import logging
+
+from fastapi import HTTPException, status
+from mcp.server.auth.middleware.auth_context import get_access_token
+from mcp.server.auth.middleware.bearer_auth import AccessToken
+from mcp.server.auth.provider import TokenVerifier
+from mcp.server.auth.settings import AuthSettings
+from mcp.server.fastmcp import FastMCP
+
+from backend.auth import authenticate_token
+from backend.services import files_tree_service, source_service
+
+logger = logging.getLogger("stash.mcp")
+
+MCP_NAME = "stash"
+MCP_VERSION = "0.x"
+MCP_MOUNT_PATH = "/api/v1/mcp"
+
+TOOL_INSTRUCTIONS = (
+    "Stash — shared memory for AI coding agents. "
+    "Authenticate with a Stash API key via the Authorization: Bearer header."
+)
+
+# ---------------------------------------------------------------------------
+# Token verifier (MCP SDK TokenVerifier protocol)
+# ---------------------------------------------------------------------------
+
+
+class StashTokenVerifier(TokenVerifier):
+    """Resolve a Stash API key (``st_`` / ``mc_``) to an ``AccessToken``.
+
+    Protocol: ``mcp.server.auth.provider.TokenVerifier``
+    - ``verify_token(self, token: str) -> AccessToken | None``
+    """
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        try:
+            user = await authenticate_token(token)
+        except HTTPException as exc:
+            if exc.status_code == status.HTTP_401_UNAUTHORIZED:
+                return None
+            raise
+
+        user_id = str(user["id"])
+        return AccessToken(
+            token=token,
+            client_id=user_id,
+            subject=user_id,
+            scopes=["stash:full"],
+            claims={
+                "name": user.get("name", ""),
+                "email": user.get("email", ""),
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# MCP tools
+# ---------------------------------------------------------------------------
+
+mcp = FastMCP(
+    MCP_NAME,
+    instructions=TOOL_INSTRUCTIONS,
+    token_verifier=StashTokenVerifier(),
+    auth=AuthSettings(
+        issuer_url="https://joinstash.ai",
+        resource_server_url="https://joinstash.ai/api/v1/mcp",
+    ),
+)
+
+
+@mcp.tool()
+async def get_stash_info() -> str:
+    """Return identity info about the Stash server and authenticated user."""
+    token: AccessToken | None = get_access_token()
+    return json.dumps(
+        {
+            "name": MCP_NAME,
+            "version": MCP_VERSION,
+            "user_id": token.subject if token else "",
+            "client_id": token.client_id if token else "",
+            "scopes": list(token.scopes) if token else [],
+        }
+    )
+
+
+@mcp.tool()
+async def stash_search(query: str, limit: int = 10) -> str:
+    """Search across all Stash content accessible to the authenticated user:
+    native files, sessions, connected-source documents, and federated sources.
+
+    Args:
+        query: The search query string.
+        limit: Maximum number of results to return (default 10).
+
+    Returns:
+        JSON string with a list of result objects, each containing
+        source, ref, snippet, and optionally name / source_name keys.
+    """
+    token: AccessToken | None = get_access_token()
+    user_id = token.subject if token else ""
+    results = await source_service.search_all(user_id, user_id, query, limit=limit)
+    if results is None:
+        return json.dumps([])
+    return json.dumps(results)
+
+
+@mcp.tool()
+async def stash_session_search(query: str, limit: int = 10) -> str:
+    """Search the authenticated user's recent sessions by keyword.
+
+    Performs full-text search across session transcript content (user
+    messages, assistant messages, tool calls, etc.) and returns matching
+    events with their session context. Results are scoped to sessions
+    the authenticated user can read.
+
+    Args:
+        query: The search query string (keywords or natural-language
+            phrases — uses PostgreSQL websearch syntax).
+        limit: Maximum number of matching events to return (default 10).
+
+    Returns:
+        JSON string with keys:
+          - query: The original search query.
+          - count: Number of events returned.
+          - results: Array of matching history event objects. Each event
+            has session_id, agent_name, event_type, content (snippet),
+            created_at, and rank fields.
+    """
+    from uuid import UUID
+
+    from backend.services.memory_service import search_scope_events
+
+    token: AccessToken | None = get_access_token()
+    if token is None or not token.subject:
+        return json.dumps({"error": "Authentication required"})
+
+    user_id = UUID(token.subject)
+    results = await search_scope_events(
+        owner_user_id=user_id,
+        user_id=user_id,
+        query=query,
+        limit=limit,
+    )
+    return json.dumps(
+        {
+            "query": query,
+            "count": len(results),
+            "results": results,
+        },
+        default=str,
+    )
+
+
+@mcp.tool()
+async def stash_memory_search(
+    query: str,
+    scope: str | None = None,
+    layer: str | None = None,
+    limit: int = 5,
+) -> str:
+    """Search the authenticated user's Memory wiki pages by keyword.
+
+    Performs full-text search across pages in the Memory folder subtree
+    (the agent-curated wiki) and returns matching pages with name,
+    content excerpt, and rank. Results are scoped to the authenticated
+    user's own Memory folder.
+
+    Args:
+        query: The search query string (keywords or natural-language
+            phrases — uses PostgreSQL websearch syntax).
+        scope: Optional scope filter ("agent" or "project"). In Stash,
+            all memory is per-user (project-scoped). Defaults to "project".
+        layer: Optional layer filter ("long-term" or "daily"). In Stash,
+            all memory pages are long-term wiki content. Defaults to
+            "long-term".
+        limit: Maximum number of results to return (default 5).
+
+    Returns:
+        JSON string with keys:
+          - query: The original search query.
+          - count: Number of results returned.
+          - results: Array of matching page objects. Each page has id,
+            name, folder_id, search_text (excerpt), content_type,
+            updated_at, and rank fields.
+    """
+    from uuid import UUID
+
+    token: AccessToken | None = get_access_token()
+    if token is None or not token.subject:
+        return json.dumps({"error": "Authentication required"})
+
+    user_id = UUID(token.subject)
+    results = await files_tree_service.search_pages_fts(
+        owner_user_id=user_id,
+        query=query,
+        limit=limit,
+        user_id=user_id,
+    )
+
+    out = []
+    for r in results:
+        entry = {
+            "id": str(r["id"]),
+            "name": r["name"],
+            "folder_id": str(r["folder_id"]),
+            "search_text": r["search_text"][:500] if r["search_text"] else "",
+            "content_type": r["content_type"],
+            "updated_at": str(r["updated_at"]),
+            "rank": round(float(r["rank"]), 4),
+        }
+        out.append(entry)
+
+    return json.dumps(
+        {
+            "query": query,
+            "count": len(out),
+            "results": out,
+        },
+        default=str,
+    )
+
+
+@mcp.tool()
+async def stash_vfs_ls(path: str = "/") -> str:
+    """List directory contents in Stash's virtual filesystem.
+
+    Browse Stash as a single path-based filesystem. Start with
+    ``stash_vfs_ls(path="/")`` to discover the top-level sections.
+
+    VFS path format:
+    - ``/`` — root, lists top-level sections (files, sessions, sources, memory, tables, skills)
+    - ``/files/...`` — pages and uploaded files
+    - ``/sources/<handle>/...`` — connected source documents
+    - ``/sessions/...`` — agent session transcripts
+    - ``/memory/...`` — agent-curated Memory wiki
+    - ``/tables/...`` — table schemas and row data
+    - ``/skills/...`` — published Skill folders
+
+    Args:
+        path: The VFS directory path to list (default: "/").
+
+    Returns:
+        JSON object with keys: path, is_dir, entries (sorted list of entry names),
+        entry_count, type.
+        On error: JSON object with keys: error (description), path.
+    """
+    import json
+
+    from backend.main import app
+    from backend.services.vfs_service import run_vfs_script
+
+    token = get_access_token()
+    if not token:
+        return json.dumps({"error": "Authentication required"})
+
+    authorization = f"Bearer {token.token}"
+    result = await run_vfs_script(app, authorization, f"ls {path}", cwd="/")
+
+    if result["exit_code"] != 0:
+        return json.dumps(
+            {
+                "error": result["stderr"].strip(),
+                "path": path,
+            }
+        )
+
+    entries = [line.strip() for line in result["stdout"].split("\n") if line.strip()]
+    return json.dumps(
+        {
+            "path": path,
+            "is_dir": True,
+            "entries": entries,
+            "entry_count": len(entries),
+            "type": "directory",
+        }
+    )
+
+
+@mcp.tool()
+async def stash_vfs_cat(path: str) -> str:
+    """Read a file's contents from Stash's virtual filesystem.
+
+    Read the text content of any file accessible via the VFS. Use
+    ``stash_vfs_ls`` first to discover file paths.
+
+    VFS path format:
+    - ``/files/<page>.md`` — pages and uploaded files
+    - ``/sources/<handle>/.../<file>`` — connected source documents
+    - ``/sessions/...`` — agent session transcripts
+    - ``/memory/...`` — agent-curated Memory wiki
+
+    Args:
+        path: The VFS file path to read.
+
+    Returns:
+        JSON object with keys: path, content (file contents), size (character count).
+        For binary or missing files: JSON object with keys: error (description), path.
+    """
+    import json
+
+    from backend.main import app
+    from backend.services.vfs_service import run_vfs_script
+
+    token = get_access_token()
+    if not token:
+        return json.dumps({"error": "Authentication required"})
+
+    authorization = f"Bearer {token.token}"
+    result = await run_vfs_script(app, authorization, f"cat {path}", cwd="/")
+
+    if result["exit_code"] != 0:
+        return json.dumps(
+            {
+                "error": result["stderr"].strip(),
+                "path": path,
+            }
+        )
+
+    content = result["stdout"]
+    if not content:
+        return json.dumps(
+            {
+                "error": "File is empty or binary — no text content returned",
+                "path": path,
+            }
+        )
+
+    return json.dumps(
+        {
+            "path": path,
+            "content": content,
+            "size": len(content),
+        }
+    )
+
+
+@mcp.tool()
+async def stash_session_upload(
+    session_id: str,
+    agent_name: str = "",
+    cwd: str | None = None,
+    events: str = "[]",
+    replace: bool = False,
+) -> str:
+    """Upload a session transcript to Stash, making it searchable.
+
+    Accepts session metadata and an array of event objects as a JSON
+    string. Creates or updates the session row and inserts events.
+    Uploaded sessions become immediately searchable via
+    ``stash_session_search``.
+
+    Args:
+        session_id: Unique session identifier (e.g. ``sess_abc123``).
+        agent_name: Name of the agent that recorded the session (e.g.
+            ``claude-code``). Falls back to per-event ``agent_name``.
+        cwd: Working directory for the session context.
+        events: JSON string of an array of event objects. Each event may
+            have: ``event_type`` (required), ``content`` (required),
+            ``agent_name``, ``tool_name``, ``metadata``, ``created_at``.
+        replace: If True and the session already has events, delete
+            existing events before inserting the new ones (default False).
+
+    Returns:
+        JSON string with keys: ``session_id``, ``event_count`` (total events
+        provided), ``imported`` (number of events inserted).
+        On auth failure: ``{"error": "Authentication required"}``.
+    """
+    from uuid import UUID
+
+    from backend.database import get_pool
+    from backend.services import memory_service, session_service
+
+    token: AccessToken | None = get_access_token()
+    if token is None or not token.subject:
+        return json.dumps({"error": "Authentication required"})
+
+    user_id = UUID(token.subject)
+
+    # Parse events JSON
+    try:
+        event_list = json.loads(events)
+    except json.JSONDecodeError:
+        return json.dumps({"error": "Invalid JSON in events parameter"})
+
+    if not isinstance(event_list, list):
+        return json.dumps({"error": "events must be a JSON array"})
+
+    # Fill in defaults per event
+    for ev in event_list:
+        if not ev.get("agent_name"):
+            ev["agent_name"] = agent_name
+        if not ev.get("session_id"):
+            ev["session_id"] = session_id
+        if "metadata" not in ev or ev["metadata"] is None:
+            ev["metadata"] = {}
+
+    # Validate required fields
+    for i, ev in enumerate(event_list):
+        if "event_type" not in ev or not ev["event_type"]:
+            return json.dumps({"error": f"Event at index {i} missing required field: event_type"})
+        if "content" not in ev or ev["content"] is None:
+            return json.dumps({"error": f"Event at index {i} missing required field: content"})
+
+    event_count = len(event_list)
+
+    # Check for existing events
+    pool = get_pool()
+    existing = await pool.fetchval(
+        "SELECT COUNT(*) FROM history_events WHERE owner_user_id = $1 AND session_id = $2",
+        user_id,
+        session_id,
+    )
+
+    if existing:
+        if replace:
+            await pool.execute(
+                "DELETE FROM history_events WHERE owner_user_id = $1 AND session_id = $2",
+                user_id,
+                session_id,
+            )
+        else:
+            # Idempotent: just upsert the session metadata and return
+            await session_service.upsert_session(
+                user_id,
+                session_id,
+                agent_name=agent_name,
+                cwd=cwd,
+                created_by=user_id,
+            )
+            return json.dumps(
+                {
+                    "session_id": session_id,
+                    "event_count": event_count,
+                    "imported": 0,
+                    "skipped": True,
+                    "reason": "session already has events",
+                }
+            )
+
+    # Upsert session
+    await session_service.upsert_session(
+        user_id,
+        session_id,
+        agent_name=agent_name,
+        cwd=cwd,
+        created_by=user_id,
+    )
+
+    # Set cwd in event metadata if provided
+    if cwd:
+        for ev in event_list:
+            meta = ev.get("metadata")
+            if isinstance(meta, dict) and "cwd" not in meta:
+                meta["cwd"] = cwd
+
+    # Push events
+    inserted = await memory_service.push_events_batch(user_id, user_id, event_list)
+
+    return json.dumps(
+        {
+            "session_id": session_id,
+            "event_count": event_count,
+            "imported": len(inserted),
+        }
+    )
+
+
+@mcp.tool()
+async def stash_memory_append(
+    scope: str,
+    layer: str,
+    content: str,
+) -> str:
+    """Append markdown content to the authenticated user's persistent Memory wiki in Stash.
+
+    Each ``(scope, layer)`` pair maps to one page in the Memory folder
+    (e.g. ``project-long-term``, ``agent-daily``).  If the page does not exist
+    it is created; if it exists the new content is appended at the bottom
+    with a timestamp heading separator.
+
+    Args:
+        scope: Which memory scope: ``"agent"`` or ``"project"``.
+        layer: Which memory layer: ``"long-term"`` or ``"daily"``.
+        content: Markdown content to append.
+
+    Returns:
+        JSON string with keys: ``page_id``, ``name``, ``action``
+        (``"created"`` | ``"appended"``), ``app_url``.
+    """
+    import json
+    from datetime import UTC, datetime
+    from uuid import UUID
+
+    from backend.database import get_pool
+
+    VALID_SCOPES = {"agent", "project"}
+    VALID_LAYERS = {"long-term", "daily"}
+
+    # Validate parameters early
+    if scope not in VALID_SCOPES:
+        return json.dumps(
+            {"error": f"Invalid scope '{scope}'. Must be one of: {', '.join(sorted(VALID_SCOPES))}"}
+        )
+    if layer not in VALID_LAYERS:
+        return json.dumps(
+            {"error": f"Invalid layer '{layer}'. Must be one of: {', '.join(sorted(VALID_LAYERS))}"}
+        )
+
+    # Auth check
+    token: AccessToken | None = get_access_token()
+    if token is None or not token.subject:
+        return json.dumps({"error": "Authentication required"})
+
+    user_id = UUID(token.subject)
+
+    # Resolve the memory folder
+    memory = await files_tree_service.get_or_create_memory_folder(user_id, user_id)
+    memory_folder_id = memory["id"]
+
+    # Compute page name from scope + layer
+    page_name = f"{scope}-{layer}"
+
+    # Look for an existing page with that name in the memory folder
+    pool = get_pool()
+    existing = await pool.fetchrow(
+        "SELECT id, owner_user_id, folder_id, name, content_markdown "
+        "FROM pages WHERE owner_user_id = $1 AND folder_id = $2 AND name = $3 AND deleted_at IS NULL",
+        user_id,
+        memory_folder_id,
+        page_name,
+    )
+
+    if existing:
+        # Page exists — append content with timestamp separator
+        ts = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+        new_content = existing["content_markdown"] + f"\n\n## {ts}\n\n{content}"
+        updated = await files_tree_service.update_page(
+            page_id=existing["id"],
+            owner_user_id=user_id,
+            updated_by=user_id,
+            content=new_content,
+        )
+        return json.dumps(
+            {
+                "page_id": str(existing["id"]),
+                "name": page_name,
+                "action": "appended",
+                "app_url": updated.get("app_url", ""),
+            }
+        )
+
+    # Page does not exist — create it
+    page = await files_tree_service.create_page(
+        owner_user_id=user_id,
+        name=page_name,
+        created_by=user_id,
+        folder_id=memory_folder_id,
+        content=content,
+    )
+    return json.dumps(
+        {
+            "page_id": str(page["id"]),
+            "name": page_name,
+            "action": "created",
+            "app_url": page.get("app_url", ""),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Factory — returns the Starlette ASGI sub-application
+# ---------------------------------------------------------------------------
+
+
+def create_mcp_app():
+    """Build and return the MCP sub-application mounted in main.py.
+
+    Notes
+    -----
+    We pass ``mount_path="/"`` so the MCP SDK does **not** prepend the
+    mount prefix into its internal ``normalized_message_endpoint``  — doing so
+    would cause the path to be duplicated because FastAPI's ``app.mount()``
+    already sets ``root_path`` in the ASGI scope, and the SSE transport
+    prepends that again.  With ``mount_path="/"`` the message path stays as
+    ``/messages/`` and the actual mount prefix (``/api/v1/mcp``) is added
+    exactly once — by FastAPI's mount machinery.
+    """
+    return mcp.sse_app(mount_path="/")

--- a/backend/tasks/embeddings.py
+++ b/backend/tasks/embeddings.py
@@ -227,3 +227,55 @@ async def _reconcile() -> int:
 @celery.task(name="backend.tasks.embeddings.reconcile")
 def reconcile() -> int:
     return run_async(_reconcile())
+
+
+async def _backfill_history_events() -> int:
+    """One-shot backfill for history_events rows that were never embedded.
+
+    The periodic reconciler only retries rows with `embed_stale = TRUE`;
+    rows written while no embedding provider was configured (or before the
+    write-time pipeline existed) sit at `embedding IS NULL, embed_stale
+    FALSE` and would stay invisible to vector search forever. This task
+    embeds those rows in bounded batches with the same TEXT_LIMIT/
+    content-hash gating as the reconciler. Idempotent: a success clears the
+    row out of the WHERE clause (embedding set); a provider failure hands
+    the batch to the 60s reconciler (embed_stale = TRUE) so this task
+    neither loops forever nor double-processes reconciler-owned rows.
+    """
+    pool = get_pool()
+    total = 0
+    while True:
+        rows = await pool.fetch(
+            "SELECT id, LEFT(content, $2) AS content FROM history_events "
+            "WHERE embedding IS NULL AND embed_stale = FALSE "
+            "AND content IS NOT NULL AND content <> '' LIMIT $1",
+            BATCH_SIZE,
+            TEXT_LIMIT,
+        )
+        if not rows:
+            break
+        ids = [r["id"] for r in rows]
+        texts = [r["content"] for r in rows]
+        hashes = [_text_hash(t) for t in texts]
+        vecs = await embedding_service.embed_batch(texts)
+        if not vecs:
+            # Provider failed after retries: hand this batch to the
+            # reconciler instead of spinning on it.
+            await pool.executemany(
+                "UPDATE history_events SET content_hash = $1, embed_stale = TRUE WHERE id = $2",
+                list(zip(hashes, ids)),
+            )
+            break
+        await pool.executemany(
+            "UPDATE history_events SET embedding = $1, content_hash = $2, embed_stale = FALSE WHERE id = $3",
+            [(v, h, eid) for eid, v, h in zip(ids, vecs, hashes)],
+        )
+        total += len(ids)
+    if total:
+        logger.info("history event embedding backfill: embedded %d row(s)", total)
+    return total
+
+
+@celery.task(name="backend.tasks.embeddings.backfill_history_event_embeddings")
+def backfill_history_event_embeddings() -> int:
+    return run_async(_backfill_history_events())

--- a/backend/tests/test_docker_release_contract.py
+++ b/backend/tests/test_docker_release_contract.py
@@ -1,0 +1,86 @@
+"""Release contract for the self-host Docker images.
+
+These are static source-level guards: they read the compose files and
+Dockerfiles as plain text (no YAML library is a declared dependency, and CI
+installs only backend/requirements*.txt). They encode the operator directive
+and the compose-merge invariant so neither can silently regress:
+
+- pi must never be installed or referenced inside either image.
+- every service key a local override declares must also exist in the prod
+  file, so an override can never introduce a service with no image (the
+  collab/#982 bug class).
+
+The literal `docker compose config -q` / `up -d` reproduction is deliberately
+NOT here: CI has no compose contract for it, and a conditional skip would
+weaken the assertion. Those commands are run by the release executor with the
+real exit status recorded.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROD_COMPOSE = REPO_ROOT / "docker-compose.prod.yml"
+LOCAL_COMPOSE = REPO_ROOT / "docker-compose.local.yml"
+BACKEND_DOCKERFILE = REPO_ROOT / "backend" / "Dockerfile"
+FRONTEND_DOCKERFILE = REPO_ROOT / "frontend" / "Dockerfile"
+
+# The operative pi-absence gate. A broad `pi|npm|node` alternation can never
+# return zero: it matches `pip install`, `libatspi2.0-0`, and the mandatory
+# node:20-alpine / npm ci lines that build a Next.js image. This narrow
+# pattern names only real pi artifacts.
+PI_REFERENCE = re.compile(r"earendil-works/pi|/pi/|pi install|pi-coding-agent", re.IGNORECASE)
+
+# A service key: exactly two spaces of indent under the top-level `services:`
+# mapping. Nested properties (four+ spaces) never match this shape.
+SERVICE_KEY = re.compile(r"^  ([^\s#][^:]*):")
+
+
+def service_keys(path: Path) -> list[str]:
+    """Collect the service names declared under a top-level `services:` block."""
+    keys: list[str] = []
+    in_services = False
+    for line in path.read_text().splitlines():
+        if line.startswith("services:"):
+            in_services = True
+            continue
+        if in_services:
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            if not line.startswith(" "):
+                # A new top-level key ends the services block.
+                break
+            match = SERVICE_KEY.match(line)
+            if match:
+                keys.append(match.group(1))
+    return keys
+
+
+def test_no_override_only_services():
+    """Every local override service must also exist in the prod file.
+
+    Compose merge creates a service from an override that prod does not
+    declare, then rejects it for lacking an image/build — the collab/#982
+    bug class. This generalizes the fix so no override can reintroduce it.
+    `caddy` is legitimate because prod declares it.
+    """
+    prod = set(service_keys(PROD_COMPOSE))
+    local = set(service_keys(LOCAL_COMPOSE))
+    assert prod, "prod compose must declare services"
+    orphans = local - prod
+    assert orphans == set(), f"override declares services with no prod entry: {sorted(orphans)}"
+
+
+def test_compose_files_do_not_mention_collab():
+    """Neither compose file may reference the deleted collab service or 3458."""
+    for path in (PROD_COMPOSE, LOCAL_COMPOSE):
+        text = path.read_text()
+        assert "collab" not in text, f"{path.name} still mentions collab"
+        assert "3458" not in text, f"{path.name} still mentions port 3458"
+
+
+def test_dockerfiles_install_no_pi():
+    """Operator directive: the Docker image must not install pi at all."""
+    for path in (BACKEND_DOCKERFILE, FRONTEND_DOCKERFILE):
+        offenders = [line for line in path.read_text().splitlines() if PI_REFERENCE.search(line)]
+        assert offenders == [], f"{path.name} references pi: {offenders}"

--- a/backend/tests/test_docker_release_contract.py
+++ b/backend/tests/test_docker_release_contract.py
@@ -16,7 +16,9 @@ weaken the assertion. Those commands are run by the release executor with the
 real exit status recorded.
 """
 
+import json
 import re
+import tomllib
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -24,6 +26,9 @@ PROD_COMPOSE = REPO_ROOT / "docker-compose.prod.yml"
 LOCAL_COMPOSE = REPO_ROOT / "docker-compose.local.yml"
 BACKEND_DOCKERFILE = REPO_ROOT / "backend" / "Dockerfile"
 FRONTEND_DOCKERFILE = REPO_ROOT / "frontend" / "Dockerfile"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+PLUGIN_MANIFEST = REPO_ROOT / "plugins" / "claude-plugin" / ".claude-plugin" / "plugin.json"
+MARKETPLACE_MANIFEST = REPO_ROOT / ".claude-plugin" / "marketplace.json"
 
 # The operative pi-absence gate. A broad `pi|npm|node` alternation can never
 # return zero: it matches `pip install`, `libatspi2.0-0`, and the mandatory
@@ -77,6 +82,60 @@ def test_compose_files_do_not_mention_collab():
         text = path.read_text()
         assert "collab" not in text, f"{path.name} still mentions collab"
         assert "3458" not in text, f"{path.name} still mentions port 3458"
+
+
+# A GHCR image reference to one of our two release images, capturing its tag.
+# This mirrors the same shape the (currently inert) bump automation rewrites.
+GHCR_PIN = re.compile(r"ghcr\.io/fergana-labs/(stash-[a-z]+):(\S+)")
+
+
+def cli_version() -> str:
+    with PYPROJECT.open("rb") as handle:
+        return tomllib.load(handle)["project"]["version"]
+
+
+def test_compose_pins_track_the_cli_version():
+    """Every GHCR pin in the prod compose file must equal the CLI version.
+
+    Since the bump automation can no longer land its edits, this test is the
+    only surviving enforcement that the five self-host pins and the CLI
+    release version stay in lockstep. Pins are bare (no `v` prefix): the git
+    tag carries the `v`, the published image tags do not.
+    """
+    version = cli_version()
+    pins = GHCR_PIN.findall(PROD_COMPOSE.read_text())
+    assert pins, "prod compose must pin our release images"
+    images = {image for image, _ in pins}
+    assert images == {"stash-backend", "stash-frontend"}, f"unexpected pinned images: {images}"
+    for image, tag in pins:
+        assert not tag.startswith("v"), f"{image} pinned with a v-prefixed tag: {tag}"
+        assert tag == version, f"{image} pinned to {tag}, but CLI version is {version}"
+
+
+def test_plugin_manifests_agree_with_each_other():
+    """The Claude plugin manifest and the marketplace entry must agree.
+
+    This is the invariant the bump automation enforced by copying the plugin
+    number into the marketplace file; keep it asserted now that the
+    automation cannot land edits.
+    """
+    plugin = json.loads(PLUGIN_MANIFEST.read_text())["version"]
+    marketplace = json.loads(MARKETPLACE_MANIFEST.read_text())["plugins"][0]["version"]
+    assert plugin == marketplace, f"plugin.json {plugin} != marketplace {marketplace}"
+
+
+def test_plugin_manifest_is_not_the_cli_version():
+    """The plugin/marketplace pair is an independent, higher sequence.
+
+    It is bumped on its own schedule and is NOT part of the CLI release, so
+    it must not be expected to equal the pyproject version. Asserted so a
+    future hand-bump that conflates the two is caught.
+    """
+    plugin = json.loads(PLUGIN_MANIFEST.read_text())["version"]
+    assert plugin != cli_version(), (
+        f"plugin manifest {plugin} collides with the CLI version; "
+        "the marketplace sequence is independent"
+    )
 
 
 def test_dockerfiles_install_no_pi():

--- a/backend/tests/test_mcp.py
+++ b/backend/tests/test_mcp.py
@@ -1,0 +1,1269 @@
+"""Tests for the Stash MCP server.
+
+Covers:
+- StashTokenVerifier with valid / invalid API keys
+- SSE endpoint auth behaviour (401 without token, 200 with token)
+
+SSE tests must NOT hold the SSE connection open — the MCP SSE handler
+never closes voluntarily, so we use ``asyncio.timeout()`` to abort.
+"""
+
+import asyncio
+from datetime import UTC
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from mcp.server.auth.middleware.bearer_auth import AccessToken
+
+from backend.services.mcp_service import StashTokenVerifier, mcp, stash_search
+
+from .conftest import unique_name
+
+
+async def _register(client: AsyncClient) -> str:
+    """Register a test user and return the API key."""
+    r = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name("mcp_user"), "password": "securepassword1"},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["api_key"]
+
+
+def _headers(key: str | None = None) -> dict:
+    """Return headers dict, optionally with Authorization bearer.
+
+    Includes a Host header with port so the MCP SDK's DNS rebinding
+    wildcard check (``localhost:*`` → ``startswith("localhost:")``)
+    passes.
+    """
+    h = {"Host": "localhost:0"}
+    if key:
+        h["Authorization"] = f"Bearer {key}"
+    return h
+
+
+# ---------------------------------------------------------------------------
+# Token verifier tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verifier_valid_key(client: AsyncClient):
+    """StashTokenVerifier resolves a real API key to an AccessToken."""
+    api_key = await _register(client)
+    verifier = StashTokenVerifier()
+    result = await verifier.verify_token(api_key)
+
+    assert result is not None
+    assert result.subject is not None
+    assert len(result.subject) > 0  # UUID string
+    assert result.client_id == result.subject  # same user
+    assert result.token == api_key
+
+
+@pytest.mark.asyncio
+async def test_verifier_invalid_key():
+    """StashTokenVerifier returns None for a bogus API key."""
+    result = await StashTokenVerifier().verify_token("st_invalid_key_12345")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# SSE endpoint tests
+#
+# WARNING: The MCP SSE handler never closes the connection by itself, so
+# a plain ``client.get()`` hangs forever.  We run the request in a task
+# with a short timeout, check status/headers, and let the timeout abort it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sse_endpoint_auth_required(client: AsyncClient):
+    """The /api/v1/mcp/sse endpoint rejects unauthenticated requests with 401."""
+    # No auth header — the BearerAuthBackend rejects before the SSE handler.
+    r = await client.get("/api/v1/mcp/sse", headers=_headers())
+    assert r.status_code == 401, f"expected 401, got {r.status_code}"
+
+    # Valid key — SSE connection opens.  Abort with a timeout.
+    api_key = await _register(client)
+    with pytest.raises(TimeoutError):
+        async with asyncio.timeout(3):
+            r = await client.get("/api/v1/mcp/sse", headers=_headers(api_key))
+            assert r.status_code == 200, f"expected 200, got {r.status_code}"
+            ct = r.headers.get("content-type", "")
+            assert ct.startswith("text/event-stream"), f"expected SSE content type, got {ct}"
+            # If we get here, the response started — the timeout will abort
+            # the open SSE connection.
+
+
+@pytest.mark.asyncio
+async def test_sse_endpoint_authenticated(client: AsyncClient):
+    """Authenticated request to SSE endpoint returns 200 with SSE content type."""
+    api_key = await _register(client)
+    with pytest.raises(TimeoutError):
+        async with asyncio.timeout(3):
+            r = await client.get("/api/v1/mcp/sse", headers=_headers(api_key))
+            assert r.status_code == 200, f"expected 200, got {r.status_code}"
+            ct = r.headers.get("content-type", "")
+            assert ct.startswith("text/event-stream"), f"expected SSE content type, got {ct}"
+
+
+# ---------------------------------------------------------------------------
+# stash_search tool tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stash_search_registered():
+    """stash_search is registered as an MCP tool with correct schema."""
+    tools = await mcp.list_tools()
+    tool_names = [t.name for t in tools]
+    assert "stash_search" in tool_names, f"stash_search not found in {tool_names}"
+
+    tool = next(t for t in tools if t.name == "stash_search")
+    schema = tool.inputSchema
+    props = schema.get("properties", {})
+
+    # query is a required string
+    assert "query" in props
+    assert props["query"]["type"] == "string"
+    assert "query" in schema.get("required", [])
+
+    # limit is an optional integer with default 10
+    assert "limit" in props
+    assert props["limit"]["type"] == "integer"
+    assert "limit" not in schema.get("required", [])
+    assert props["limit"].get("default") == 10
+
+
+@pytest.mark.asyncio
+async def test_stash_search_calls_service():
+    """stash_search calls source_service.search_all with correct args."""
+    fake_results = [
+        {
+            "source": "native-files",
+            "ref": "abc-123",
+            "name": "test page",
+            "snippet": "some content",
+        }
+    ]
+    fake_token = AsyncMock()
+    fake_token.subject = "00000000-0000-0000-0000-000000000001"
+
+    mock_search = AsyncMock(return_value=fake_results)
+
+    with patch("backend.services.mcp_service.get_access_token", return_value=fake_token):
+        with patch("backend.services.mcp_service.source_service.search_all", mock_search):
+            result = await stash_search(query="test query", limit=5)
+
+    # Verify search_all was called with the right args
+    mock_search.assert_awaited_once_with(
+        fake_token.subject, fake_token.subject, "test query", limit=5
+    )
+
+    # Verify result is correct JSON
+    import json
+
+    parsed = json.loads(result)
+    assert parsed == fake_results
+
+
+@pytest.mark.asyncio
+async def test_stash_search_none_results():
+    """stash_search returns [] when search_all returns None."""
+    fake_token = AsyncMock()
+    fake_token.subject = "00000000-0000-0000-0000-000000000002"
+
+    mock_search = AsyncMock(return_value=None)
+
+    with patch("backend.services.mcp_service.get_access_token", return_value=fake_token):
+        with patch("backend.services.mcp_service.source_service.search_all", mock_search):
+            result = await stash_search(query="nothing")
+
+    assert result == "[]"
+
+
+# ---------------------------------------------------------------------------
+# stash_session_search tool tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_search_registered():
+    """stash_session_search is registered as an MCP tool with correct schema."""
+    from backend.services.mcp_service import mcp
+
+    tools = await mcp.list_tools()
+    tool_names = [t.name for t in tools]
+    assert "stash_session_search" in tool_names
+
+    tool = next(t for t in tools if t.name == "stash_session_search")
+    # MCP SDK uses inputSchema which is a JSON schema dict
+    schema = tool.inputSchema if hasattr(tool, "inputSchema") else {}
+    props = schema.get("properties", {})
+    assert "query" in props
+    assert props["query"]["type"] == "string"
+    assert "limit" in props
+    assert props["limit"]["type"] == "integer"
+    assert props["limit"].get("default") == 10
+
+
+@pytest.mark.asyncio
+async def test_session_search_auth_required():
+    """Returns auth error when no token is available."""
+    import json
+    from unittest.mock import patch
+
+    from backend.services.mcp_service import stash_session_search
+
+    with patch("backend.services.mcp_service.get_access_token", return_value=None):
+        result = await stash_session_search("test query")
+
+    parsed = json.loads(result)
+    assert parsed == {"error": "Authentication required"}
+
+
+@pytest.mark.asyncio
+async def test_session_search_returns_json_envelope():
+    """Returns structured JSON with query, count, and results keys."""
+    import json
+    from datetime import datetime
+    from unittest.mock import patch
+    from uuid import UUID
+
+    from backend.services.mcp_service import stash_session_search
+
+    fake_token = AccessToken(
+        token="test-token",
+        client_id="550e8400-e29b-41d4-a716-446655440000",
+        subject="550e8400-e29b-41d4-a716-446655440000",
+        scopes=["stash:full"],
+    )
+    fake_events = [
+        {
+            "id": UUID("11111111-1111-1111-1111-111111111111"),
+            "session_id": "sess_abc",
+            "agent_name": "claude-code",
+            "event_type": "user_message",
+            "content": "How do I implement this?",
+            "created_at": datetime(2026, 7, 14, 12, 0, 0, tzinfo=UTC),
+            "rank": 0.85,
+        },
+        {
+            "id": UUID("22222222-2222-2222-2222-222222222222"),
+            "session_id": "sess_def",
+            "agent_name": "claude-code",
+            "event_type": "assistant_message",
+            "content": "Here's how you can implement that.",
+            "created_at": datetime(2026, 7, 14, 12, 5, 0, tzinfo=UTC),
+            "rank": 0.72,
+        },
+    ]
+
+    with (
+        patch(
+            "backend.services.mcp_service.get_access_token",
+            return_value=fake_token,
+        ),
+        patch(
+            "backend.services.memory_service.search_scope_events",
+            return_value=fake_events,
+        ),
+    ):
+        result = await stash_session_search("test query")
+
+    parsed = json.loads(result)
+    assert parsed["query"] == "test query"
+    assert parsed["count"] == 2
+    assert len(parsed["results"]) == 2
+    assert parsed["results"][0]["session_id"] == "sess_abc"
+    assert parsed["results"][1]["agent_name"] == "claude-code"
+
+
+@pytest.mark.asyncio
+async def test_session_search_empty_results():
+    """Returns count: 0 and results: [] when no matches."""
+    import json
+    from unittest.mock import patch
+
+    from backend.services.mcp_service import stash_session_search
+
+    fake_token = AccessToken(
+        token="test-token",
+        client_id="550e8400-e29b-41d4-a716-446655440000",
+        subject="550e8400-e29b-41d4-a716-446655440000",
+        scopes=["stash:full"],
+    )
+
+    with (
+        patch(
+            "backend.services.mcp_service.get_access_token",
+            return_value=fake_token,
+        ),
+        patch(
+            "backend.services.memory_service.search_scope_events",
+            return_value=[],
+        ),
+    ):
+        result = await stash_session_search("no matches")
+
+    parsed = json.loads(result)
+    assert parsed["count"] == 0
+    assert parsed["results"] == []
+
+
+@pytest.mark.asyncio
+async def test_session_search_calls_service_with_correct_args():
+    """Calls search_scope_events with the authenticated user and correct params."""
+    from unittest.mock import patch
+    from uuid import UUID
+
+    from backend.services.mcp_service import stash_session_search
+
+    user_uuid = "550e8400-e29b-41d4-a716-446655440000"
+    fake_token = AccessToken(
+        token="test-token",
+        client_id=user_uuid,
+        subject=user_uuid,
+        scopes=["stash:full"],
+    )
+
+    with (
+        patch(
+            "backend.services.mcp_service.get_access_token",
+            return_value=fake_token,
+        ),
+        patch(
+            "backend.services.memory_service.search_scope_events",
+            return_value=[],
+        ) as mock_search,
+    ):
+        await stash_session_search("test", limit=5)
+
+    mock_search.assert_awaited_once_with(
+        owner_user_id=UUID(user_uuid),
+        user_id=UUID(user_uuid),
+        query="test",
+        limit=5,
+    )
+
+
+# ---------------------------------------------------------------------------
+# stash_vfs_ls tool tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stash_vfs_ls_registered():
+    """stash_vfs_ls is registered as an MCP tool with correct schema."""
+    tools = await mcp.list_tools()
+    tool_names = [t.name for t in tools]
+    assert "stash_vfs_ls" in tool_names
+
+    tool = next(t for t in tools if t.name == "stash_vfs_ls")
+    schema = tool.inputSchema
+    props = schema.get("properties", {})
+
+    assert "path" in props
+    assert props["path"]["type"] == "string"
+    assert props["path"].get("default") == "/"
+    assert "path" not in schema.get("required", [])
+
+
+@pytest.mark.asyncio
+async def test_stash_vfs_ls_lists_root():
+    """stash_vfs_ls(path="/") returns top-level VFS sections."""
+    from unittest.mock import patch
+
+    from backend.services.mcp_service import stash_vfs_ls
+
+    fake_token = AsyncMock()
+    fake_token.token = "st_test_key"
+
+    fake_result = {
+        "stdout": "files\nsessions\nsources\nmemory\ntables\nskills\n",
+        "stderr": "",
+        "exit_code": 0,
+        "cwd": "/",
+    }
+
+    with patch("backend.services.mcp_service.get_access_token", return_value=fake_token):
+        with patch("backend.services.vfs_service.run_vfs_script", return_value=fake_result):
+            result = await stash_vfs_ls()
+
+    import json
+
+    parsed = json.loads(result)
+    assert parsed["path"] == "/"
+    assert parsed["is_dir"] is True
+    assert "files" in parsed["entries"]
+    assert "sessions" in parsed["entries"]
+    assert parsed["entry_count"] >= 1
+    assert parsed["type"] == "directory"
+
+
+@pytest.mark.asyncio
+async def test_stash_vfs_ls_nonexistent():
+    """Non-existent path returns structured error."""
+    from unittest.mock import patch
+
+    from backend.services.mcp_service import stash_vfs_ls
+
+    fake_token = AsyncMock()
+    fake_token.token = "st_test_key"
+
+    fake_result = {
+        "stdout": "",
+        "stderr": "ls: /nonexistent: No such file or directory\n",
+        "exit_code": 1,
+        "cwd": "/",
+    }
+
+    with patch("backend.services.mcp_service.get_access_token", return_value=fake_token):
+        with patch("backend.services.vfs_service.run_vfs_script", return_value=fake_result):
+            result = await stash_vfs_ls(path="/nonexistent")
+
+    import json
+
+    parsed = json.loads(result)
+    assert "error" in parsed
+    assert parsed["path"] == "/nonexistent"
+
+
+@pytest.mark.asyncio
+async def test_stash_vfs_ls_auth_required():
+    """Returns auth error when no token is available."""
+    from unittest.mock import patch
+
+    from backend.services.mcp_service import stash_vfs_ls
+
+    with patch("backend.services.mcp_service.get_access_token", return_value=None):
+        result = await stash_vfs_ls()
+
+    import json
+
+    parsed = json.loads(result)
+    assert parsed == {"error": "Authentication required"}
+
+
+# ---------------------------------------------------------------------------
+# stash_vfs_cat tool tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vfs_cat_registered():
+    """stash_vfs_cat is registered as an MCP tool with correct schema."""
+    tools = await mcp.list_tools()
+    tool_names = [t.name for t in tools]
+    assert "stash_vfs_cat" in tool_names
+
+    tool = next(t for t in tools if t.name == "stash_vfs_cat")
+    schema = tool.inputSchema
+    props = schema.get("properties", {})
+
+    assert "path" in props
+    assert props["path"]["type"] == "string"
+    assert "path" in schema.get("required", [])
+
+
+@pytest.mark.asyncio
+async def test_vfs_cat_read_file():
+    """stash_vfs_cat returns file content for a valid path."""
+    from unittest.mock import patch
+
+    from backend.services.mcp_service import stash_vfs_cat
+
+    fake_token = AsyncMock()
+    fake_token.token = "st_test_key"
+
+    fake_result = {
+        "stdout": "# Hello World\n\nThis is a test file.\n",
+        "stderr": "",
+        "exit_code": 0,
+        "cwd": "/",
+    }
+
+    with patch("backend.services.mcp_service.get_access_token", return_value=fake_token):
+        with patch("backend.services.vfs_service.run_vfs_script", return_value=fake_result):
+            result = await stash_vfs_cat(path="/files/test.md")
+
+    import json
+
+    parsed = json.loads(result)
+    assert parsed["path"] == "/files/test.md"
+    assert parsed["content"] == "# Hello World\n\nThis is a test file.\n"
+    assert parsed["size"] == 36
+
+
+@pytest.mark.asyncio
+async def test_vfs_cat_nonexistent_path():
+    """Non-existent path returns structured error."""
+    from unittest.mock import patch
+
+    from backend.services.mcp_service import stash_vfs_cat
+
+    fake_token = AsyncMock()
+    fake_token.token = "st_test_key"
+
+    fake_result = {
+        "stdout": "",
+        "stderr": "cat: /nonexistent: No such file or directory\n",
+        "exit_code": 1,
+        "cwd": "/",
+    }
+
+    with patch("backend.services.mcp_service.get_access_token", return_value=fake_token):
+        with patch("backend.services.vfs_service.run_vfs_script", return_value=fake_result):
+            result = await stash_vfs_cat(path="/nonexistent")
+
+    import json
+
+    parsed = json.loads(result)
+    assert "error" in parsed
+    assert parsed["path"] == "/nonexistent"
+
+
+@pytest.mark.asyncio
+async def test_vfs_cat_empty_file():
+    """Empty stdout returns descriptive error."""
+    from unittest.mock import patch
+
+    from backend.services.mcp_service import stash_vfs_cat
+
+    fake_token = AsyncMock()
+    fake_token.token = "st_test_key"
+
+    fake_result = {
+        "stdout": "",
+        "stderr": "",
+        "exit_code": 0,
+        "cwd": "/",
+    }
+
+    with patch("backend.services.mcp_service.get_access_token", return_value=fake_token):
+        with patch("backend.services.vfs_service.run_vfs_script", return_value=fake_result):
+            result = await stash_vfs_cat(path="/files/binary.bin")
+
+    import json
+
+    parsed = json.loads(result)
+    assert "error" in parsed
+    assert "empty or binary" in parsed["error"]
+    assert parsed["path"] == "/files/binary.bin"
+
+
+@pytest.mark.asyncio
+async def test_vfs_cat_auth_required():
+    """Returns auth error when no token is available."""
+    from unittest.mock import patch
+
+    from backend.services.mcp_service import stash_vfs_cat
+
+    with patch("backend.services.mcp_service.get_access_token", return_value=None):
+        result = await stash_vfs_cat(path="/files/test.md")
+
+    import json
+
+    parsed = json.loads(result)
+    assert parsed == {"error": "Authentication required"}
+
+
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# stash_session_upload tool tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_upload_registered():
+    """stash_session_upload is registered as an MCP tool with correct schema."""
+    tools = await mcp.list_tools()
+    tool_names = [t.name for t in tools]
+    assert "stash_session_upload" in tool_names
+
+    tool = next(t for t in tools if t.name == "stash_session_upload")
+    schema = tool.inputSchema
+    props = schema.get("properties", {})
+
+    # session_id is a required string
+    assert "session_id" in props
+    assert props["session_id"]["type"] == "string"
+    assert "session_id" in schema.get("required", [])
+
+    # agent_name is an optional string with empty default
+    assert "agent_name" in props
+    assert props["agent_name"]["type"] == "string"
+    assert "agent_name" not in schema.get("required", [])
+
+    # cwd is an optional string|null (MCP SDK uses anyOf for str | None)
+    assert "cwd" in props
+    assert "string" in [s.get("type") for s in props["cwd"].get("anyOf", [])]
+    assert "cwd" not in schema.get("required", [])
+
+    # events is an optional string with "[]" default
+    assert "events" in props
+    assert props["events"]["type"] == "string"
+    assert "events" not in schema.get("required", [])
+
+    # replace is an optional boolean with default false
+    assert "replace" in props
+    assert props["replace"]["type"] == "boolean"
+    assert "replace" not in schema.get("required", [])
+
+
+@pytest.mark.asyncio
+async def test_session_upload_auth_required():
+    """Returns auth error when no token is available."""
+    import json
+    from unittest.mock import patch
+
+    from backend.services.mcp_service import stash_session_upload
+
+    with patch("backend.services.mcp_service.get_access_token", return_value=None):
+        result = await stash_session_upload(session_id="sess_test")
+
+    parsed = json.loads(result)
+    assert parsed == {"error": "Authentication required"}
+
+
+@pytest.mark.asyncio
+async def test_session_upload_creates_session_and_events():
+    """Happy path: creates session and pushes events, returns correct counts."""
+    import json
+    from unittest.mock import AsyncMock, patch
+    from uuid import UUID
+
+    from backend.services.mcp_service import stash_session_upload
+
+    user_uuid = "550e8400-e29b-41d4-a716-446655440000"
+    fake_token = AccessToken(
+        token="test-token",
+        client_id=user_uuid,
+        subject=user_uuid,
+        scopes=["stash:full"],
+    )
+
+    fake_session = {"id": UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), "session_id": "sess_test"}
+    fake_events = [{"id": UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")}]
+
+    # Mock pool.fetchval to return 0 (no existing events)
+    mock_pool = AsyncMock()
+    mock_pool.fetchval = AsyncMock(return_value=0)
+
+    with (
+        patch("backend.services.mcp_service.get_access_token", return_value=fake_token),
+        patch(
+            "backend.services.session_service.upsert_session", return_value=fake_session
+        ) as mock_upsert,
+        patch(
+            "backend.services.memory_service.push_events_batch", return_value=fake_events
+        ) as mock_push,
+        patch("backend.database.get_pool", return_value=mock_pool),
+    ):
+        result = await stash_session_upload(
+            session_id="sess_test",
+            agent_name="test-agent",
+            events='[{"event_type": "user_message", "content": "hello", "agent_name": "test-agent"}]',
+        )
+
+    parsed = json.loads(result)
+    assert parsed["session_id"] == "sess_test"
+    assert parsed["event_count"] == 1
+    assert parsed["imported"] == 1
+
+    mock_upsert.assert_awaited_once()
+    mock_push.assert_awaited_once()
+    # Verify push_events_batch got the right owner_user_id
+    args, _ = mock_push.await_args
+    assert args[0] == UUID(user_uuid)  # owner_user_id
+
+
+@pytest.mark.asyncio
+async def test_session_upload_empty_events():
+    """Empty events array returns imported: 0."""
+    import json
+    from unittest.mock import AsyncMock, patch
+    from uuid import UUID
+
+    from backend.services.mcp_service import stash_session_upload
+
+    user_uuid = "550e8400-e29b-41d4-a716-446655440000"
+    fake_token = AccessToken(
+        token="test-token",
+        client_id=user_uuid,
+        subject=user_uuid,
+        scopes=["stash:full"],
+    )
+
+    fake_session = {"id": UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), "session_id": "sess_empty"}
+
+    mock_pool = AsyncMock()
+    mock_pool.fetchval = AsyncMock(return_value=0)
+
+    with (
+        patch("backend.services.mcp_service.get_access_token", return_value=fake_token),
+        patch("backend.services.session_service.upsert_session", return_value=fake_session),
+        patch("backend.database.get_pool", return_value=mock_pool),
+    ):
+        result = await stash_session_upload(
+            session_id="sess_empty",
+            agent_name="test-agent",
+            events="[]",
+        )
+
+    parsed = json.loads(result)
+    assert parsed["session_id"] == "sess_empty"
+    assert parsed["event_count"] == 0
+    assert parsed["imported"] == 0
+
+
+@pytest.mark.asyncio
+async def test_session_upload_missing_event_type():
+    """Events missing required event_type return a clear error."""
+    import json
+    from unittest.mock import patch
+
+    from backend.services.mcp_service import stash_session_upload
+
+    user_uuid = "550e8400-e29b-41d4-a716-446655440000"
+    fake_token = AccessToken(
+        token="test-token",
+        client_id=user_uuid,
+        subject=user_uuid,
+        scopes=["stash:full"],
+    )
+
+    with patch("backend.services.mcp_service.get_access_token", return_value=fake_token):
+        result = await stash_session_upload(
+            session_id="sess_bad",
+            events='[{"content": "hello without event_type"}]',
+        )
+
+    parsed = json.loads(result)
+    assert "error" in parsed
+    assert "event_type" in parsed["error"]
+
+
+@pytest.mark.asyncio
+async def test_session_upload_idempotent():
+    """Returns skipped=True when session already has events (no replace)."""
+    import json
+    from unittest.mock import AsyncMock, patch
+    from uuid import UUID
+
+    from backend.services.mcp_service import stash_session_upload
+
+    user_uuid = "550e8400-e29b-41d4-a716-446655440000"
+    fake_token = AccessToken(
+        token="test-token",
+        client_id=user_uuid,
+        subject=user_uuid,
+        scopes=["stash:full"],
+    )
+
+    fake_session = {
+        "id": UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        "session_id": "sess_existing",
+    }
+
+    # Mock pool.fetchval to return 5 (existing events found)
+    mock_pool = AsyncMock()
+    mock_pool.fetchval = AsyncMock(return_value=5)
+
+    with (
+        patch("backend.services.mcp_service.get_access_token", return_value=fake_token),
+        patch(
+            "backend.services.session_service.upsert_session", return_value=fake_session
+        ) as mock_upsert,
+        patch("backend.services.memory_service.push_events_batch") as mock_push,
+        patch("backend.database.get_pool", return_value=mock_pool),
+    ):
+        result = await stash_session_upload(
+            session_id="sess_existing",
+            agent_name="test-agent",
+            events='[{"event_type": "user_message", "content": "hello"}]',
+            replace=False,
+        )
+
+    parsed = json.loads(result)
+    assert parsed["session_id"] == "sess_existing"
+    assert parsed["imported"] == 0
+    assert parsed["skipped"] is True
+    assert "reason" in parsed
+
+    # push_events_batch should NOT have been called
+    mock_push.assert_not_awaited()
+    # But upsert_session should still be called for metadata refresh
+    mock_upsert.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# stash_memory_search tool tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memory_search_registered():
+    """stash_memory_search is registered as an MCP tool with correct schema."""
+    tools = await mcp.list_tools()
+    tool_names = [t.name for t in tools]
+    assert "stash_memory_search" in tool_names
+
+    tool = next(t for t in tools if t.name == "stash_memory_search")
+    schema = tool.inputSchema
+    props = schema.get("properties", {})
+
+    assert "query" in props
+    assert props["query"]["type"] == "string"
+    assert "query" in schema.get("required", [])
+
+    assert "scope" in props
+    assert "anyOf" in props["scope"]
+    assert any(alt["type"] == "string" for alt in props["scope"]["anyOf"])
+    assert any(alt["type"] == "null" for alt in props["scope"]["anyOf"])
+    assert "scope" not in schema.get("required", [])
+
+    assert "layer" in props
+    assert "anyOf" in props["layer"]
+    assert any(alt["type"] == "string" for alt in props["layer"]["anyOf"])
+    assert any(alt["type"] == "null" for alt in props["layer"]["anyOf"])
+    assert "layer" not in schema.get("required", [])
+
+    assert "limit" in props
+    assert props["limit"]["type"] == "integer"
+    assert props["limit"].get("default") == 5
+    assert "limit" not in schema.get("required", [])
+
+
+@pytest.mark.asyncio
+async def test_memory_search_auth_required():
+    """Returns auth error when no token is available."""
+    from unittest.mock import patch
+
+    from backend.services.mcp_service import stash_memory_search
+
+    with patch("backend.services.mcp_service.get_access_token", return_value=None):
+        result = await stash_memory_search("test query")
+
+    import json
+
+    parsed = json.loads(result)
+    assert parsed == {"error": "Authentication required"}
+
+
+@pytest.mark.asyncio
+async def test_memory_search_calls_service():
+    """Returns structured JSON with query, count, and results keys."""
+    import json
+    from datetime import datetime
+    from unittest.mock import patch
+    from uuid import UUID
+
+    from backend.services.mcp_service import stash_memory_search
+
+    fake_token = AccessToken(
+        token="test-token",
+        client_id="550e8400-e29b-41d4-a716-446655440000",
+        subject="550e8400-e29b-41d4-a716-446655440000",
+        scopes=["stash:full"],
+    )
+    fake_pages = [
+        {
+            "id": UUID("11111111-1111-1111-1111-111111111111"),
+            "name": "Architecture Overview",
+            "folder_id": UUID("22222222-2222-2222-2222-222222222222"),
+            "search_text": "The system uses a microservices architecture",
+            "content_type": "markdown",
+            "updated_at": datetime(2026, 7, 14, 12, 0, 0),
+            "rank": 0.95,
+        },
+        {
+            "id": UUID("33333333-3333-3333-3333-333333333333"),
+            "name": "API Design",
+            "folder_id": UUID("44444444-4444-4444-4444-444444444444"),
+            "search_text": "RESTful API design principles",
+            "content_type": "markdown",
+            "updated_at": datetime(2026, 7, 13, 10, 0, 0),
+            "rank": 0.72,
+        },
+    ]
+
+    with (
+        patch(
+            "backend.services.mcp_service.get_access_token",
+            return_value=fake_token,
+        ),
+        patch(
+            "backend.services.files_tree_service.search_pages_fts",
+            return_value=fake_pages,
+        ) as mock_search,
+    ):
+        result = await stash_memory_search("architecture", limit=3)
+
+    parsed = json.loads(result)
+    assert parsed["query"] == "architecture"
+    assert parsed["count"] == 2
+    assert len(parsed["results"]) == 2
+    assert parsed["results"][0]["name"] == "Architecture Overview"
+    assert parsed["results"][0]["id"] == str(fake_pages[0]["id"])
+    assert parsed["results"][1]["name"] == "API Design"
+    assert parsed["results"][1]["id"] == str(fake_pages[1]["id"])
+
+    mock_search.assert_awaited_once_with(
+        owner_user_id=UUID("550e8400-e29b-41d4-a716-446655440000"),
+        query="architecture",
+        limit=3,
+        user_id=UUID("550e8400-e29b-41d4-a716-446655440000"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_memory_search_empty_results():
+    """Returns count: 0 and results: [] when no matches."""
+    import json
+    from unittest.mock import patch
+
+    from backend.services.mcp_service import stash_memory_search
+
+    fake_token = AccessToken(
+        token="test-token",
+        client_id="550e8400-e29b-41d4-a716-446655440000",
+        subject="550e8400-e29b-41d4-a716-446655440000",
+        scopes=["stash:full"],
+    )
+
+    with (
+        patch(
+            "backend.services.mcp_service.get_access_token",
+            return_value=fake_token,
+        ),
+        patch(
+            "backend.services.files_tree_service.search_pages_fts",
+            return_value=[],
+        ),
+    ):
+        result = await stash_memory_search("no matches")
+
+    parsed = json.loads(result)
+    assert parsed["query"] == "no matches"
+    assert parsed["count"] == 0
+    assert parsed["results"] == []
+
+
+@pytest.mark.asyncio
+async def test_memory_search_default_params():
+    """Uses default limit=5 when not specified."""
+    from unittest.mock import patch
+    from uuid import UUID
+
+    from backend.services.mcp_service import stash_memory_search
+
+    fake_token = AccessToken(
+        token="test-token",
+        client_id="550e8400-e29b-41d4-a716-446655440000",
+        subject="550e8400-e29b-41d4-a716-446655440000",
+        scopes=["stash:full"],
+    )
+
+    with (
+        patch(
+            "backend.services.mcp_service.get_access_token",
+            return_value=fake_token,
+        ),
+        patch(
+            "backend.services.files_tree_service.search_pages_fts",
+            return_value=[],
+        ) as mock_search,
+    ):
+        await stash_memory_search("test")
+
+    mock_search.assert_awaited_once_with(
+        owner_user_id=UUID("550e8400-e29b-41d4-a716-446655440000"),
+        query="test",
+        limit=5,
+        user_id=UUID("550e8400-e29b-41d4-a716-446655440000"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# stash_memory_append tool tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memory_append_registered():
+    """stash_memory_append is registered as an MCP tool with correct schema."""
+    tools = await mcp.list_tools()
+    tool_names = [t.name for t in tools]
+    assert "stash_memory_append" in tool_names
+
+    tool = next(t for t in tools if t.name == "stash_memory_append")
+    schema = tool.inputSchema
+    props = schema.get("properties", {})
+
+    assert "scope" in props
+    assert props["scope"]["type"] == "string"
+    assert "scope" in schema.get("required", [])
+
+    assert "layer" in props
+    assert props["layer"]["type"] == "string"
+    assert "layer" in schema.get("required", [])
+
+    assert "content" in props
+    assert props["content"]["type"] == "string"
+    assert "content" in schema.get("required", [])
+
+
+@pytest.mark.asyncio
+async def test_memory_append_creates_new_page():
+    """When no existing page, creates a new page with correct name."""
+    import json
+    from unittest.mock import AsyncMock, patch
+    from uuid import UUID
+
+    from backend.services.mcp_service import stash_memory_append
+
+    user_uuid = "550e8400-e29b-41d4-a716-446655440000"
+    fake_token = AccessToken(
+        token="test-token",
+        client_id=user_uuid,
+        subject=user_uuid,
+        scopes=["stash:full"],
+    )
+
+    memory_folder_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    fake_memory = {"id": memory_folder_id}
+
+    new_page_id = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    fake_page = {
+        "id": new_page_id,
+        "name": "project-long-term",
+        "app_url": "https://joinstash.ai/memory/project-long-term",
+    }
+
+    # Mock pool.fetchrow to return None (no existing page)
+    mock_pool = AsyncMock()
+    mock_pool.fetchrow = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "backend.services.mcp_service.get_access_token",
+            return_value=fake_token,
+        ),
+        patch(
+            "backend.services.files_tree_service.get_or_create_memory_folder",
+            return_value=fake_memory,
+        ),
+        patch(
+            "backend.services.files_tree_service.create_page",
+            return_value=fake_page,
+        ) as mock_create_page,
+        patch("backend.database.get_pool", return_value=mock_pool),
+    ):
+        result = await stash_memory_append(
+            scope="project",
+            layer="long-term",
+            content="# Test memory entry\n\nSome important context.",
+        )
+
+    parsed = json.loads(result)
+    assert parsed["page_id"] == str(new_page_id)
+    assert parsed["name"] == "project-long-term"
+    assert parsed["action"] == "created"
+    assert parsed["app_url"] == fake_page["app_url"]
+
+    mock_create_page.assert_awaited_once_with(
+        owner_user_id=UUID(user_uuid),
+        name="project-long-term",
+        created_by=UUID(user_uuid),
+        folder_id=memory_folder_id,
+        content="# Test memory entry\n\nSome important context.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_memory_append_appends_to_existing():
+    """When page exists, appends content with timestamp separator."""
+    import json
+    from unittest.mock import AsyncMock, patch
+    from uuid import UUID
+
+    from backend.services.mcp_service import stash_memory_append
+
+    user_uuid = "550e8400-e29b-41d4-a716-446655440000"
+    fake_token = AccessToken(
+        token="test-token",
+        client_id=user_uuid,
+        subject=user_uuid,
+        scopes=["stash:full"],
+    )
+
+    memory_folder_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    fake_memory = {"id": memory_folder_id}
+
+    page_id = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+    existing_content = "# Existing memory\n\nPrevious entry."
+
+    # Mock pool.fetchrow to return an existing page
+    existing_row = {
+        "id": page_id,
+        "owner_user_id": UUID(user_uuid),
+        "folder_id": memory_folder_id,
+        "name": "agent-daily",
+        "content_markdown": existing_content,
+    }
+    mock_pool = AsyncMock()
+    mock_pool.fetchrow = AsyncMock(return_value=existing_row)
+
+    fake_updated = {
+        "id": page_id,
+        "name": "agent-daily",
+        "app_url": "https://joinstash.ai/memory/agent-daily",
+    }
+
+    with (
+        patch(
+            "backend.services.mcp_service.get_access_token",
+            return_value=fake_token,
+        ),
+        patch(
+            "backend.services.files_tree_service.get_or_create_memory_folder",
+            return_value=fake_memory,
+        ),
+        patch(
+            "backend.services.files_tree_service.update_page",
+            return_value=fake_updated,
+        ) as mock_update_page,
+        patch("backend.database.get_pool", return_value=mock_pool),
+    ):
+        result = await stash_memory_append(
+            scope="agent",
+            layer="daily",
+            content="New observation for today.",
+        )
+
+    parsed = json.loads(result)
+    assert parsed["page_id"] == str(page_id)
+    assert parsed["name"] == "agent-daily"
+    assert parsed["action"] == "appended"
+    assert parsed["app_url"] == fake_updated["app_url"]
+
+    # Verify update_page was called with merged content
+    # The merged content should start with existing + newline + heading with timestamp
+    _args, kwargs = mock_update_page.await_args
+    assert kwargs["page_id"] == page_id
+    assert kwargs["owner_user_id"] == UUID(user_uuid)
+    assert kwargs["updated_by"] == UUID(user_uuid)
+    assert kwargs["content"].startswith(existing_content + "\n\n## ")
+    assert "New observation for today." in kwargs["content"]
+
+
+@pytest.mark.asyncio
+async def test_memory_append_auth_required():
+    """Returns auth error when no token is available."""
+    import json
+    from unittest.mock import patch
+
+    from backend.services.mcp_service import stash_memory_append
+
+    with patch("backend.services.mcp_service.get_access_token", return_value=None):
+        result = await stash_memory_append(scope="project", layer="long-term", content="test")
+
+    parsed = json.loads(result)
+    assert parsed == {"error": "Authentication required"}
+
+
+@pytest.mark.asyncio
+async def test_memory_append_invalid_scope():
+    """Returns error for invalid scope value."""
+    import json
+    from unittest.mock import patch
+
+    from backend.services.mcp_service import stash_memory_append
+
+    with patch("backend.services.mcp_service.get_access_token", return_value=None):
+        result = await stash_memory_append(scope="invalid-scope", layer="long-term", content="test")
+
+    parsed = json.loads(result)
+    assert "error" in parsed
+    assert "Invalid scope" in parsed["error"]
+
+
+@pytest.mark.asyncio
+async def test_memory_append_invalid_layer():
+    """Returns error for invalid layer value."""
+    import json
+    from unittest.mock import patch
+
+    from backend.services.mcp_service import stash_memory_append
+
+    with patch("backend.services.mcp_service.get_access_token", return_value=None):
+        result = await stash_memory_append(scope="project", layer="invalid-layer", content="test")
+
+    parsed = json.loads(result)
+    assert "error" in parsed
+    assert "Invalid layer" in parsed["error"]
+
+
+@pytest.mark.asyncio
+async def test_memory_append_all_scope_layer_combinations():
+    """All 4 scope/layer combinations produce distinct page names."""
+    import json
+    from unittest.mock import AsyncMock, patch
+    from uuid import UUID
+
+    from backend.services.mcp_service import stash_memory_append
+
+    user_uuid = "550e8400-e29b-41d4-a716-446655440000"
+    fake_token = AccessToken(
+        token="test-token",
+        client_id=user_uuid,
+        subject=user_uuid,
+        scopes=["stash:full"],
+    )
+
+    memory_folder_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    fake_memory = {"id": memory_folder_id}
+
+    # Mock pool.fetchrow to return None (no existing page each time)
+    mock_pool = AsyncMock()
+    mock_pool.fetchrow = AsyncMock(return_value=None)
+
+    combinations = [
+        ("agent", "long-term", "agent-long-term"),
+        ("agent", "daily", "agent-daily"),
+        ("project", "long-term", "project-long-term"),
+        ("project", "daily", "project-daily"),
+    ]
+
+    for scope, layer, expected_name in combinations:
+        page_id = UUID(f"{hash(scope + layer) & 0xFFFFFFFF:08x}-0000-0000-0000-000000000000"[:36])
+        fake_page = {"id": page_id, "name": expected_name, "app_url": ""}
+
+        with (
+            patch(
+                "backend.services.mcp_service.get_access_token",
+                return_value=fake_token,
+            ),
+            patch(
+                "backend.services.files_tree_service.get_or_create_memory_folder",
+                return_value=fake_memory,
+            ),
+            patch(
+                "backend.services.files_tree_service.create_page",
+                return_value=fake_page,
+            ) as mock_create_page,
+            patch("backend.database.get_pool", return_value=mock_pool),
+        ):
+            result = await stash_memory_append(scope=scope, layer=layer, content="test")
+
+        parsed = json.loads(result)
+        assert parsed["name"] == expected_name
+        assert parsed["action"] == "created"
+
+        # Verify create_page was called with the expected name
+        _, kwargs = mock_create_page.await_args
+        assert kwargs["name"] == expected_name

--- a/backend/tests/test_memory_semantic_search.py
+++ b/backend/tests/test_memory_semantic_search.py
@@ -71,8 +71,8 @@ async def _register(client) -> dict:
 
 async def _ensure_session(pool, owner_id, user_id, session_id: str):
     await pool.execute(
-        "INSERT INTO sessions (id, owner_user_id, session_id, agent_name, created_by) "
-        "VALUES (gen_random_uuid(), $1, $2, 'fusion', $3) "
+        "INSERT INTO sessions (id, owner_user_id, session_id, agent_name, created_by, last_event_at) "
+        "VALUES (gen_random_uuid(), $1, $2, 'fusion', $3, now()) "
         "ON CONFLICT (owner_user_id, session_id) DO NOTHING",
         owner_id,
         session_id,

--- a/backend/tests/test_memory_semantic_search.py
+++ b/backend/tests/test_memory_semantic_search.py
@@ -1,0 +1,272 @@
+"""Tests for GET /me/sessions/events/semantic-search and the history-events
+embedding backfill task (RUFU-126).
+
+The semantic-search endpoint is the session-events counterpart of
+/me/pages/semantic-search: same scope-membership auth, 503 while the
+embedding service is unconfigured, 500 when the query cannot be embedded,
+and similarity-ranked rows whose `similarity` is exposed as `rank` in the
+HistoryEventListResponse envelope. The backfill task embeds history_events
+rows that were written while no provider was configured (`embedding IS
+NULL, embed_stale = FALSE`) — rows the 60s reconciler never retries — and
+must be idempotent.
+"""
+
+import numpy as np
+import pytest
+
+from backend.services.embeddings import BaseEmbedder, set_embedder
+from backend.tasks.embeddings import _backfill_history_events
+
+from .conftest import unique_name
+
+# Deterministic 384-dim basis vectors: e_i has 1.0 at index i, 0 elsewhere.
+# Cosine similarity between different basis vectors is 0; a vector with
+# itself is 1. Ordering is exact and independent of provider math.
+DIMS = 384
+
+
+def _basis(i: int) -> list[float]:
+    v = [0.0] * DIMS
+    v[i] = 1.0
+    return v
+
+
+class FixedVectorEmbedder(BaseEmbedder):
+    """Configured fake that embeds every text as a fixed direction (e0)."""
+
+    name = "fixed"
+
+    def __init__(self, fail: bool = False):
+        self.fail = fail
+        self.batch_calls: list[list[str]] = []
+
+    def is_configured(self) -> bool:
+        return True
+
+    async def embed_batch(self, texts: list[str]):
+        self.batch_calls.append(list(texts))
+        if self.fail:
+            return None
+        return [np.array(_basis(0), dtype=np.float32) for _ in texts]
+
+
+class UnconfiguredEmbedder(BaseEmbedder):
+    name = "unconfigured"
+
+    def is_configured(self) -> bool:
+        return False
+
+    async def embed_batch(self, texts: list[str]):
+        return None
+
+
+async def _register(client) -> dict:
+    resp = await client.post(
+        "/api/v1/users/register",
+        json={"name": unique_name(), "password": "securepassword1"},
+    )
+    assert resp.status_code == 201, resp.body
+    return resp.json()
+
+
+async def _ensure_session(pool, owner_id, user_id, session_id: str):
+    await pool.execute(
+        "INSERT INTO sessions (id, owner_user_id, session_id, agent_name, created_by) "
+        "VALUES (gen_random_uuid(), $1, $2, 'fusion', $3) "
+        "ON CONFLICT (owner_user_id, session_id) DO NOTHING",
+        owner_id,
+        session_id,
+        user_id,
+    )
+
+
+async def _insert_event(
+    pool,
+    owner_id,
+    user_id,
+    content: str,
+    embedding: list[float] | None,
+    session_id: str = "test-session",
+):
+    await _ensure_session(pool, owner_id, user_id, session_id)
+    await pool.execute(
+        "INSERT INTO history_events "
+        "(id, owner_user_id, created_by, agent_name, event_type, session_id, "
+        "content, metadata, embedding, content_hash, embed_stale) "
+        "VALUES (gen_random_uuid(), $1, $2, 'fusion', 'assistant_message', "
+        "$6, $3, $4, $5, NULL, FALSE)",
+        owner_id,
+        user_id,
+        content,
+        {},
+        embedding,
+        session_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_requires_auth(client):
+    resp = await client.get(
+        "/api/v1/me/sessions/events/semantic-search", params={"q": "hello world"}
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_forbidden_outside_scope(client):
+    alice = await _register(client)
+    bob = await _register(client)
+    resp = await client.get(
+        "/api/v1/me/sessions/events/semantic-search",
+        params={"q": "hello world"},
+        headers={
+            "Authorization": f"Bearer {bob['api_key']}",
+            "X-Stash-Scope": alice["id"],
+        },
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_503_when_embedder_unconfigured(client):
+    user = await _register(client)
+    set_embedder(UnconfiguredEmbedder())
+    resp = await client.get(
+        "/api/v1/me/sessions/events/semantic-search",
+        params={"q": "hello world"},
+        headers={"Authorization": f"Bearer {user['api_key']}"},
+    )
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "Embedding service not configured"
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_500_on_embed_failure(client):
+    user = await _register(client)
+    set_embedder(FixedVectorEmbedder(fail=True))
+    resp = await client.get(
+        "/api/v1/me/sessions/events/semantic-search",
+        params={"q": "hello world"},
+        headers={"Authorization": f"Bearer {user['api_key']}"},
+    )
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Failed to embed query"
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_ranks_by_similarity(client, pool):
+    user = await _register(client)
+    set_embedder(FixedVectorEmbedder())  # query embeds as basis vector e0
+
+    # Exact direction match (similarity 1.0) and orthogonal direction (0.0).
+    await _insert_event(pool, user["id"], user["id"], "good match event", _basis(0))
+    await _insert_event(pool, user["id"], user["id"], "other direction event", _basis(1))
+
+    resp = await client.get(
+        "/api/v1/me/sessions/events/semantic-search",
+        params={"q": "hello world"},
+        headers={"Authorization": f"Bearer {user['api_key']}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["has_more"] is False
+    events = body["events"]
+    assert [e["content"] for e in events] == ["good match event", "other direction event"]
+    assert events[0]["rank"] is not None
+    assert events[0]["rank"] == pytest.approx(1.0, abs=1e-3)
+    assert events[1]["rank"] == pytest.approx(0.0, abs=1e-3)
+    # Session path metadata flows through the shared event model.
+    assert events[0]["session_id"] == "test-session"
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_scope_isolation(client, pool):
+    alice = await _register(client)
+    bob = await _register(client)
+    set_embedder(FixedVectorEmbedder())
+
+    await _insert_event(pool, alice["id"], alice["id"], "alice event", _basis(0))
+    await _insert_event(pool, bob["id"], bob["id"], "bob event", _basis(0))
+
+    resp = await client.get(
+        "/api/v1/me/sessions/events/semantic-search",
+        params={"q": "hello world"},
+        headers={"Authorization": f"Bearer {alice['api_key']}"},
+    )
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    assert [e["content"] for e in events] == ["alice event"]
+
+    resp = await client.get(
+        "/api/v1/me/sessions/events/semantic-search",
+        params={"q": "hello world"},
+        headers={"Authorization": f"Bearer {bob['api_key']}"},
+    )
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    assert [e["content"] for e in events] == ["bob event"]
+
+
+async def _db_state(pool, content: str) -> dict:
+    row = await pool.fetchrow(
+        "SELECT embedding, content_hash, embed_stale FROM history_events WHERE content = $1",
+        content,
+    )
+    assert row is not None
+    return {
+        "embedded": row["embedding"] is not None,
+        "content_hash": row["content_hash"],
+        "embed_stale": row["embed_stale"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_backfill_embeds_unembedded_rows_and_is_idempotent(client, pool):
+    user = await _register(client)
+    user_id = user["id"]
+    # Rows written while no provider was configured: NULL embedding, not stale.
+    for i in range(3):
+        await _insert_event(pool, user_id, user_id, f"backfill event {i}", None)
+
+    embedder = FixedVectorEmbedder()
+    set_embedder(embedder)
+    embedded = await _backfill_history_events()
+    assert embedded == 3
+    assert len(embedder.batch_calls) == 1
+
+    for i in range(3):
+        state = await _db_state(pool, f"backfill event {i}")
+        assert state["embedded"] is True
+        assert state["content_hash"] is not None
+        assert state["embed_stale"] is False
+
+    # Second run: nothing left to backfill, no new provider calls.
+    embedder2 = FixedVectorEmbedder()
+    set_embedder(embedder2)
+    embedded = await _backfill_history_events()
+    assert embedded == 0
+    assert len(embedder2.batch_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_backfill_hands_provider_failure_to_reconciler(client, pool):
+    user = await _register(client)
+    user_id = user["id"]
+    for i in range(2):
+        await _insert_event(pool, user_id, user_id, f"failure event {i}", None)
+
+    # Provider failure: batch is handed to the 60s reconciler (embed_stale),
+    # so a subsequent backfill run does not re-process or loop on it.
+    set_embedder(FixedVectorEmbedder(fail=True))
+    embedded = await _backfill_history_events()
+    assert embedded == 0
+    for i in range(2):
+        state = await _db_state(pool, f"failure event {i}")
+        assert state["embedded"] is False
+        assert state["embed_stale"] is True
+
+    embedder = FixedVectorEmbedder()
+    set_embedder(embedder)
+    embedded = await _backfill_history_events()
+    assert embedded == 0
+    assert len(embedder.batch_calls) == 0

--- a/cli/tests/test_mcp_server.py
+++ b/cli/tests/test_mcp_server.py
@@ -1,0 +1,275 @@
+"""Tests for the MCP server tool functions against the currently shipped API.
+
+Uses the self-contained _FakeClient monkeypatch pattern (mirrored from
+test_sources_cli.py): patch mcp_server._client to inject a fake StashClient,
+then verify the right client method is called with the right arguments and the
+returned JSON envelope matches the shipped contract.
+
+The shipped cli/mcp_server.py surface (STAS-086 reconciliation):
+- stash_search maps its seven parameters onto StashClient.search_sources and
+  returns the raw {"results", "has_more"} envelope via _json — client
+  exceptions propagate (there is no try/except).
+- stash_vfs maps onto StashClient.run_vfs(script, cwd=cwd) and returns
+  {stdout, stderr, exit_code} via _json; a non-zero exit_code is a valid shell
+  result (e.g. grep found nothing), not an error.
+"""
+
+import json
+
+import httpx
+import pytest
+
+from cli import mcp_server
+from cli.client import split_source_tokens
+
+
+def _parse(result_str: str) -> object:
+    """Parse the JSON string returned by an MCP tool."""
+    return json.loads(result_str)
+
+
+class _FakeClient:
+    """Records every search_sources / run_vfs call made by the tools."""
+
+    def __init__(self, calls: list):
+        self._calls = calls
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def search_sources(
+        self,
+        query,
+        source=None,
+        include_sources=None,
+        exclude_sources=None,
+        limit=20,
+        modified_after=None,
+        modified_before=None,
+    ):
+        self._calls.append(
+            (
+                "search",
+                query,
+                source,
+                include_sources,
+                exclude_sources,
+                limit,
+                modified_after,
+                modified_before,
+            )
+        )
+        return {
+            "results": [
+                {
+                    "source": "files",
+                    "ref": "p1",
+                    "name": "Runbook",
+                    "snippet": "deploy instructions",
+                },
+            ],
+            "has_more": False,
+        }
+
+    def run_vfs(self, script: str, cwd: str = "/") -> dict:
+        self._calls.append(("vfs", script, cwd))
+        return {
+            "stdout": f"contents of {script} at {cwd}",
+            "stderr": "",
+            "exit_code": 0,
+        }
+
+
+def _wire(monkeypatch) -> list:
+    calls: list = []
+    monkeypatch.setattr(mcp_server, "_client", lambda: _FakeClient(calls))
+    return calls
+
+
+def test_split_source_tokens() -> None:
+    """split_source_tokens is the shared helper the tool uses for its
+    comma-separated include/exclude params; its contract is reused verbatim."""
+    assert split_source_tokens("") is None
+    assert split_source_tokens(" , ") is None
+    assert split_source_tokens("files") == ["files"]
+    assert split_source_tokens("files, gmail") == ["files", "gmail"]
+
+
+class TestStashSearch:
+    """Tests for the shipped stash_search MCP tool.
+
+    The tool is a thin wrapper: it maps its seven parameters onto
+    StashClient.search_sources and returns the raw {"results", "has_more"}
+    search envelope via _json — with no query/source/count wrapper keys and no
+    try/except, so client exceptions propagate (fail-loud, per AGENTS.md).
+    """
+
+    def test_search_everything_passes_source_none(self, monkeypatch) -> None:
+        """No source filter -> source=None, empty source filters -> None."""
+        calls = _wire(monkeypatch)
+        result_str = mcp_server.stash_search("migration")
+        result = _parse(result_str)
+
+        assert calls == [("search", "migration", None, None, None, 20, None, None)]
+        assert result == {
+            "results": [
+                {
+                    "source": "files",
+                    "ref": "p1",
+                    "name": "Runbook",
+                    "snippet": "deploy instructions",
+                },
+            ],
+            "has_more": False,
+        }
+
+    def test_search_scoped_to_source(self, monkeypatch) -> None:
+        """source="src-abc" passed through untouched as the client keyword."""
+        calls = _wire(monkeypatch)
+        mcp_server.stash_search("rotate", source="src-abc")
+        assert calls == [("search", "rotate", "src-abc", None, None, 20, None, None)]
+
+    def test_search_splits_include_exclude_sources(self, monkeypatch) -> None:
+        """Comma-separated include/exclude params -> token lists via
+        split_source_tokens ("files, gmail" -> ["files", "gmail"])."""
+        calls = _wire(monkeypatch)
+        mcp_server.stash_search(
+            "migration", include_sources="files, gmail", exclude_sources="slack"
+        )
+        assert calls == [
+            ("search", "migration", None, ["files", "gmail"], ["slack"], 20, None, None)
+        ]
+
+    def test_search_forwards_limit(self, monkeypatch) -> None:
+        """limit passed through as the client keyword."""
+        calls = _wire(monkeypatch)
+        mcp_server.stash_search("test", limit=5)
+        assert calls == [("search", "test", None, None, None, 5, None, None)]
+
+    def test_search_unset_modified_bounds_become_none(self, monkeypatch) -> None:
+        """Blank modified_after/before -> None (no window restriction)."""
+        calls = _wire(monkeypatch)
+        mcp_server.stash_search("rotate", modified_after="", modified_before="")
+        assert calls == [("search", "rotate", None, None, None, 20, None, None)]
+
+    def test_search_forwards_modified_range(self, monkeypatch) -> None:
+        """Set ISO bounds pass through untouched; the server parses them."""
+        calls = _wire(monkeypatch)
+        mcp_server.stash_search(
+            "migration", modified_after="2026-01-01", modified_before="2026-02-01T00:00:00Z"
+        )
+        assert calls == [
+            ("search", "migration", None, None, None, 20, "2026-01-01", "2026-02-01T00:00:00Z")
+        ]
+
+    def test_search_envelope_has_no_wrapper_keys(self, monkeypatch) -> None:
+        """The returned JSON is exactly the raw {"results", "has_more"} server
+        envelope — no query/source/count wrapper keys from the old API."""
+        _wire(monkeypatch)
+        result = _parse(mcp_server.stash_search("migration"))
+        assert set(result.keys()) == {"results", "has_more"}
+
+    def test_search_empty_results(self, monkeypatch) -> None:
+        """Client returns the empty envelope -> it serializes verbatim."""
+
+        class _EmptyClient:
+            def search_sources(
+                self,
+                query,
+                source=None,
+                include_sources=None,
+                exclude_sources=None,
+                limit=20,
+                modified_after=None,
+                modified_before=None,
+            ):
+                return {"results": [], "has_more": False}
+
+        monkeypatch.setattr(mcp_server, "_client", lambda: _EmptyClient())
+        result = _parse(mcp_server.stash_search("nothing"))
+        assert result == {"results": [], "has_more": False}
+
+    def test_search_http_error_propagates(self, monkeypatch) -> None:
+        """Shipped stash_search has no try/except, so an httpx.HTTPError from
+        the client must propagate (fail-loud), not be swallowed into a
+        structured-error envelope."""
+
+        class _ErrorClient:
+            def search_sources(self, query, **kwargs):
+                raise httpx.HTTPError("500 Server Error")
+
+        monkeypatch.setattr(mcp_server, "_client", lambda: _ErrorClient())
+        with pytest.raises(httpx.HTTPError):
+            mcp_server.stash_search("fail")
+
+    def test_search_connect_error_propagates(self, monkeypatch) -> None:
+        """The same fail-loud contract holds for connection errors."""
+
+        class _ConnectErrorClient:
+            def search_sources(self, query, **kwargs):
+                raise httpx.ConnectError("Connection refused")
+
+        monkeypatch.setattr(mcp_server, "_client", lambda: _ConnectErrorClient())
+        with pytest.raises(httpx.ConnectError):
+            mcp_server.stash_search("offline")
+
+    def test_search_generic_error_propagates(self, monkeypatch) -> None:
+        """A generic client failure (ValueError) also propagates rather than
+        being shaped into a structured-error envelope."""
+
+        class _GenericErrorClient:
+            def search_sources(self, query, **kwargs):
+                raise ValueError("Something went wrong")
+
+        monkeypatch.setattr(mcp_server, "_client", lambda: _GenericErrorClient())
+        with pytest.raises(ValueError):
+            mcp_server.stash_search("boom")
+
+
+class TestStashVfsTools:
+    """Tests for the shipped script-based stash_vfs MCP tool.
+
+    The tool is a thin wrapper over StashClient.run_vfs(script, cwd=cwd) that
+    returns the {"stdout", "stderr", "exit_code"} shell result via _json. A
+    non-zero exit_code (e.g. grep found nothing) is a valid shell result, not
+    a raised error.
+    """
+
+    def test_vfs_runs_script_at_root(self, monkeypatch) -> None:
+        """Defaults cwd="/": stash_vfs("ls /files") -> run_vfs("ls /files", "/")."""
+        calls = _wire(monkeypatch)
+        result = _parse(mcp_server.stash_vfs("ls /files"))
+        assert calls == [("vfs", "ls /files", "/")]
+        assert result == {
+            "stdout": "contents of ls /files at /",
+            "stderr": "",
+            "exit_code": 0,
+        }
+
+    def test_vfs_passes_through_cwd(self, monkeypatch) -> None:
+        """cwd is passed through to run_vfs untouched."""
+        calls = _wire(monkeypatch)
+        result = _parse(mcp_server.stash_vfs("ls", cwd="/sources"))
+        assert calls == [("vfs", "ls", "/sources")]
+        assert result["exit_code"] == 0
+
+    def test_vfs_nonzero_exit_code_is_shell_result(self, monkeypatch) -> None:
+        """A non-zero exit_code (grep/no-match) is a normal field in the
+        returned shell result dict, not a raised error."""
+
+        class _GrepNoMatchClient:
+            def __init__(self, calls: list):
+                self._calls = calls
+
+            def run_vfs(self, script: str, cwd: str = "/") -> dict:
+                self._calls.append(("vfs", script, cwd))
+                return {"stdout": "", "stderr": "no matches found", "exit_code": 1}
+
+        calls: list = []
+        monkeypatch.setattr(mcp_server, "_client", lambda: _GrepNoMatchClient(calls))
+        result = _parse(mcp_server.stash_vfs("grep nosuchterm /files"))
+        assert calls == [("vfs", "grep nosuchterm /files", "/")]
+        assert result == {"stdout": "", "stderr": "no matches found", "exit_code": 1}

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -15,10 +15,6 @@ services:
     ports:
       - "3457:3457"
 
-  collab:
-    ports:
-      - "3458:3458"
-
   caddy:
     profiles:
       - production-domain

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -60,7 +60,7 @@ services:
       retries: 5
 
   backend:
-    image: ghcr.io/fergana-labs/stash-backend:0.1.365
+    image: ghcr.io/fergana-labs/stash-backend:0.1.368
     restart: always
     expose:
       - "3456"
@@ -83,7 +83,7 @@ services:
       start_period: 30s
 
   worker:
-    image: ghcr.io/fergana-labs/stash-backend:0.1.365
+    image: ghcr.io/fergana-labs/stash-backend:0.1.368
     restart: always
     depends_on:
       postgres:
@@ -105,7 +105,7 @@ services:
   # a 30-min task. Concurrency 2 keeps 2 children x 800MB (see
   # worker_max_memory_per_child) plus the parent inside a 2GB box.
   heavy-worker:
-    image: ghcr.io/fergana-labs/stash-backend:0.1.365
+    image: ghcr.io/fergana-labs/stash-backend:0.1.368
     restart: always
     depends_on:
       postgres:
@@ -123,7 +123,7 @@ services:
     command: ["celery", "-A", "backend.celery_app", "worker", "--loglevel=info", "--concurrency=2", "-Q", "heavy"]
 
   beat:
-    image: ghcr.io/fergana-labs/stash-backend:0.1.365
+    image: ghcr.io/fergana-labs/stash-backend:0.1.368
     restart: always
     depends_on:
       redis:
@@ -139,7 +139,7 @@ services:
     command: ["celery", "-A", "backend.celery_app", "beat", "--loglevel=info"]
 
   frontend:
-    image: ghcr.io/fergana-labs/stash-frontend:0.1.365
+    image: ghcr.io/fergana-labs/stash-frontend:0.1.368
     restart: always
     expose:
       - "3457"

--- a/docs/fusion-integration.md
+++ b/docs/fusion-integration.md
@@ -1,0 +1,303 @@
+# Fusion Agent Integration with Stash
+
+> **Stash** — shared memory for AI coding agents.
+> This guide shows a Fusion operator how to initialize a Fusion agent so it can
+> talk to Stash through two complementary surfaces: the **Stash MCP server**
+> (robust tool calling for search, VFS browsing, and memory) and the
+> **`FusionSession` logging SDK** (reliable auto-syncing of session transcripts
+> to Stash without the agent self-reporting).
+
+A companion, client-agnostic walkthrough lives at
+[`docs/stash-mcp-integration.md`](stash-mcp-integration.md). That doc covers
+the shared endpoint/auth facts and other clients (Claude Desktop, Cursor, VS
+Code). This guide is specifically about **Fusion**, goes deeper on the tool
+reference and the logger, and should be read alongside it — it does not repeat
+or contradict it.
+
+---
+
+## 1. Overview
+
+Fusion agents get two ways to use Stash:
+
+1. **MCP server (call tools).** Fusion connects to Stash's hosted SSE MCP
+   server at `https://joinstash.ai/api/v1/mcp/sse` and authenticates with a
+   Stash API key (`st_…` / `mc_…`). The server exposes tools for full-text
+   search (`stash_search`, `stash_session_search`, `stash_memory_search`),
+   VFS browsing and reading connected sources (`stash_vfs_ls`, `stash_vfs_cat`),
+   uploading a session transcript (`stash_session_upload`), appending to the
+   persistent Memory wiki (`stash_memory_append`), and verifying the connection
+   (`get_stash_info`). The server module is
+   [`backend/services/mcp_service.py`](../backend/services/mcp_service.py),
+   mounted in [`backend/main.py`](../backend/main.py) with `app.mount`.
+
+2. **Logger (record the run).** A Fusion agent wraps its run with the
+   `FusionSession` context manager to auto-capture user / assistant / tool
+   messages into a Stash session and upload a transcript on exit. This is the
+   "don't make the agent self-report" path — the wrapper does the bookkeeping
+   for you.
+
+---
+
+## 2. Prerequisites
+
+- A Stash account on [joinstash.ai](https://joinstash.ai) (free tier works).
+- A Stash **API key** with the `full` (read + write) access level for tool
+  calling; `read` access is sufficient if you only push session logs. Keys are
+  created under **Settings → API Keys** and are shown only once.
+  - Prefix: `st_` (new keys) or legacy `mc_`.
+  - Key types: `full` (read + write) and `read` (reads + transcript upload).
+- A Fusion project / agent with the ability to define MCP server configuration
+  and to run Python (for the logger).
+
+---
+
+## Part A — Connect to the Stash MCP Server
+
+### 3. Transport and server endpoints
+
+Stash's MCP server speaks **Server-Sent Events (SSE)** transport only — there
+is no stdio transport for the hosted server. (The standalone local/CLI server
+at `cli/mcp_server.py` is a separate surface for local development; it is not
+the hosted server this section configures.)
+
+| Property | Value |
+|----------|-------|
+| Mount path | `https://joinstash.ai/api/v1/mcp` |
+| SSE endpoint | `https://joinstash.ai/api/v1/mcp/sse` |
+| Messages endpoint | `https://joinstash.ai/api/v1/mcp/messages/` |
+| Transport | SSE |
+| Authentication | `Authorization: Bearer st_…` header |
+| Token prefix | `st_` or `mc_` |
+
+### 4. Fusion MCP config JSON
+
+In your Fusion project's MCP configuration, register a `stash` server. The
+exact JSON shape matches Fusion's standard `mcpServers` block:
+
+```json
+{
+  "mcpServers": {
+    "stash": {
+      "transport": "sse",
+      "url": "https://joinstash.ai/api/v1/mcp/sse",
+      "headers": {
+        "Authorization": "Bearer st_YOUR_API_KEY_HERE"
+      }
+    }
+  }
+}
+```
+
+Replace `st_YOUR_API_KEY_HERE` with a real key (`st_…` or `mc_…`). The bearer
+token goes in the `Authorization` header — it is **never** placed in the URL.
+Fusion's client opens the SSE stream, receives the message endpoint from the
+server, and POSTs tool invocations to `/api/v1/mcp/messages/`.
+
+### 5. Verifying the connection
+
+Give the Fusion agent these instructions so it can confirm the link and use the
+tools correctly:
+
+```text
+You have access to the Stash MCP server for search, VFS browsing, and memory.
+
+Verify your connection with `get_stash_info` before relying on the tools.
+Use `stash_search` to find past work, sessions, and connected-source documents.
+Use `stash_vfs_ls` / `stash_vfs_cat` to browse and read files from the VFS.
+Use `stash_session_search` to recall past agent sessions by keyword.
+Use `stash_memory_search` to search the agent-curated Memory wiki.
+Use `stash_memory_append` to persist durable notes into the Memory wiki.
+Use `stash_session_upload` to push an already-recorded session transcript.
+
+Every tool returns a JSON string; parse it before acting on the result.
+```
+
+### 6. Tool Reference
+
+All eight tools below are registered in the MCP server at
+[`backend/services/mcp_service.py`](../backend/services/mcp_service.py). Each
+returns a **JSON string**. Required and optional parameters come from the
+function signatures in that module.
+
+| Tool | Description | Required parameters | Optional parameters |
+|------|-------------|---------------------|---------------------|
+| `get_stash_info` | Return identity info about the Stash server and the authenticated user — includes `user_id`, `client_id`, `scopes`, name, version | — | — |
+| `stash_search` | Search across all Stash content accessible to the authenticated user: native files, sessions, connected-source documents, and federated sources | `query` (string) | `limit` (int, default 10) |
+| `stash_session_search` | Full-text search of the authenticated user's recent session transcripts (user messages, assistant messages, tool calls); returns matching events with session context | `query` (string) | `limit` (int, default 10) |
+| `stash_memory_search` | Search the authenticated user's Memory wiki pages by keyword | `query` (string) | `scope` (`"agent"` / `"project"`), `layer` (`"long-term"` / `"daily"`), `limit` (int, default 5) |
+| `stash_vfs_ls` | List directory contents in Stash's virtual filesystem; start with `path="/"` to discover the top-level sections | — | `path` (string, default `"/"`) |
+| `stash_vfs_cat` | Read a file's text contents from the VFS; use `stash_vfs_ls` first to discover file paths | `path` (string) | — |
+| `stash_session_upload` | Upload a session transcript to Stash (session metadata + a JSON array of events), making it searchable; supports idempotent `replace` | `session_id` (string) | `agent_name` (string), `cwd` (string), `events` (JSON string, default `"[]"`), `replace` (bool, default false) |
+| `stash_memory_append` | Append Markdown content to the authenticated user's persistent Memory wiki page for a `(scope, layer)` pair (e.g. `project-long-term`); creates the page if it does not exist | `scope` (`"agent"` / `"project"`), `layer` (`"long-term"` / `"daily"`), `content` (string) | — |
+
+### 7. VFS path format
+
+The virtual filesystem organizes content under these top-level paths (used by
+`stash_vfs_ls` / `stash_vfs_cat`):
+
+| Path | Contents |
+|------|----------|
+| `/` | Root — lists top-level sections |
+| `/files/…` | Pages and uploaded files |
+| `/sources/<handle>/…` | Connected source documents (GitHub, Notion, Slack, etc.) |
+| `/sessions/…` | Agent session transcripts |
+| `/memory/…` | Agent-curated Memory wiki |
+| `/tables/…` | Table schemas and row data |
+| `/skills/…` | Published Skill folders |
+
+---
+
+## Part B — Initialize the `FusionSession` Logger
+
+The logger is a Python context manager delivered by the **`stash-sdk`** package
+(module `sdk/src/stash_sdk/session_store.py`). It wraps a Fusion run so that
+user, assistant, and tool events are captured into a Stash session and the
+transcript is uploaded when the run exits — the agent never has to self-report.
+
+> **Status note.** The SDK ships with the `stash-sdk` package on the
+> `stash-sdk` distribution (`Stash` and `StashError` are already exported from
+> `sdk/src/stash_sdk/__init__.py`). The `FusionSession` wrapper and its
+> `Stash.create_session` client method are the **intended API surface** provided
+> by the SDK shipment; they are documented here as designed. If your installed
+> version already exports `FusionSession`, the exact signatures below apply;
+> otherwise the API is the one specified here.
+
+### 8. Basic usage
+
+```python
+from stash_sdk import Stash, FusionSession
+
+with FusionSession(
+    agent_name="fusion",
+    api_key="st_YOUR_API_KEY_HERE",
+    base_url="https://api.joinstash.ai",
+    cwd="/path/to/repo",
+) as s:
+    s.log_user_message("Hello!")           # event_type="user_message"
+    s.log_tool_use("search", results)      # event_type="tool_use"
+    s.log_assistant_message("Found it!")   # event_type="assistant_message"
+```
+
+- **`__enter__`** calls `Stash.create_session()` (a `POST /api/v1/me/sessions`
+  upsert) so the `session_id`, `agent_name`, `cwd`, and `files_touched` are
+  locked in at session start. It returns the `FusionSession` itself.
+- **`log_user_message(text)`** records an event with `event_type="user_message"`.
+- **`log_assistant_message(text)`** records an event with
+  `event_type="assistant_message"`.
+- **`log_tool_use(tool_name, result)`** records an event with
+  `event_type="tool_use"`.
+- A generic `log_event(...)` accepts arbitrary fields (`session_id`,
+  `agent_name`, `event_type`, `content`, `tool_name`, `metadata`).
+
+Each `log_*` call appends an event dict to an in-memory buffer **and** to a
+crash-safe local JSONL backstop file, then flushes the buffer via
+`Stash.push_events_batch()` when the buffer reaches a batch threshold or enough
+time has elapsed since the last flush. On exit it uploads the backstop file as
+the gzipped transcript.
+
+### 9. Session lifecycle and the `EventKind` model
+
+The logger's events mirror Stash's canonical lifecycle, defined by the
+`EventKind` literal in `stashai/plugin/event.py`:
+
+| Stash `EventKind` | Meaning | `FusionSession` mapping |
+|-------------------|---------|-------------------------|
+| `session_start` | A session begins | session created in `__enter__` via `create_session` |
+| `prompt` | A user prompt is recorded | `log_user_message` |
+| `tool_use` | A tool call / response is recorded | `log_tool_use` |
+| `stop` | The agent finishes responding | `log_assistant_message` / final assistant output |
+| `session_end` | The session ends | `__exit__` flushes events and uploads the transcript |
+
+These map onto the auto-sync flow the Claude/Codex/Hermes hooks already use:
+`create_session_record` and `finalize_session_upload` in
+[`stashai/plugin/hooks.py`](../stashai/plugin/hooks.py), backed by
+`StashClient.create_session` in
+[`stashai/plugin/stash_client.py`](../stashai/plugin/stash_client.py). The
+logger reuses the same endpoints: `POST /api/v1/me/sessions` to create the row,
+`POST /api/v1/me/sessions/events/batch` to flush buffered events, and
+`POST /api/v1/me/transcripts` to upload the transcript.
+
+### 10. Error handling
+
+The logger is deliberately **crash-safe** and **best-effort**:
+
+- **Crash-safe backstop.** Every event is written to
+  `~/.stash/sessions/<session_id>.jsonl` before it is buffered. A mid-run crash
+  or network outage never loses events — the file is the durable record and is
+  re-uploaded on the next exit. The path is overridable via a `data_dir`
+  argument (used by tests).
+- **Suppressed network errors.** Buffer-flush and transcript-upload failures are
+  caught, logged as warnings, and suppressed so the Fusion agent's run is never
+  interrupted by a Stash outage. This is the one deliberate exception to the
+  repo's "fail loud" rule (see `AGENTS.md`): a logging wrapper must never crash
+  the thing it is logging.
+- **Sessions are never deleted on exit.** Stash keeps the history.
+- **Local/CLI tooling fail loud** where it matters. The plugin hooks that mirror
+  this flow (`create_session_record`, `finalize_session_upload`) stay
+  best-effort for the same reason.
+
+---
+
+## Configuration Reference
+
+### 11. Where values come from
+
+Fusion agents and the logger read the same configuration sources the rest of
+Stash uses:
+
+- **User config file** — `~/.stash/config.json` (managed by
+  [`cli/config.py`](../cli/config.py)), with keys `base_url`, `api_key`, and
+  `username`.
+- **Environment override** — the `STASH_API_KEY` environment variable overrides
+  `api_key` when set.
+- **Per-agent config** — the agent plugins resolve values via
+  [`stashai/plugin/agent_config.py`](../stashai/plugin/agent_config.py):
+  `get_config` returns `api_endpoint` (defaults to the production base URL),
+  `api_key`, and `agent_name`; `data_dir_from_env` derives the local data
+  directory from an env var plus a default subpath; `is_configured` tells you
+  whether a client is ready to use.
+
+Common values:
+
+| Setting | Example | Source |
+|---------|---------|--------|
+| `base_url` | `https://api.joinstash.ai` | `~/.stash/config.json` (`base_url`) or `PRODUCTION_BASE_URL` |
+| `api_key` | `st_…` / `mc_…` | `~/.stash/config.json` (`api_key`) or `STASH_API_KEY` env var |
+| `username` / `agent_name` | `fusion` | `~/.stash/config.json` (`username`) |
+
+If `base_url` is omitted, the default is the production API
+(`https://api.joinstash.ai`), which is the correct base for the hosted MCP
+server and the logger.
+
+---
+
+## Local Development
+
+To point a Fusion agent or the logger at a **local** Stash backend instead of
+the hosted one:
+
+- Run the Stash backend locally (see the repo README for the local stack) so
+  the MCP sub-application mounts at `/api/v1/mcp`.
+- Set the Fusion MCP config `url` to your local SSE endpoint, e.g.
+  `http://localhost:3456/api/v1/mcp/sse`, and use a local API key.
+- Pass `base_url="http://localhost:3456"` to `FusionSession` (or set
+  `base_url` in `~/.stash/config.json`).
+- For purely local experiments separate from the hosted SSE server, the repo's
+  `cli/mcp_server.py` provides a standalone stdio server — this is a separate
+  local/CLI surface, not the hosted SSE server, and is not what Fusion connects
+  to in production.
+
+---
+
+## See also
+
+- [`docs/stash-mcp-integration.md`](stash-mcp-integration.md) — the generic,
+  client-agnostic MCP guide (endpoint/auth facts, other clients, `uvx mcp-remote`
+  bridge).
+- [`backend/services/mcp_service.py`](../backend/services/mcp_service.py) — the
+  hosted MCP server, its auth model, and the authoritative tool listing.
+- `stashai/plugin/hooks.py` and `stashai/plugin/stash_client.py` — the
+  auto-sync flow the `FusionSession` logger mirrors.
+- `sdk/src/stash_sdk/client.py` — the `Stash` client methods the logger builds
+  on (`push_events_batch`, `upload_transcript`, …).

--- a/docs/stash-mcp-integration.md
+++ b/docs/stash-mcp-integration.md
@@ -1,0 +1,328 @@
+# Stash MCP Integration
+
+> **Stash** — shared memory for AI coding agents.  
+> This guide explains how to configure any MCP-compatible client to connect to
+> the Stash MCP server, giving agents tools for search, VFS browsing, memory,
+> and session management.
+
+---
+
+## 1. Overview
+
+Stash provides a Model Context Protocol (MCP) server that exposes your Stash
+workspace — files, sessions, connected sources, memory, and skills — as a
+discoverable tool set. Any MCP client (Claude Desktop, Fusion agents, Cursor,
+VS Code via Continue.dev, or any MCP-compatible application) can connect via
+the SSE transport and use these tools to browse, search, and read content from
+your Stash.
+
+**Server URL:** `https://joinstash.ai/api/v1/mcp`  
+**SSE endpoint:** `https://joinstash.ai/api/v1/mcp/sse`  
+**Messages endpoint:** `https://joinstash.ai/api/v1/mcp/messages/`
+
+All tool responses are JSON strings.
+
+---
+
+## 2. Prerequisites
+
+- A Stash account on [joinstash.ai](https://joinstash.ai) (free tier works)
+- A Stash API key (`st_…` or legacy `mc_…` prefix)
+- An MCP-compatible client (Claude Desktop, Fusion, Cursor, VS Code, or any
+  client that supports SSE transport or `uvx`+`mcp-remote`)
+
+---
+
+## 3. Generating an API Key
+
+### Via the Stash Web UI (recommended)
+
+1. Log in at [joinstash.ai](https://joinstash.ai)
+2. Navigate to **Settings → API Keys**
+3. Click **Create New Key**
+4. Choose an access level:
+   - **Full access** (`full`) — read and write operations
+   - **Read access** (`read`) — reads plus transcript/session upload (for
+     production agents that only need to push session logs)
+5. Copy the raw key immediately — it is shown only once
+
+### Via the REST API
+
+When password-based auth is enabled (not Auth0), you can register a new user
+and get an API key in one call:
+
+```bash
+curl -X POST https://joinstash.ai/api/v1/users/register \
+  -H "Content-Type: application/json" \
+  -d '{"name": "your-username", "password": "your-password", "email": "you@example.com"}'
+```
+
+The response includes `api_key` — a `st_`-prefixed token.
+
+For existing users, the UI is the intended path. You can also create additional
+keys via:
+
+```bash
+curl -X POST https://joinstash.ai/api/v1/users/me/keys \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "mcp-key", "access": "full"}'
+```
+
+> ⚠️ The raw key is returned only once. Store it securely. Keys are hashed
+> before being persisted — Stash never stores the raw key.
+
+### API Key Format
+
+- Prefix: `st_` (new keys) or `mc_` (legacy keys from the pre-rename era)
+- Both prefixes remain valid for as long as the key exists
+- Key types: `full` (read + write) and `read` (reads + transcript upload)
+
+---
+
+## 4. Server Configuration
+
+The Stash MCP server uses **Server-Sent Events (SSE)** transport. There is no
+stdio transport — all clients must connect via SSE.
+
+| Property | Value |
+|----------|-------|
+| Mount path | `https://joinstash.ai/api/v1/mcp` |
+| SSE endpoint | `https://joinstash.ai/api/v1/mcp/sse` |
+| Messages endpoint | `https://joinstash.ai/api/v1/mcp/messages/` |
+| Authentication | Bearer token via `Authorization` header |
+| Token prefix | `st_` or `mc_` |
+| Port | 443 (standard HTTPS) |
+
+Clients that do not support SSE natively can use the
+[`mcp-remote`](https://github.com/geelen/mcp-remote) bridge to
+wrap the SSE endpoint as a stdio subprocess.
+
+---
+
+## 5. Claude Desktop Configuration
+
+### Option A — Using `uvx mcp-remote` (works with any Claude Desktop version)
+
+Install `mcp-remote` once:
+
+```bash
+uv tool install mcp-remote
+```
+
+Then add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "stash": {
+      "command": "uvx",
+      "args": ["mcp-remote", "https://joinstash.ai/api/v1/mcp/sse"],
+      "env": {
+        "STASH_API_KEY": "st_YOUR_API_KEY_HERE"
+      }
+    }
+  }
+}
+```
+
+The `STASH_API_KEY` env var is picked up by `mcp-remote` and forwarded as the
+`Authorization: Bearer` header.
+
+### Option B — Direct SSE (for clients with native SSE support)
+
+```json
+{
+  "mcpServers": {
+    "stash": {
+      "type": "sse",
+      "url": "https://joinstash.ai/api/v1/mcp/sse",
+      "headers": {
+        "Authorization": "Bearer st_YOUR_API_KEY_HERE"
+      }
+    }
+  }
+}
+```
+
+---
+
+## 6. Fusion Agent Configuration
+
+### MCP Server Settings
+
+In your Fusion project's MCP configuration, add:
+
+```json
+{
+  "mcpServers": {
+    "stash": {
+      "transport": "sse",
+      "url": "https://joinstash.ai/api/v1/mcp/sse",
+      "headers": {
+        "Authorization": "Bearer st_YOUR_API_KEY_HERE"
+      }
+    }
+  }
+}
+```
+
+### Agent Instructions Snippet
+
+Include the following in your Fusion agent's instructions or Prompt.md so the
+agent knows how to use the Stash MCP tools:
+
+```
+You have access to the Stash MCP server for search, VFS browsing, and memory.
+
+Use `stash_search` to find past work, sessions, and connected-source documents.
+Use `stash_vfs_ls` / `stash_vfs_cat` to browse and read files from the VFS.
+Use `stash_session_search` to recall past agent sessions by keyword.
+Use `get_stash_info` to verify your connection is working.
+
+Always send your Stash API key as `Authorization: Bearer st_YOUR_KEY` in the
+MCP Authentication header.
+```
+
+---
+
+## 7. Available Tools
+
+All tools are registered in the MCP server at
+[`backend/services/mcp_service.py`](../backend/services/mcp_service.py). Each
+returns a JSON string.
+
+| Tool | Description | Required Parameters | Optional Parameters |
+|------|-------------|-------------------|-------------------|
+| `get_stash_info` | Return identity info about the Stash server and authenticated user — includes `user_id`, `client_id`, `scopes`, name, version | — | — |
+| `stash_search` | Search across all Stash content accessible to the authenticated user: native files, sessions, connected-source documents, and federated sources | `query` (string) | `limit` (int, default 10) |
+| `stash_session_search` | Search the authenticated user's recent sessions by keyword — performs full-text search across session transcript content (user messages, assistant messages, tool calls) and returns matching events with session context. Uses PostgreSQL websearch syntax. | `query` (string) | `limit` (int, default 10) |
+| `stash_vfs_ls` | List directory contents in Stash's virtual filesystem. Start with `stash_vfs_ls(path="/")` to discover the top-level sections. | — | `path` (string, default `"/"`) |
+| `stash_vfs_cat` | Read a file's text contents from Stash's VFS. Use `stash_vfs_ls` first to discover file paths. | `path` (string) | — |
+
+### VFS Path Format
+
+The Stash virtual filesystem organizes content under these top-level paths:
+
+| Path | Contents |
+|------|----------|
+| `/` | Root — lists top-level sections |
+| `/files/…` | Pages and uploaded files |
+| `/sources/<handle>/…` | Connected source documents (GitHub, Notion, Slack, etc.) |
+| `/sessions/…` | Agent session transcripts |
+| `/memory/…` | Agent-curated Memory wiki |
+| `/tables/…` | Table schemas and row data |
+| `/skills/…` | Published Skill folders |
+
+### Additional Tools
+
+The MCP server may be extended with additional tools over time. Agents may find
+tools such as:
+
+- `stash_session_upload` — upload session transcripts
+- `stash_memory_search` — search agent memory
+- `stash_memory_append` — append to agent memory
+
+For the canonical, always-up-to-date tool listing, connect any MCP client and
+call `get_stash_info`, or inspect the server's tool registration endpoint.
+
+---
+
+## 8. Testing the Connection
+
+Follow these steps to verify your MCP client is properly connected:
+
+### Step 1: Connect
+
+Configure your MCP client with the SSE endpoint and API key (see sections 5–6
+above). Restart the client so it fetches the tool list from the server.
+
+### Step 2: Call `get_stash_info`
+
+This is the simplest tool and requires no arguments. It confirms auth is
+working and returns basic identity info.
+
+**Expected response** (formatted):
+```json
+{
+  "name": "stash",
+  "version": "0.x",
+  "user_id": "your-user-uuid",
+  "client_id": "your-user-uuid",
+  "scopes": ["stash:full"]
+}
+```
+
+**If you get an error**, see the Troubleshooting section below.
+
+### Step 3: Browse the VFS
+
+```javascript
+stash_vfs_ls(path="/")
+```
+
+**Expected response** — a directory listing showing the top-level VFS sections:
+```json
+{
+  "path": "/",
+  "is_dir": true,
+  "entries": ["files", "sessions", "sources", "memory", "tables", "skills", "..."],
+  "entry_count": 6,
+  "type": "directory"
+}
+```
+
+### Step 4: Search
+
+```javascript
+stash_search(query="test")
+```
+
+**Expected response** — a JSON array of results from your Stash content, or an
+empty array `[]` if no content matches.
+
+### Step 5: Session Search (optional)
+
+```javascript
+stash_session_search(query="deployment")
+```
+
+Searches your past agent sessions by keyword. Returns matching events with
+session context, or `{"count": 0, "results": []}` if none are found.
+
+---
+
+## 9. Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| **401 Unauthorized** | Missing or invalid API key | Verify the key is correct and starts with `st_` (or `mc_` for legacy keys). Generate a new key from **Settings → API Keys** in the Stash UI. |
+| **401 on SSE endpoint** | No `Authorization` header sent | Add `"Authorization": "Bearer st_YOUR_KEY"` to your MCP client configuration. If using `uvx mcp-remote`, ensure `STASH_API_KEY` is set in `env`. |
+| **"Authentication required"** | Token not passed to tool handler | Ensure your MCP client forwards auth headers with POST requests to the messages endpoint, not just the SSE connection. |
+| **SSE connection hangs** | Firewall, proxy, or network issue | Check that outbound HTTPS to `joinstash.ai` on port 443 is allowed. No custom port is needed. |
+| **Tool not found** | Outdated client cache | Restart the MCP client to re-fetch the tool list from the server. |
+| **"Invalid API key"** | Key was revoked or mistyped | Generate a new key at **Settings → API Keys** in the Stash UI. Keys are shown only once at creation — if lost, revoke the old key and create a new one. |
+| **403 Forbidden on write** | Using a read-access key for a mutating operation | Create a new key with `"access": "full"` via **Settings → API Keys**. |
+| **Empty results from `stash_search`** | No content indexed yet | Upload files, connect sources (GitHub, Notion, etc.), or use Stash for a few sessions to build up indexable content. |
+
+### Auth Mode Note
+
+Stash supports two authentication modes:
+
+- **API key** (`st_` / `mc_` prefix) — the standard mode documented here. Works
+  regardless of whether Auth0 is enabled.
+- **Auth0 JWT** (when `AUTH0_ENABLED=true` on the server) — only used by the web
+  UI. MCP clients should always use API keys, not JWTs.
+
+---
+
+## 10. Additional Resources
+
+- [Stash](https://joinstash.ai) — shared memory for AI coding agents
+- [Model Context Protocol specification](https://modelcontextprotocol.io) —
+  the protocol underlying this integration
+- [Fusion](https://runfusion.ai) — AI-orchestrated task board
+- [`mcp-remote` bridge](https://github.com/geelen/mcp-remote) —
+  wraps SSE MCP servers for clients that only support stdio
+- Stash API reference — see the [API docs](../backend/routers/README.md) and
+  [MCP service source](../backend/services/mcp_service.py)

--- a/plugins/claude-plugin/scripts/config.py
+++ b/plugins/claude-plugin/scripts/config.py
@@ -24,14 +24,14 @@ PRODUCTION_BASE_URL = "https://api.joinstash.ai"
 def get_stdin_data() -> dict:
     try:
         return json.loads(sys.stdin.read())
-    except Exception:
+    except (json.JSONDecodeError, OSError):
         return {}
 
 
 def _read_json(path: Path) -> dict:
     try:
         return json.loads(path.read_text())
-    except Exception:
+    except (json.JSONDecodeError, OSError):
         return {}
 
 

--- a/plugins/claude-plugin/scripts/on_prompt.py
+++ b/plugins/claude-plugin/scripts/on_prompt.py
@@ -16,11 +16,8 @@ def main():
     cfg = get_config()
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            stream_user_message(client, cfg, state, event.prompt_text, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_user_message(client, cfg, state, event.prompt_text, event)
 
 
 if __name__ == "__main__":

--- a/plugins/claude-plugin/scripts/on_session_end.py
+++ b/plugins/claude-plugin/scripts/on_session_end.py
@@ -16,11 +16,8 @@ def main():
     cfg = get_config()
 
     event = adapt_stop(get_stdin_data())
-    try:
-        with get_client() as client:
-            stream_session_end(client, cfg, state, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_session_end(client, cfg, state, event)
 
     state["session_id"] = ""
     save_state(DATA_DIR, state)

--- a/plugins/claude-plugin/scripts/on_session_start.py
+++ b/plugins/claude-plugin/scripts/on_session_start.py
@@ -90,13 +90,10 @@ def main():
     state = load_state(DATA_DIR)
 
     session_context = ""
-    try:
-        from config import get_client
+    from config import get_client
 
-        with get_client() as client:
-            session_url = create_session_record(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        session_url = None
+    with get_client() as client:
+        session_url = create_session_record(client, cfg, state, event, DATA_DIR)
 
     # The CLI upgrade runs from scripts/ensure_cli.sh before this script is
     # reached: an upgrade invoked here cannot run on the stale CLIs that need it.

--- a/plugins/claude-plugin/scripts/on_stop.py
+++ b/plugins/claude-plugin/scripts/on_stop.py
@@ -28,11 +28,8 @@ def main():
     event = adapt_stop(get_stdin_data())
     cfg = get_config()
 
-    try:
-        with get_client() as client:
-            stream_assistant_message(client, cfg, state, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_assistant_message(client, cfg, state, event)
     warning = upload_health_warning(cfg, state, event, DATA_DIR)
     if warning:
         # Claude Code only shows a Stop hook's `systemMessage`; bare stdout

--- a/plugins/claude-plugin/scripts/on_tool_use.py
+++ b/plugins/claude-plugin/scripts/on_tool_use.py
@@ -19,11 +19,8 @@ def main():
         return
 
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_tool_use(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_tool_use(client, cfg, state, event, DATA_DIR)
 
 
 if __name__ == "__main__":

--- a/plugins/codex-plugin/scripts/on_prompt.py
+++ b/plugins/codex-plugin/scripts/on_prompt.py
@@ -15,11 +15,8 @@ def main():
     cfg = get_config()
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            stream_user_message(client, cfg, state, event.prompt_text, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_user_message(client, cfg, state, event.prompt_text, event)
 
 
 if __name__ == "__main__":

--- a/plugins/codex-plugin/scripts/on_session_start.py
+++ b/plugins/codex-plugin/scripts/on_session_start.py
@@ -61,11 +61,8 @@ def main():
     reset_stats(DATA_DIR)
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            create_session_record(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        return
+    with get_client() as client:
+        create_session_record(client, cfg, state, event, DATA_DIR)
 
     spawn_skills_sync(cfg)
 

--- a/plugins/codex-plugin/scripts/on_stop.py
+++ b/plugins/codex-plugin/scripts/on_stop.py
@@ -31,11 +31,8 @@ def main():
     event = adapt_stop(get_stdin_data())
     remember_transcript_path(state, event, DATA_DIR)
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_assistant_message(client, cfg, state, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_assistant_message(client, cfg, state, event)
 
     spawn_transcript_upload(
         data_dir=DATA_DIR,

--- a/plugins/codex-plugin/scripts/on_tool_use.py
+++ b/plugins/codex-plugin/scripts/on_tool_use.py
@@ -14,11 +14,8 @@ def main():
     if not event.tool_name:
         return
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_tool_use(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_tool_use(client, cfg, state, event, DATA_DIR)
 
 
 if __name__ == "__main__":

--- a/plugins/cursor-plugin/scripts/adapt.py
+++ b/plugins/cursor-plugin/scripts/adapt.py
@@ -90,7 +90,7 @@ def _parse_tool_output(raw) -> dict | None:
     if isinstance(raw, str):
         try:
             parsed = json.loads(raw)
-        except Exception:
+        except json.JSONDecodeError:
             return {"raw": raw}
         return parsed if isinstance(parsed, dict) else {"raw": raw}
     return {"raw": str(raw)}

--- a/plugins/cursor-plugin/scripts/on_agent_response.py
+++ b/plugins/cursor-plugin/scripts/on_agent_response.py
@@ -28,11 +28,8 @@ def main():
     if not event.last_assistant_message:
         return
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_assistant_message(client, cfg, state, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_assistant_message(client, cfg, state, event)
     warning = upload_health_warning(cfg, state, event, DATA_DIR)
     if warning:
         print(color_upload_health_warning(warning))

--- a/plugins/cursor-plugin/scripts/on_prompt.py
+++ b/plugins/cursor-plugin/scripts/on_prompt.py
@@ -20,11 +20,8 @@ def main():
     cfg = get_config()
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            stream_user_message(client, cfg, state, event.prompt_text, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_user_message(client, cfg, state, event.prompt_text, event)
 
 
 if __name__ == "__main__":

--- a/plugins/cursor-plugin/scripts/on_session_end.py
+++ b/plugins/cursor-plugin/scripts/on_session_end.py
@@ -16,12 +16,9 @@ def main():
     cfg = get_config()
 
     event = adapt_session_end(get_stdin_data())
-    try:
-        with get_client() as client:
-            stream_session_end(client, cfg, state, event)
-            finalize_session_upload(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_session_end(client, cfg, state, event)
+        finalize_session_upload(client, cfg, state, event, DATA_DIR)
 
     state["session_id"] = ""
     save_state(DATA_DIR, state)

--- a/plugins/cursor-plugin/scripts/on_session_start.py
+++ b/plugins/cursor-plugin/scripts/on_session_start.py
@@ -31,11 +31,10 @@ def main():
     reset_stats(DATA_DIR)
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            create_session_record(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        create_session_record(client, cfg, state, event, DATA_DIR)
+
+    spawn_self_upgrade()
 
     spawn_self_upgrade()
 

--- a/plugins/cursor-plugin/scripts/on_tool_use.py
+++ b/plugins/cursor-plugin/scripts/on_tool_use.py
@@ -14,11 +14,8 @@ def main():
     if not event.tool_name:
         return
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_tool_use(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_tool_use(client, cfg, state, event, DATA_DIR)
 
 
 if __name__ == "__main__":

--- a/plugins/gemini-plugin/scripts/on_prompt.py
+++ b/plugins/gemini-plugin/scripts/on_prompt.py
@@ -16,11 +16,8 @@ def main():
     cfg = get_config()
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            stream_user_message(client, cfg, state, event.prompt_text, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_user_message(client, cfg, state, event.prompt_text, event)
 
 
 if __name__ == "__main__":

--- a/plugins/gemini-plugin/scripts/on_session_end.py
+++ b/plugins/gemini-plugin/scripts/on_session_end.py
@@ -16,12 +16,9 @@ def main():
     cfg = get_config()
 
     event = adapt_session_end(get_stdin_data())
-    try:
-        with get_client() as client:
-            stream_session_end(client, cfg, state, event)
-            finalize_session_upload(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_session_end(client, cfg, state, event)
+        finalize_session_upload(client, cfg, state, event, DATA_DIR)
 
     state["session_id"] = ""
     save_state(DATA_DIR, state)

--- a/plugins/gemini-plugin/scripts/on_session_start.py
+++ b/plugins/gemini-plugin/scripts/on_session_start.py
@@ -31,11 +31,8 @@ def main():
     reset_stats(DATA_DIR)
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            create_session_record(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        create_session_record(client, cfg, state, event, DATA_DIR)
 
     spawn_skills_sync(cfg)
     spawn_self_upgrade()

--- a/plugins/gemini-plugin/scripts/on_stop.py
+++ b/plugins/gemini-plugin/scripts/on_stop.py
@@ -24,11 +24,8 @@ def main():
     event = adapt_stop(get_stdin_data())
     remember_transcript_path(state, event, DATA_DIR)
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_assistant_message(client, cfg, state, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_assistant_message(client, cfg, state, event)
     warning = upload_health_warning(cfg, state, event, DATA_DIR)
     if warning:
         print(color_upload_health_warning(warning))

--- a/plugins/gemini-plugin/scripts/on_tool_use.py
+++ b/plugins/gemini-plugin/scripts/on_tool_use.py
@@ -14,11 +14,8 @@ def main():
     if not event.tool_name:
         return
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_tool_use(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_tool_use(client, cfg, state, event, DATA_DIR)
 
 
 if __name__ == "__main__":

--- a/plugins/hermes-plugin/scripts/on_prompt.py
+++ b/plugins/hermes-plugin/scripts/on_prompt.py
@@ -21,11 +21,8 @@ def main():
     cfg = get_config()
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            stream_user_message(client, cfg, state, event.prompt_text, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_user_message(client, cfg, state, event.prompt_text, event)
 
 
 if __name__ == "__main__":

--- a/plugins/hermes-plugin/scripts/on_session_end.py
+++ b/plugins/hermes-plugin/scripts/on_session_end.py
@@ -16,12 +16,9 @@ def main():
     cfg = get_config()
 
     event = adapt_session_end(get_stdin_data())
-    try:
-        with get_client() as client:
-            stream_session_end(client, cfg, state, event)
-            finalize_session_upload(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_session_end(client, cfg, state, event)
+        finalize_session_upload(client, cfg, state, event, DATA_DIR)
 
     state["session_id"] = ""
     save_state(DATA_DIR, state)

--- a/plugins/hermes-plugin/scripts/on_session_start.py
+++ b/plugins/hermes-plugin/scripts/on_session_start.py
@@ -37,11 +37,9 @@ def main():
     reset_stats(DATA_DIR)
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            create_session_record(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    # A failed session create must abort before the background spawns, not vanish silently.
+    with get_client() as client:
+        create_session_record(client, cfg, state, event, DATA_DIR)
 
     spawn_skills_sync(cfg)
     spawn_self_upgrade()

--- a/plugins/hermes-plugin/scripts/on_stop.py
+++ b/plugins/hermes-plugin/scripts/on_stop.py
@@ -26,11 +26,8 @@ def main():
     state = load_state(DATA_DIR)
     event = adapt_stop(get_stdin_data())
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_assistant_message(client, cfg, state, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_assistant_message(client, cfg, state, event)
     warning = upload_health_warning(cfg, state, event, DATA_DIR)
     if warning:
         print(color_upload_health_warning(warning), file=sys.stderr)

--- a/plugins/hermes-plugin/scripts/on_tool_use.py
+++ b/plugins/hermes-plugin/scripts/on_tool_use.py
@@ -16,11 +16,8 @@ def main():
     if not event.tool_name:
         return
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_tool_use(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_tool_use(client, cfg, state, event, DATA_DIR)
 
 
 if __name__ == "__main__":

--- a/plugins/openclaw-plugin/scripts/on_prompt.py
+++ b/plugins/openclaw-plugin/scripts/on_prompt.py
@@ -21,11 +21,8 @@ def main():
     cfg = get_config()
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            stream_user_message(client, cfg, state, event.prompt_text, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_user_message(client, cfg, state, event.prompt_text, event)
 
 
 if __name__ == "__main__":

--- a/plugins/openclaw-plugin/scripts/on_session_end.py
+++ b/plugins/openclaw-plugin/scripts/on_session_end.py
@@ -16,12 +16,9 @@ def main():
     cfg = get_config()
 
     event = adapt_session_end(get_stdin_data())
-    try:
-        with get_client() as client:
-            stream_session_end(client, cfg, state, event)
-            finalize_session_upload(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_session_end(client, cfg, state, event)
+        finalize_session_upload(client, cfg, state, event, DATA_DIR)
 
     state["session_id"] = ""
     save_state(DATA_DIR, state)

--- a/plugins/openclaw-plugin/scripts/on_session_start.py
+++ b/plugins/openclaw-plugin/scripts/on_session_start.py
@@ -31,11 +31,8 @@ def main():
     reset_stats(DATA_DIR)
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            create_session_record(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        create_session_record(client, cfg, state, event, DATA_DIR)
 
     spawn_skills_sync(cfg)
     spawn_self_upgrade()

--- a/plugins/openclaw-plugin/scripts/on_stop.py
+++ b/plugins/openclaw-plugin/scripts/on_stop.py
@@ -26,11 +26,8 @@ def main():
     event = adapt_stop(get_stdin_data())
     cfg = get_config()
 
-    try:
-        with get_client() as client:
-            stream_assistant_message(client, cfg, state, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_assistant_message(client, cfg, state, event)
     warning = upload_health_warning(cfg, state, event, DATA_DIR)
     if warning:
         print(color_upload_health_warning(warning))

--- a/plugins/opencode-plugin/scripts/on_prompt.py
+++ b/plugins/opencode-plugin/scripts/on_prompt.py
@@ -14,11 +14,8 @@ def main():
     event = adapt_prompt(get_stdin_data())
     cfg = get_config()
     state = load_state(DATA_DIR)
-    try:
-        with get_client() as client:
-            stream_user_message(client, cfg, state, event.prompt_text, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_user_message(client, cfg, state, event.prompt_text, event)
 
 
 if __name__ == "__main__":

--- a/plugins/opencode-plugin/scripts/on_session_end.py
+++ b/plugins/opencode-plugin/scripts/on_session_end.py
@@ -16,12 +16,9 @@ def main():
     cfg = get_config()
 
     event = adapt_session_end(get_stdin_data())
-    try:
-        with get_client() as client:
-            stream_session_end(client, cfg, state, event)
-            finalize_session_upload(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_session_end(client, cfg, state, event)
+        finalize_session_upload(client, cfg, state, event, DATA_DIR)
 
     state["session_id"] = ""
     save_state(DATA_DIR, state)

--- a/plugins/opencode-plugin/scripts/on_session_start.py
+++ b/plugins/opencode-plugin/scripts/on_session_start.py
@@ -28,12 +28,9 @@ def _flush_stale_session(prior_sid: str, state: dict) -> None:
     cfg = get_config()
     stale_state = {**state, "session_id": prior_sid}
     stale_event = HookEvent(kind="session_end", session_id=prior_sid, cwd="")
-    try:
-        with get_client() as client:
-            stream_session_end(client, cfg, stale_state, stale_event)
-            finalize_session_upload(client, cfg, stale_state, stale_event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_session_end(client, cfg, stale_state, stale_event)
+        finalize_session_upload(client, cfg, stale_state, stale_event, DATA_DIR)
 
 
 def main():
@@ -56,11 +53,8 @@ def main():
     reset_stats(DATA_DIR)
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            create_session_record(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        create_session_record(client, cfg, state, event, DATA_DIR)
 
     spawn_skills_sync(cfg)
     spawn_self_upgrade()

--- a/plugins/opencode-plugin/scripts/on_tool_use.py
+++ b/plugins/opencode-plugin/scripts/on_tool_use.py
@@ -14,11 +14,8 @@ def main():
     if not event.tool_name:
         return
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_tool_use(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_tool_use(client, cfg, state, event, DATA_DIR)
 
 
 if __name__ == "__main__":

--- a/plugins/pi-plugin/AGENTS.md
+++ b/plugins/pi-plugin/AGENTS.md
@@ -1,0 +1,37 @@
+# Stash
+
+You have the `stash` CLI on your PATH. Run `stash --help` to see commands. Use it to read transcripts, pages, and history from your Stash.
+
+Your activity in this repo is streamed to your Stash, so your other agents and you can see what you're working on.
+
+## What a Skill is
+
+A **Skill** is a *special folder* — one containing a SKILL.md — holding related artifacts (pages, files, tables) that shares like any folder and gains a public URL when published. Use one when you're publishing a *collection* of related things together — a project writeup with its supporting files, a research thread with its sources, a session transcript plus the files it produced.
+
+A Skill is **not** a wrapper to slap on every single file you happen to share. One-item Skills clutter Discover and defeat the model.
+
+## How to share things
+
+- **One file someone should look at** → `stash upload <path> --json` and hand them the returned `app_url`. No Skill needed.
+- **A folder / project into your Stash** → `stash upload <path> --json`. Returns the folder `app_url`. No Skill created by default.
+- **A curated bundle as one shareable thing** → `stash upload <path> --skill "<title>" --json`, or `stash skills create "<name>" --public` to start a fresh one. Returns the Skill `url`.
+- **A coding session (transcript + touched files)** → `stash share <session_id>`. Sessions are inherently a bundle.
+
+Run `stash prompts agent-guidance` any time you want this guidance reprinted in full.
+
+## Browsing
+
+`stash ls` shows everything Stash can reach as one filesystem — your files, session transcripts, and every connected integration (GitHub, Slack, Gong, Gmail, Drive, Notion, …). When asked what you have access to, run it and show the tree; drill in with `stash ls <source>/<path>`.
+
+Use `stash vfs` when you want to browse Stash like a filesystem without mounting anything into the OS. It accepts bash-shaped commands over the virtual Stash tree:
+- `stash vfs ls /me`
+- `stash vfs "find /me -maxdepth 3 -type f"`
+- `stash vfs "rg \"query\" /me"`
+- `stash vfs "cat '/me/README.md' | sed -n '1,80p'"`
+
+## Common reads (all support `--json`)
+
+- `stash search "<query>"` — full-text search across transcripts
+- `stash vfs "cat '/me/sessions/_index.jsonl'"` — recent events
+- `stash sessions agents` — who's been active
+- `stash vfs "find /me -name '*.md'"` — your pages

--- a/plugins/pi-plugin/README.md
+++ b/plugins/pi-plugin/README.md
@@ -1,0 +1,87 @@
+# Stash Plugin for Pi
+
+Streams Pi coding sessions to Stash using Pi's native `~/.pi/hooks/` system.
+
+## Prerequisites
+
+- `stash` CLI installed and logged in
+- `.stash` manifest present in repo (or ancestor)
+- Python 3.10+ and `httpx`
+- Pi installed with hook directory support (`~/.pi/hooks/`)
+
+## Install
+
+The recommended way to install the Pi hooks is through the `stash` CLI, which
+supersedes the manual instructions below: `stash settings` (or the interactive
+`stash connect` flow) detects Pi on your machine and copies the self-contained
+hook runtime into `~/.pi/` (`_run.sh`, `scripts/hooks/*`, and the `on_*.py`
+handlers) from the shipped assets under `stashai/plugin/assets/pi/`. No
+symlinks are created, so the install keeps working even if the stash checkout
+or pipx env moves, and it never depends on this repo's location.
+
+Manual install (fallback, when you cannot run the CLI installer):
+
+```bash
+cd path/to/stash/plugins/pi-plugin
+export PLUGIN_ROOT=$(pwd)
+mkdir -p ~/.pi/hooks
+
+# Symlink each hook wrapper (symlinks auto-update when you pull the repo)
+ln -sf "$PLUGIN_ROOT/scripts/hooks/"* ~/.pi/hooks/
+
+# Agent context — tells Pi it has the stash CLI available
+cat AGENTS.md >> ~/.pi/AGENTS.md
+```
+
+Note that the manual symlink path points at this checkout, so it breaks if the
+repo moves; prefer the CLI installer which copies the runtime into `~/.pi/`.
+
+## How Pi hooks work
+
+Pi reads executable files from `~/.pi/hooks/` — one file per event name.
+Each hook receives JSON on stdin with the event payload and must exit
+with status 0. The hook files in `scripts/hooks/` are thin bash wrappers
+that delegate to `_run.sh`, which resolves the correct Python interpreter
+and dispatches to the corresponding `on_*.py` handler.
+
+## Commands
+
+Everything is a plain `stash` CLI subcommand — no slash commands or skills:
+
+| Command | Description |
+|---------|-------------|
+| `stash connect` | Interactive setup (auth + store) |
+| `stash settings` | Interactive settings page (streaming, scope, endpoint, …) |
+| `stash disconnect` | Pause event streaming across every installed plugin |
+
+## What streams
+
+| Pi event | Stash event | Notes |
+|---|---|---|
+| `session_start` | — (warms cache) | Session record created, skills synced |
+| `user_message` | `user_message` | User prompt streamed |
+| `tool_use` | `tool_use` | Tool invocations streamed (bash, read, write, edit, grep, …) |
+| `assistant_message` | `assistant_message` + transcript upload | Per-turn assistant response; transcript uploaded in background with 60s cooldown |
+| `session_end` | `session_end` | Session finalized, state cleared |
+
+## Known gaps
+
+1. **Pi hook coverage depends on Pi's runtime.** Pi's hook system is still
+   maturing. Check Pi's documentation for which events fire reliably and
+   whether all tool types are covered.
+2. **macOS / Linux only.** Pi runs on macOS and Linux. No Windows support.
+   (Consistent with all existing Stash streaming plugins.)
+
+## Retrieval
+
+Pi has shell access. For reads mid-conversation, have the agent invoke
+the `stash` CLI. Use `stash vfs` for filesystem-style browsing without an OS mount:
+
+```
+stash vfs "find /me -maxdepth 3 -type f"
+stash vfs "rg \"database migration\" /me"
+stash vfs "cat '/me/README.md' | sed -n '1,80p'"
+stash vfs "cat '/me/sessions/_index.jsonl'"
+stash search "<query>"
+stash whoami --json
+```

--- a/plugins/pi-plugin/scripts/_run.sh
+++ b/plugins/pi-plugin/scripts/_run.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Re-exec a plugin hook script under the python that has stashai installed.
+#
+# When stashai ships via pipx or uv (the install.sh defaults), the package
+# lives in an isolated venv — the system `python3` (often a pyenv shim) can't
+# import `stashai.plugin.*`, which breaks every plugin script. We resolve the
+# `stash` binary's symlink to find the venv it lives in, then exec its
+# python. Falls back to system `python3` for the plain `pip install --user`
+# case where stashai is on the user's site-packages directly.
+set -euo pipefail
+
+SCRIPT="$1"
+shift
+
+if [ "$SCRIPT" = "on_session_start" ]; then
+  command -v uv >/dev/null 2>&1 && uv tool install --quiet stashai@latest >/dev/null 2>&1 &
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="$SCRIPT_DIR/$SCRIPT.py"
+
+REPO_ROOT=""
+case "$SCRIPT_DIR" in
+  */stashai/plugin/assets/*/scripts)
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
+    ;;
+  */plugins/*-plugin/scripts)
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+    ;;
+esac
+if [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT/stashai" ] && [ -d "$REPO_ROOT/cli" ]; then
+  export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+fi
+
+PY=""
+if command -v stash >/dev/null 2>&1; then
+  STASH_BIN="$(command -v stash)"
+  # Find the interpreter that can import stashai. On Unix the pipx/uv shim is a
+  # symlink, so the venv python sits next to the resolved binary. On Windows the
+  # shim is a real .exe (not a symlink), so realpath stays in the shim dir and we
+  # also probe the uv tool venv. The path work is done in python because bash
+  # mishandles Windows backslash paths, and we only accept an interpreter that
+  # can actually import stashai — so we never silently pick the wrong one.
+  PY="$(python3 - "$STASH_BIN" <<'PY_EOF' 2>/dev/null || true
+import os, sys, shutil, subprocess
+stash = os.path.realpath(sys.argv[1])
+d = os.path.dirname(stash)
+cands = [os.path.join(d, "python"), os.path.join(d, "python.exe"),
+         os.path.join(d, "Scripts", "python.exe")]
+uv = shutil.which("uv")
+if uv:
+    try:
+        td = subprocess.run([uv, "tool", "dir"], capture_output=True,
+                            text=True, timeout=5).stdout.strip()
+    except (subprocess.TimeoutExpired, OSError) as e:
+        print(f"stash: uv tool dir failed: {e}", file=sys.stderr)
+        td = ""
+    if td:
+        cands += [os.path.join(td, "stashai", "bin", "python"),
+                  os.path.join(td, "stashai", "Scripts", "python.exe")]
+for c in cands:
+    if not os.path.exists(c):
+        continue
+    try:
+        subprocess.run([c, "-c", "import stashai"], check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10)
+    except (subprocess.SubprocessError, OSError) as e:
+        print(f"stash: {c} cannot import stashai: {e}", file=sys.stderr)
+        continue
+    print(c.replace(os.sep, "/"))
+    break
+PY_EOF
+)"
+fi
+
+# pip --user (stashai on system site-packages) or any case the venv-python
+# heuristic missed — fall through to whatever python3 is on PATH.
+if [ -z "$PY" ]; then
+  PY="python3"
+fi
+
+exec "$PY" "$TARGET" "$@"

--- a/plugins/pi-plugin/scripts/adapt.py
+++ b/plugins/pi-plugin/scripts/adapt.py
@@ -1,0 +1,102 @@
+"""Pi agent stdin payload -> canonical HookEvent.
+
+Pi uses executable hook files in ~/.pi/hooks/ — one file per event:
+session_start, user_message, tool_use, assistant_message, session_end.
+Each hook receives JSON on stdin with event-specific fields.
+
+Common input fields (every event): session_id, cwd, hook_event_name.
+Turn-scoped events add turn_id.
+
+Per-event extras:
+  session_start     {model, ...}
+  user_message      {turn_id, prompt}
+  tool_use          {turn_id, tool_name, tool_input, tool_use_id}
+  assistant_message {turn_id, last_assistant_message}
+  session_end       {}
+
+Pi tool names are lowercase native names:
+  bash, read, write, edit, grep, url_open, ask_followup, question,
+  search, memory, think, execute_command, use_mcp_tool
+"""
+
+from __future__ import annotations
+
+from stashai.plugin.event import HookEvent
+
+_TOOL_MAP = {
+    "bash": "bash",
+    "read": "read",
+    "write": "write",
+    "edit": "edit",
+    "grep": "grep",
+    "url_open": "webfetch",
+    "ask_followup": "ask",
+    "question": "ask",
+    "search": "ask",
+    "memory": "think",
+    "think": "think",
+    "execute_command": "bash",
+    "use_mcp_tool": "mcp",
+}
+_EXTRA_KEYS = ("model",)
+
+
+def _normalize(name: str) -> str:
+    return _TOOL_MAP.get(name.lower(), name.lower())
+
+
+def _extras(data: dict) -> dict:
+    return {key: data[key] for key in _EXTRA_KEYS if isinstance(data.get(key), str) and data[key]}
+
+
+def adapt_session_start(data: dict) -> HookEvent:
+    return HookEvent(
+        kind="session_start",
+        session_id=data.get("session_id", ""),
+        cwd=data.get("cwd", ""),
+        extras=_extras(data),
+    )
+
+
+def adapt_prompt(data: dict) -> HookEvent:
+    return HookEvent(
+        kind="prompt",
+        session_id=data.get("session_id", ""),
+        cwd=data.get("cwd", ""),
+        prompt_text=data.get("prompt", ""),
+        extras=_extras(data),
+    )
+
+
+def adapt_tool_use(data: dict) -> HookEvent:
+    tool_input = data.get("tool_input", {}) or {}
+    if isinstance(tool_input, str):
+        tool_input = {"raw": tool_input}
+    return HookEvent(
+        kind="tool_use",
+        session_id=data.get("session_id", ""),
+        cwd=data.get("cwd", ""),
+        tool_name=_normalize(data.get("tool_name", "")),
+        tool_input=tool_input,
+        tool_response=data.get("tool_response"),
+        extras=_extras(data),
+    )
+
+
+def adapt_stop(data: dict) -> HookEvent:
+    return HookEvent(
+        kind="stop",
+        session_id=data.get("session_id", ""),
+        cwd=data.get("cwd", ""),
+        last_assistant_message=data.get("last_assistant_message", ""),
+        extras=_extras(data),
+    )
+
+
+def adapt_session_end(data: dict) -> HookEvent:
+    return HookEvent(
+        kind="session_end",
+        session_id=data.get("session_id", ""),
+        cwd=data.get("cwd", ""),
+        extras=_extras(data),
+    )

--- a/plugins/pi-plugin/scripts/config.py
+++ b/plugins/pi-plugin/scripts/config.py
@@ -1,0 +1,69 @@
+"""Pi agent plugin config. Reads from ~/.stash/config.json (CLI config).
+
+Shared logic lives in `stashai.plugin.agent_config`; this module only
+supplies the per-agent constants.
+"""
+
+from __future__ import annotations
+
+import os
+
+from stashai.plugin import agent_config
+from stashai.plugin.agent_config import get_stdin_data
+from stashai.plugin.stash_client import StashClient
+
+_CLIENT = "pi"
+DATA_DIR = agent_config.data_dir_from_env("STASH_PI_DATA", ".stash/plugins/pi")
+
+__all__ = [
+    "DATA_DIR",
+    "get_client",
+    "get_config",
+    "get_stdin_data",
+    "is_configured",
+    "is_fusion_managed",
+]
+
+
+def get_config() -> dict:
+    return agent_config.get_config(_CLIENT)
+
+
+def get_client() -> StashClient:
+    return agent_config.get_client(_CLIENT, DATA_DIR)
+
+
+def is_configured() -> bool:
+    return agent_config.is_configured(_CLIENT)
+
+
+def is_fusion_managed(cwd: str | None) -> bool:
+    """True when a session runs inside a Fusion project directory.
+
+    Variant-1 guard: pi-plugin must stay silent for sessions whose working
+    directory is inside a Fusion project (a directory containing `.fusion/`).
+    There, Fusion's own engine session capture is the canonical recorder, so
+    recording from pi-hooks as well would double-record the same conversation
+    into Stash (once as `sess_*`, once as `fusion-<taskId>-<hash>`). Sessions
+    outside Fusion projects (standalone `pi` usage) are still recorded.
+
+    An empty/None cwd fails loud with ValueError rather than silently choosing
+    the "record" direction the guard exists to prevent.
+    """
+    if not cwd:
+        raise ValueError(
+            "is_fusion_managed requires a non-empty cwd; refusing to guess the recording direction"
+        )
+    home = os.path.expanduser("~")
+    d = os.path.abspath(cwd)
+    while True:
+        # Marker must never match the global Fusion config dir at $HOME/.fusion
+        # (daemon token / global settings). Walking the whole tree up to /
+        # would classify every Pi session under $HOME as Fusion-managed and
+        # silently stop all recording on the machine.
+        if d != home and os.path.isdir(os.path.join(d, ".fusion")):
+            return True
+        parent = os.path.dirname(d)
+        if parent == d:
+            return False
+        d = parent

--- a/plugins/pi-plugin/scripts/hooks/assistant_message
+++ b/plugins/pi-plugin/scripts/hooks/assistant_message
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/../_run.sh" on_stop "$@"

--- a/plugins/pi-plugin/scripts/hooks/session_end
+++ b/plugins/pi-plugin/scripts/hooks/session_end
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/../_run.sh" on_session_end "$@"

--- a/plugins/pi-plugin/scripts/hooks/session_start
+++ b/plugins/pi-plugin/scripts/hooks/session_start
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/../_run.sh" on_session_start "$@"

--- a/plugins/pi-plugin/scripts/hooks/tool_use
+++ b/plugins/pi-plugin/scripts/hooks/tool_use
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/../_run.sh" on_tool_use "$@"

--- a/plugins/pi-plugin/scripts/hooks/user_message
+++ b/plugins/pi-plugin/scripts/hooks/user_message
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/../_run.sh" on_prompt "$@"

--- a/plugins/pi-plugin/scripts/on_prompt.py
+++ b/plugins/pi-plugin/scripts/on_prompt.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Pi user_message: stream prompt to Stash."""
+
+from adapt import adapt_prompt
+from config import (
+    DATA_DIR,
+    get_client,
+    get_config,
+    get_stdin_data,
+    is_configured,
+    is_fusion_managed,
+)
+
+from stashai.plugin.hooks import stream_user_message
+from stashai.plugin.state import load_state
+
+
+def main():
+    if not is_configured():
+        return
+    event = adapt_prompt(get_stdin_data())
+    if is_fusion_managed(event.cwd):
+        return
+    cfg = get_config()
+    state = load_state(DATA_DIR)
+
+    # A failed upload must surface to the hook runner, not vanish silently.
+    with get_client() as client:
+        stream_user_message(client, cfg, state, event.prompt_text, event)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/pi-plugin/scripts/on_session_end.py
+++ b/plugins/pi-plugin/scripts/on_session_end.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Pi session_end: push session_end and finalize."""
+
+from adapt import adapt_session_end
+from config import (
+    DATA_DIR,
+    get_client,
+    get_config,
+    get_stdin_data,
+    is_configured,
+    is_fusion_managed,
+)
+
+from stashai.plugin.hooks import finalize_session_upload, stream_session_end
+from stashai.plugin.state import load_state, save_state
+
+
+def main():
+    if not is_configured():
+        return
+
+    state = load_state(DATA_DIR)
+    cfg = get_config()
+
+    event = adapt_session_end(get_stdin_data())
+    if is_fusion_managed(event.cwd):
+        return
+    # A failed finalize must surface to the hook runner, not vanish silently.
+    with get_client() as client:
+        stream_session_end(client, cfg, state, event)
+        finalize_session_upload(client, cfg, state, event, DATA_DIR)
+
+    state["session_id"] = ""
+    save_state(DATA_DIR, state)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/pi-plugin/scripts/on_session_start.py
+++ b/plugins/pi-plugin/scripts/on_session_start.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Pi session_start: save session_id and create the session record."""
+
+import json
+import os
+
+from adapt import adapt_session_start
+from config import (
+    DATA_DIR,
+    get_client,
+    get_config,
+    get_stdin_data,
+    is_fusion_managed,
+)
+
+from cli.formatting import echo_stdout
+from stashai.plugin.hooks import (
+    color_upload_health_warning,
+    create_session_record,
+    reset_session_record_state,
+    uploads_disabled_warning,
+    uploads_enabled,
+)
+from stashai.plugin.session_upload import spawn_session_watcher, spawn_skills_sync
+from stashai.plugin.state import load_state, reset_stats, save_state
+
+
+def main():
+    event = adapt_session_start(get_stdin_data())
+    if is_fusion_managed(event.cwd):
+        return
+    cfg = get_config()
+    state = load_state(DATA_DIR)
+    if not uploads_enabled(cfg, event):
+        warning = uploads_disabled_warning(cfg, state, event, DATA_DIR)
+        if warning:
+            echo_stdout(json.dumps({"systemMessage": color_upload_health_warning(warning)}))
+        return
+
+    reset_session_record_state(state)
+    state["session_id"] = event.session_id
+    save_state(DATA_DIR, state)
+    reset_stats(DATA_DIR)
+    state = load_state(DATA_DIR)
+
+    # A failed session-create must surface to the hook runner, not vanish
+    # silently; the watcher spawns only when the record was actually created.
+    with get_client() as client:
+        create_session_record(client, cfg, state, event, DATA_DIR)
+
+    spawn_skills_sync(cfg)
+
+    if state.get("session_row_id"):
+        spawn_session_watcher(
+            agent_pid=os.getppid(),
+            session_id=event.session_id,
+            agent_name=cfg.get("agent_name", ""),
+            base_url=cfg.get("api_endpoint", ""),
+            api_key=cfg.get("api_key", ""),
+            cwd=event.cwd or "",
+            data_dir=DATA_DIR,
+            session_row_id=state.get("session_row_id", ""),
+            transcript_path=event.transcript_path,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/pi-plugin/scripts/on_stop.py
+++ b/plugins/pi-plugin/scripts/on_stop.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Pi assistant_message: stream assistant message and upload transcript.
+
+Pi's assistant_message hook fires per-turn. We push assistant_message (not
+session_end) and deliberately do NOT clear session_id — subsequent turns in
+the same session need it for correlation. session_end is handled separately.
+
+Transcript upload is spawned as a detached background process (so it doesn't
+block the hook timeout) with a 60s cooldown between uploads per session.
+"""
+
+import json
+
+from adapt import adapt_stop
+from config import (
+    DATA_DIR,
+    get_client,
+    get_config,
+    get_stdin_data,
+    is_configured,
+    is_fusion_managed,
+)
+
+from cli.formatting import echo_stdout
+from stashai.plugin.hooks import (
+    color_upload_health_warning,
+    remember_transcript_path,
+    stream_assistant_message,
+    upload_health_warning,
+)
+from stashai.plugin.state import load_state
+from stashai.plugin.transcript_upload import spawn_transcript_upload
+
+
+def main():
+    if not is_configured():
+        return
+    state = load_state(DATA_DIR)
+    event = adapt_stop(get_stdin_data())
+    if is_fusion_managed(event.cwd):
+        return
+    remember_transcript_path(state, event, DATA_DIR)
+    cfg = get_config()
+    # A failed stream must surface to the hook runner, not vanish silently.
+    with get_client() as client:
+        stream_assistant_message(client, cfg, state, event)
+
+    spawn_transcript_upload(
+        data_dir=DATA_DIR,
+        transcript_path=event.transcript_path,
+        session_id=state.get("session_id", ""),
+        agent_name=cfg["agent_name"],
+        cwd=event.cwd,
+        base_url=cfg["api_endpoint"],
+        api_key=cfg["api_key"],
+        session_folder_id=cfg.get("session_folder_id", ""),
+    )
+    warning = upload_health_warning(cfg, state, event, DATA_DIR)
+    if warning:
+        echo_stdout(json.dumps({"systemMessage": color_upload_health_warning(warning)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/pi-plugin/scripts/on_tool_use.py
+++ b/plugins/pi-plugin/scripts/on_tool_use.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Pi tool_use: stream tool use to Stash."""
+
+from adapt import adapt_tool_use
+from config import (
+    DATA_DIR,
+    get_client,
+    get_config,
+    get_stdin_data,
+    is_configured,
+    is_fusion_managed,
+)
+
+from stashai.plugin.hooks import stream_tool_use
+from stashai.plugin.state import load_state
+
+
+def main():
+    if not is_configured():
+        return
+    state = load_state(DATA_DIR)
+    event = adapt_tool_use(get_stdin_data())
+    if is_fusion_managed(event.cwd):
+        return
+    if not event.tool_name:
+        return
+    cfg = get_config()
+    # A failed upload must surface to the hook runner, not vanish silently.
+    with get_client() as client:
+        stream_tool_use(client, cfg, state, event, DATA_DIR)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/pytest.ini
+++ b/plugins/pytest.ini
@@ -1,0 +1,11 @@
+[pytest]
+# Plugin runs disable coverage instead of scoping it. The root pytest.ini's
+# --cov=backend --cov-fail-under=30 gate measures only the backend package,
+# which the plugin suite barely imports, so the flagless `pytest plugins/tests`
+# would hard-fail on 0-2% backend coverage despite all tests passing. plugins/
+# has no importable package to scope coverage to, so --no-cov is the honest
+# override, matching how CI runs the plugin job (python -m pytest plugins/tests --no-cov).
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = session
+asyncio_default_test_loop_scope = session
+addopts = --no-cov

--- a/plugins/tests/test_assets_in_sync.py
+++ b/plugins/tests/test_assets_in_sync.py
@@ -14,7 +14,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC_DIR = REPO_ROOT / "plugins"
 DST_DIR = REPO_ROOT / "stashai" / "plugin" / "assets"
 
-AGENTS = ("cursor", "codex", "opencode", "gemini", "openclaw", "hermes")
+AGENTS = ("cursor", "codex", "opencode", "gemini", "openclaw", "hermes", "pi")
 IGNORE_NAMES = {"__pycache__", "node_modules"}
 IGNORE_SUFFIXES = {".pyc"}
 
@@ -33,7 +33,35 @@ def _iter_tracked_files(root: Path):
 def test_every_agent_has_shipped_assets():
     for agent in AGENTS:
         assert (DST_DIR / agent).is_dir(), (
-            f"Missing shipped assets for {agent!r}: " f"expected {DST_DIR / agent} to exist"
+            f"Missing shipped assets for {agent!r}: expected {DST_DIR / agent} to exist"
+        )
+
+
+def _assert_in_sync(
+    agent: str, src_root: Path, dst_root: Path, suffixes: set[str] | None = None
+) -> None:
+    def _tracked(root: Path) -> dict:
+        return {
+            rel: path
+            for rel, path in _iter_tracked_files(root)
+            if suffixes is None or path.suffix in suffixes
+        }
+
+    src_map = _tracked(src_root)
+    dst_map = _tracked(dst_root)
+
+    assert set(src_map) == set(dst_map), (
+        f"{agent}: file set drift between {src_root} and {dst_root}. "
+        f"Only in source: {sorted(set(src_map) - set(dst_map))}; "
+        f"only in assets: {sorted(set(dst_map) - set(src_map))}"
+    )
+
+    for rel in src_map:
+        src_bytes = src_map[rel].read_bytes()
+        dst_bytes = dst_map[rel].read_bytes()
+        assert src_bytes == dst_bytes, (
+            f"{agent}: {rel} differs between {src_root} and {dst_root}. "
+            f"Re-run the vendor copy when editing plugin sources."
         )
 
 

--- a/plugins/tests/test_ensure_cli.py
+++ b/plugins/tests/test_ensure_cli.py
@@ -12,7 +12,9 @@ still reach — so these tests pin the properties that make it work.
 from __future__ import annotations
 
 import json
+import os
 import re
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -33,6 +35,28 @@ def _as_tuple(version: str) -> tuple[int, ...]:
     return tuple(int(part) for part in version.split("."))
 
 
+def _hermetic_bin_dir(tmp_path: Path) -> Path:
+    """Build a bin dir that resolves every binary the script and its stubs need.
+
+    PATH must not see any host `uv` here: a real `/usr/bin/uv` would otherwise
+    push `test_stale_cli_without_uv_fails_loudly` into the uv-present branch and
+    the no-uv "fail loudly" path would never run. So the script runs with PATH
+    set to exactly this directory, containing symlinks to the tools it and its
+    `#!/usr/bin/env bash` stubs resolve: bash, awk (version_below and the
+    `stash --version` extraction call it unconditionally), plus sleep/touch for
+    the uv stub.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+
+    for tool in ("bash", "awk", "sleep", "touch", "sh", "env"):
+        target = shutil.which(tool)
+        assert target, f"cannot build hermetic PATH: {tool} not found on the host"
+        os.symlink(target, bin_dir / tool)
+
+    return bin_dir
+
+
 def _run(
     tmp_path: Path,
     *,
@@ -40,9 +64,8 @@ def _run(
     uv_present: bool,
     uv_seconds: int = 0,
 ) -> subprocess.CompletedProcess:
-    """Run ensure_cli.sh against stub `stash`/`uv` binaries on a minimal PATH."""
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
+    """Run ensure_cli.sh against stub `stash`/`uv` binaries on a hermetic PATH."""
+    bin_dir = _hermetic_bin_dir(tmp_path)
     marker = tmp_path / "upgraded"
 
     if stash_version is not None:
@@ -61,7 +84,11 @@ def _run(
 
     return subprocess.run(
         ["bash", str(ENSURE_CLI)],
-        env={"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(tmp_path)},
+        # PATH is only the sandbox bin dir: `command -v uv` sees nothing unless
+        # the test staged a stub, but every binary the script/stubs call (bash,
+        # awk, sleep, touch) still resolves there. HOME lets find_uv() seek
+        # ~/.local/bin/uv only inside the tmp dir.
+        env={"PATH": str(bin_dir), "HOME": str(tmp_path)},
         capture_output=True,
         text=True,
     )
@@ -117,10 +144,12 @@ def test_stale_cli_does_not_block_session_start(tmp_path):
 
 def test_stale_cli_without_uv_fails_loudly(tmp_path):
     """No silent no-op: a machine that cannot self-repair has to say so, or the
-    outage stays invisible the way the original one did."""
+    outage stays invisible the way the original one did. Pinpoints the no-uv
+    branch's message, which "not being recorded" (a substring of BOTH branches)
+    would not."""
     result = _run(tmp_path, stash_version="0.1.314", uv_present=False)
     assert result.returncode == 1
-    assert "not being recorded" in result.stderr
+    assert "Session activity is not being recorded" in result.stderr
     assert result.stdout == ""
 
 

--- a/plugins/tests/test_hermes_no_swallow.py
+++ b/plugins/tests/test_hermes_no_swallow.py
@@ -1,0 +1,52 @@
+"""Assert the hermes plugin hook scripts never bare-catch Stash calls.
+
+`stash connect hermes` hands users the hook scripts from the shipped assets,
+so a swallowed error there silently drops telemetry. AGENTS.md forbids bare
+catch-alls and silent swallow-and-continue: a failed upload / session-create /
+session-end / assistant-message / tool-use must propagate to the hook runner
+(fail loud) instead of vanishing.
+
+Both the canonical source (`plugins/hermes-plugin/scripts/`) and the shipped
+copy (`stashai/plugin/assets/hermes/scripts/`) are asserted separately so
+neither side can regress independently.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIRS = (
+    REPO_ROOT / "plugins" / "hermes-plugin" / "scripts",
+    REPO_ROOT / "stashai" / "plugin" / "assets" / "hermes" / "scripts",
+)
+
+# A bare catch-all swallows the exception with no log and no fail-loud:
+# `except:` or `except Exception:` / `except BaseException:` with nothing but
+# whitespace/comments between the keyword and the colon.
+BARE_CATCH = re.compile(r"^\s*except\s*(?:Exception|BaseException)?\s*:\s*(#.*)?$")
+
+
+def _offending_lines(scripts_dir: Path) -> list[tuple[str, int, str]]:
+    offenders: list[tuple[str, int, str]] = []
+    for script in sorted(scripts_dir.glob("*.py")):
+        for lineno, line in enumerate(script.read_text().splitlines(), start=1):
+            if BARE_CATCH.match(line):
+                offenders.append((script.name, lineno, line))
+    return offenders
+
+
+def test_hermes_source_no_bare_catch_all():
+    offenders = _offending_lines(SCRIPTS_DIRS[0])
+    assert not offenders, (
+        "hermes source hook scripts must not bare-catch Stash calls (fail loud). "
+        f"Found: {offenders}"
+    )
+
+
+def test_hermes_assets_no_bare_catch_all():
+    offenders = _offending_lines(SCRIPTS_DIRS[1])
+    assert not offenders, (
+        f"shipped hermes assets must not bare-catch Stash calls (fail loud). Found: {offenders}"
+    )

--- a/plugins/tests/test_no_swallow_per_agent.py
+++ b/plugins/tests/test_no_swallow_per_agent.py
@@ -1,0 +1,99 @@
+"""Lock the fail-loud invariant on every plugin's hook scripts.
+
+Each plugin source tree (`plugins/<agent>-plugin/scripts/`) and its shipped
+assets (`stashai/plugin/assets/<agent>/scripts/`) must not contain a bare
+`except Exception:`/`except BaseException:` or an unnamed `except:` that would
+swallow a Stash API failure (upload, session-create, tool-use, session-end).
+A swallow lets telemetry vanish without a trace; these must fail loud to the
+agent's hook runner instead.
+
+Two legitimate parse/IO guards are allowed to keep a default, but only under a
+narrow, specific exception type — never a bare catch-all:
+  - cursor adapt.py `_parse_tool_output` -> `except json.JSONDecodeError`
+  - claude config.py `get_stdin_data` / `_read_json` -> `except (json.JSONDecodeError, OSError)`
+hermes and pi have NO such parse guards — every Stash call in their on_* hooks
+is fail-loud, so no narrow guard is allowed or needed there.
+
+This test also asserts the STAS-019 silent-default (`if not cwd: return False`)
+is absent from every config.py, so a missing working dir fails loud instead of
+silently falling back.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_DIR = REPO_ROOT / "plugins"
+DST_DIR = REPO_ROOT / "stashai" / "plugin" / "assets"
+
+AGENTS = ("claude", "codex", "cursor", "gemini", "openclaw", "opencode", "hermes", "pi")
+
+# Agents whose hook scripts are also mirrored into `stashai/plugin/assets/`.
+# claude/gemini/openclaw are delivered outside the shipped-asset tree, so only
+# the canonical source is checked for them.
+ASSET_AGENTS = ("codex", "cursor", "opencode", "hermes", "pi")
+
+BARE_CATCHALL = re.compile(r"^\s*except (Exception|BaseException):")
+UNNAMED_CATCHALL = re.compile(r"^\s*except:")
+
+# STAS-019's silent-default: `if not cwd:` directly falling through to
+# `return False` swallows a missing working dir instead of failing loud. We
+# match the immediate fallback only (the exact pattern STAS-019 banned) so the
+# pi is_fusion_managed walk — which legitimately returns False once a real,
+# non-empty cwd is narrowed — is not falsely flagged.
+SILENT_DEFAULT = re.compile(r"if not cwd\s*:\s*return False")
+
+
+def _script_files(root: Path) -> list[Path]:
+    scripts = root / "scripts"
+    if not scripts.is_dir():
+        return []
+    return sorted(p for p in scripts.glob("*.py") if "__pycache__" not in p.parts)
+
+
+def _check_tree(agent: str, root: Path) -> None:
+    assert (root / "scripts").is_dir(), f"{agent}: expected {root / 'scripts'} to exist"
+    for path in _script_files(root):
+        lines = path.read_text().splitlines()
+        for idx, line in enumerate(lines, start=1):
+            assert not BARE_CATCHALL.search(line), (
+                f"{agent}: {path.relative_to(REPO_ROOT)}:{idx} has a bare "
+                f"{line.strip()!r} catch-all that would swallow an error. "
+                "Stash API failures must fail loud, not vanish silently."
+            )
+            assert not UNNAMED_CATCHALL.search(line), (
+                f"{agent}: {path.relative_to(REPO_ROOT)}:{idx} has an unnamed "
+                f"`except:` that catches everything. Use a narrow, specific "
+                "exception type or fail loud."
+            )
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_no_swallow_source_and_assets(agent: str) -> None:
+    """Every hook script in the source tree and its shipped assets must fail
+    loud — no bare catch-all may swallow a Stash API error."""
+    _check_tree(agent, SRC_DIR / f"{agent}-plugin")
+    if agent in ASSET_AGENTS:
+        _check_tree(agent, DST_DIR / agent)
+
+
+def test_config_no_silent_default() -> None:
+    """None of the plugin config.py files may carry STAS-019's
+    `if not cwd: return False` silent-default, which makes a missing working
+    dir silently fall back instead of failing loud."""
+    for agent in AGENTS:
+        cfgs = [SRC_DIR / f"{agent}-plugin" / "scripts" / "config.py"]
+        if agent in ASSET_AGENTS:
+            cfgs.append(DST_DIR / agent / "scripts" / "config.py")
+        for cfg in cfgs:
+            assert cfg.is_file(), f"expected {cfg.relative_to(REPO_ROOT)} to exist"
+            text = cfg.read_text()
+            assert SILENT_DEFAULT.search(text) is None, (
+                f"{cfg.relative_to(REPO_ROOT)} carries the "
+                f"`if not cwd: return False` silent-default. Fail loud "
+                "with ValueError instead."
+            )

--- a/plugins/tests/test_pi_echo_channel.py
+++ b/plugins/tests/test_pi_echo_channel.py
@@ -1,0 +1,64 @@
+"""Assert the pi-plugin hook scripts route hook-runner data through echo_stdout.
+
+`echo_stdout` (from STAS-066's CLI channel discipline) is the single path for
+parseable stdout data. The pi hooks emit exactly one piece of parseable data to
+the hook runner — the upload/disabled `systemMessage` JSON — and it must go
+through `echo_stdout`, never a raw ``print``, so stdout stays machine-parseable.
+This invariant is enforced on BOTH the canonical source
+(`plugins/pi-plugin/scripts/`) and the shipped copy
+(`stashai/plugin/assets/pi/scripts/`) so neither regresses independently.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+SRC_DIR = REPO_ROOT / "plugins" / "pi-plugin" / "scripts"
+DST_DIR = REPO_ROOT / "stashai" / "plugin" / "assets" / "pi" / "scripts"
+
+RAW_SYSTEM_MESSAGE_PRINT = re.compile(r"print\(json\.dumps\(\{\"systemMessage\"")
+
+_EMITTING_SCRIPTS = ("on_session_start.py", "on_stop.py")
+
+
+def _py_scripts(root: Path):
+    for path in sorted(root.rglob("*.py")):
+        if "__pycache__" not in path.parts:
+            yield path
+
+
+def test_system_message_never_emitted_via_raw_print():
+    """The hook runner reads the `systemMessage` payload from stdout; routing it
+    through a raw ``print`` bypasses the STAS-066 channel discipline and risks
+    polluting stdout, so the pi hooks must use echo_stdout instead."""
+    for root in (SRC_DIR, DST_DIR):
+        for path in _py_scripts(root):
+            for lineno, line in enumerate(path.read_text().splitlines(), 1):
+                assert not RAW_SYSTEM_MESSAGE_PRINT.search(line), (
+                    f"{path.relative_to(REPO_ROOT)}:{lineno} emits a systemMessage "
+                    f"via raw print: {line.strip()!r} (use echo_stdout)"
+                )
+
+
+def test_emitting_scripts_route_system_message_through_echo_stdout():
+    """The scripts that emit parseable data import and use echo_stdout."""
+    for name in _EMITTING_SCRIPTS:
+        text = (SRC_DIR / name).read_text()
+        assert "from cli.formatting import echo_stdout" in text, (
+            f"{SRC_DIR / name} does not import echo_stdout"
+        )
+        assert "echo_stdout(json.dumps" in text, (
+            f"{SRC_DIR / name} does not route its systemMessage through echo_stdout"
+        )
+
+
+def test_both_pi_copies_carry_the_wiring():
+    """The canonical source and the shipped copy must both route via echo_stdout."""
+    for name in _EMITTING_SCRIPTS:
+        for root in (SRC_DIR, DST_DIR):
+            text = (root / name).read_text()
+            assert "from cli.formatting import echo_stdout" in text
+            assert "echo_stdout(json.dumps" in text

--- a/plugins/tests/test_pi_no_swallow.py
+++ b/plugins/tests/test_pi_no_swallow.py
@@ -1,0 +1,59 @@
+"""Assert the pi-plugin hook scripts carry no bare catch-alls and no silent
+default on a missing cwd.
+
+AGENTS.md bans `except Exception` swallow-and-continue handlers and default
+values papering over a missing input. These invariants are enforced on BOTH
+the canonical source (`plugins/pi-plugin/scripts/`) and the shipped copy
+(`stashai/plugin/assets/pi/scripts/`) so neither regresses independently.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+BARE_EXCEPT_RE = re.compile(r"^\s*except (Exception|BaseException):")
+
+SRC_DIR = REPO_ROOT / "plugins" / "pi-plugin" / "scripts"
+DST_DIR = REPO_ROOT / "stashai" / "plugin" / "assets" / "pi" / "scripts"
+
+
+def _walk_py_scripts(root: Path):
+    for path in sorted(root.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        yield path
+
+
+def test_pi_hook_scripts_have_no_bare_except():
+    for root in (SRC_DIR, DST_DIR):
+        for path in _walk_py_scripts(root):
+            for lineno, line in enumerate(path.read_text().splitlines(), 1):
+                assert not BARE_EXCEPT_RE.match(line), (
+                    f"{path.relative_to(REPO_ROOT)}:{lineno} has a bare catch-all: {line.strip()!r}"
+                )
+
+
+def test_pi_run_sh_has_no_bare_except():
+    for path in (SRC_DIR / "_run.sh", DST_DIR / "_run.sh"):
+        text = path.read_text()
+        for lineno, line in enumerate(text.splitlines(), 1):
+            assert not BARE_EXCEPT_RE.match(line), (
+                f"{path.relative_to(REPO_ROOT)}:{lineno} has a bare "
+                f"catch-all: {line.strip()!r} (narrow to subprocess/OSError)"
+            )
+
+
+def test_pi_config_fails_loud_on_missing_cwd():
+    """is_fusion_managed must raise on a missing cwd, never silently return False."""
+    for root in (SRC_DIR, DST_DIR):
+        src = (root / "config.py").read_text()
+        # The function must fail loud on a missing cwd ...
+        assert "raise ValueError" in src, f"{root.name}/config.py no longer raises on a missing cwd"
+        # ... and the old silent-default branch (`if not cwd:` -> `return False`)
+        # must be gone.
+        assert re.search(r"if not cwd:\s*return False", src) is None, (
+            f"{root.name}/config.py still silently returns False for a missing cwd"
+        )

--- a/plugins/tests/test_plugin_config.py
+++ b/plugins/tests/test_plugin_config.py
@@ -31,6 +31,9 @@ def _load_config(path: Path):
     return module
 
 
+PI_CONFIG_PATH = ROOT / "plugins/pi-plugin/scripts/config.py"
+
+
 @pytest.fixture(autouse=True)
 def _clear_claude_env(monkeypatch, tmp_path):
     for key in (
@@ -40,6 +43,50 @@ def _clear_claude_env(monkeypatch, tmp_path):
     ):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(tmp_path / "plugin-data"))
+
+
+def test_is_fusion_managed_detects_fusion_project(tmp_path, monkeypatch):
+    """A cwd inside a directory containing `.fusion/` is Fusion-managed."""
+    home = tmp_path / "home"
+    repo = tmp_path / "repo"
+    (repo / ".fusion").mkdir(parents=True)
+    (repo / "app").mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    cfg = _load_config(PI_CONFIG_PATH)
+
+    assert cfg.is_fusion_managed(str(repo / "app")) is True
+    assert cfg.is_fusion_managed(str(repo)) is True
+
+
+def test_is_fusion_managed_ignores_home_fusion_dir(tmp_path, monkeypatch):
+    """$HOME/.fusion (global Fusion config) must never silence recording."""
+    home = tmp_path / "home"
+    (home / ".fusion").mkdir(parents=True)
+    inner = home / "work" / "proj"
+    inner.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+
+    cfg = _load_config(PI_CONFIG_PATH)
+
+    assert cfg.is_fusion_managed(str(inner)) is False
+    assert cfg.is_fusion_managed(str(home)) is False
+
+
+def test_is_fusion_managed_standalone_and_invalid(tmp_path, monkeypatch):
+    """Standalone projects are never Fusion-managed; empty cwd fails loud."""
+    home = tmp_path / "home"
+    standalone = tmp_path / "standalone"
+    standalone.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    cfg = _load_config(PI_CONFIG_PATH)
+
+    assert cfg.is_fusion_managed(str(standalone)) is False
+    with pytest.raises(ValueError):
+        cfg.is_fusion_managed("")
+    with pytest.raises(ValueError):
+        cfg.is_fusion_managed(None)
 
 
 @pytest.mark.parametrize("config_path", CONFIG_PATHS, ids=lambda p: str(p.relative_to(ROOT)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stashai"
-version = "0.1.367"
+version = "0.1.368"
 description = "CLI for Stash — shared memory for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/stashai/plugin/assets/__init__.py
+++ b/stashai/plugin/assets/__init__.py
@@ -4,6 +4,7 @@ Each agent directory mirrors `plugins/<agent>-plugin/` in the source repo.
 `stash connect` reads these to install hook configs into `~/.<agent>/` without
 requiring the user to clone the stash repo.
 
+Current agents: claude, codex, cursor, gemini, openclaw, opencode, pi.
 The source-of-truth is `plugins/<agent>-plugin/`; a drift test in
 `plugins/tests/test_assets_in_sync.py` keeps the two identical.
 """

--- a/stashai/plugin/assets/claude/scripts/config.py
+++ b/stashai/plugin/assets/claude/scripts/config.py
@@ -24,14 +24,14 @@ PRODUCTION_BASE_URL = "https://api.joinstash.ai"
 def get_stdin_data() -> dict:
     try:
         return json.loads(sys.stdin.read())
-    except Exception:
+    except (json.JSONDecodeError, OSError):
         return {}
 
 
 def _read_json(path: Path) -> dict:
     try:
         return json.loads(path.read_text())
-    except Exception:
+    except (json.JSONDecodeError, OSError):
         return {}
 
 

--- a/stashai/plugin/assets/claude/scripts/on_prompt.py
+++ b/stashai/plugin/assets/claude/scripts/on_prompt.py
@@ -16,11 +16,8 @@ def main():
     cfg = get_config()
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            stream_user_message(client, cfg, state, event.prompt_text, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_user_message(client, cfg, state, event.prompt_text, event)
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/claude/scripts/on_session_end.py
+++ b/stashai/plugin/assets/claude/scripts/on_session_end.py
@@ -16,11 +16,8 @@ def main():
     cfg = get_config()
 
     event = adapt_stop(get_stdin_data())
-    try:
-        with get_client() as client:
-            stream_session_end(client, cfg, state, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_session_end(client, cfg, state, event)
 
     state["session_id"] = ""
     save_state(DATA_DIR, state)

--- a/stashai/plugin/assets/claude/scripts/on_session_start.py
+++ b/stashai/plugin/assets/claude/scripts/on_session_start.py
@@ -90,13 +90,10 @@ def main():
     state = load_state(DATA_DIR)
 
     session_context = ""
-    try:
-        from config import get_client
+    from config import get_client
 
-        with get_client() as client:
-            session_url = create_session_record(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        session_url = None
+    with get_client() as client:
+        session_url = create_session_record(client, cfg, state, event, DATA_DIR)
 
     # The CLI upgrade runs from scripts/ensure_cli.sh before this script is
     # reached: an upgrade invoked here cannot run on the stale CLIs that need it.

--- a/stashai/plugin/assets/claude/scripts/on_stop.py
+++ b/stashai/plugin/assets/claude/scripts/on_stop.py
@@ -28,11 +28,8 @@ def main():
     event = adapt_stop(get_stdin_data())
     cfg = get_config()
 
-    try:
-        with get_client() as client:
-            stream_assistant_message(client, cfg, state, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_assistant_message(client, cfg, state, event)
     warning = upload_health_warning(cfg, state, event, DATA_DIR)
     if warning:
         # Claude Code only shows a Stop hook's `systemMessage`; bare stdout

--- a/stashai/plugin/assets/claude/scripts/on_tool_use.py
+++ b/stashai/plugin/assets/claude/scripts/on_tool_use.py
@@ -19,11 +19,8 @@ def main():
         return
 
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_tool_use(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_tool_use(client, cfg, state, event, DATA_DIR)
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/codex/scripts/on_prompt.py
+++ b/stashai/plugin/assets/codex/scripts/on_prompt.py
@@ -15,11 +15,8 @@ def main():
     cfg = get_config()
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            stream_user_message(client, cfg, state, event.prompt_text, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_user_message(client, cfg, state, event.prompt_text, event)
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/codex/scripts/on_session_start.py
+++ b/stashai/plugin/assets/codex/scripts/on_session_start.py
@@ -61,11 +61,8 @@ def main():
     reset_stats(DATA_DIR)
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            create_session_record(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        return
+    with get_client() as client:
+        create_session_record(client, cfg, state, event, DATA_DIR)
 
     spawn_skills_sync(cfg)
 

--- a/stashai/plugin/assets/codex/scripts/on_stop.py
+++ b/stashai/plugin/assets/codex/scripts/on_stop.py
@@ -31,11 +31,8 @@ def main():
     event = adapt_stop(get_stdin_data())
     remember_transcript_path(state, event, DATA_DIR)
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_assistant_message(client, cfg, state, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_assistant_message(client, cfg, state, event)
 
     spawn_transcript_upload(
         data_dir=DATA_DIR,

--- a/stashai/plugin/assets/codex/scripts/on_tool_use.py
+++ b/stashai/plugin/assets/codex/scripts/on_tool_use.py
@@ -14,11 +14,8 @@ def main():
     if not event.tool_name:
         return
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_tool_use(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_tool_use(client, cfg, state, event, DATA_DIR)
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/cursor/scripts/adapt.py
+++ b/stashai/plugin/assets/cursor/scripts/adapt.py
@@ -90,7 +90,7 @@ def _parse_tool_output(raw) -> dict | None:
     if isinstance(raw, str):
         try:
             parsed = json.loads(raw)
-        except Exception:
+        except json.JSONDecodeError:
             return {"raw": raw}
         return parsed if isinstance(parsed, dict) else {"raw": raw}
     return {"raw": str(raw)}

--- a/stashai/plugin/assets/cursor/scripts/on_agent_response.py
+++ b/stashai/plugin/assets/cursor/scripts/on_agent_response.py
@@ -28,11 +28,8 @@ def main():
     if not event.last_assistant_message:
         return
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_assistant_message(client, cfg, state, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_assistant_message(client, cfg, state, event)
     warning = upload_health_warning(cfg, state, event, DATA_DIR)
     if warning:
         print(color_upload_health_warning(warning))

--- a/stashai/plugin/assets/cursor/scripts/on_prompt.py
+++ b/stashai/plugin/assets/cursor/scripts/on_prompt.py
@@ -20,11 +20,8 @@ def main():
     cfg = get_config()
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            stream_user_message(client, cfg, state, event.prompt_text, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_user_message(client, cfg, state, event.prompt_text, event)
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/cursor/scripts/on_session_end.py
+++ b/stashai/plugin/assets/cursor/scripts/on_session_end.py
@@ -16,12 +16,9 @@ def main():
     cfg = get_config()
 
     event = adapt_session_end(get_stdin_data())
-    try:
-        with get_client() as client:
-            stream_session_end(client, cfg, state, event)
-            finalize_session_upload(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_session_end(client, cfg, state, event)
+        finalize_session_upload(client, cfg, state, event, DATA_DIR)
 
     state["session_id"] = ""
     save_state(DATA_DIR, state)

--- a/stashai/plugin/assets/cursor/scripts/on_session_start.py
+++ b/stashai/plugin/assets/cursor/scripts/on_session_start.py
@@ -31,11 +31,10 @@ def main():
     reset_stats(DATA_DIR)
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            create_session_record(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        create_session_record(client, cfg, state, event, DATA_DIR)
+
+    spawn_self_upgrade()
 
     spawn_self_upgrade()
 

--- a/stashai/plugin/assets/cursor/scripts/on_tool_use.py
+++ b/stashai/plugin/assets/cursor/scripts/on_tool_use.py
@@ -14,11 +14,8 @@ def main():
     if not event.tool_name:
         return
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_tool_use(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_tool_use(client, cfg, state, event, DATA_DIR)
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/gemini/scripts/on_prompt.py
+++ b/stashai/plugin/assets/gemini/scripts/on_prompt.py
@@ -16,11 +16,8 @@ def main():
     cfg = get_config()
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            stream_user_message(client, cfg, state, event.prompt_text, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_user_message(client, cfg, state, event.prompt_text, event)
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/gemini/scripts/on_session_end.py
+++ b/stashai/plugin/assets/gemini/scripts/on_session_end.py
@@ -16,12 +16,9 @@ def main():
     cfg = get_config()
 
     event = adapt_session_end(get_stdin_data())
-    try:
-        with get_client() as client:
-            stream_session_end(client, cfg, state, event)
-            finalize_session_upload(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_session_end(client, cfg, state, event)
+        finalize_session_upload(client, cfg, state, event, DATA_DIR)
 
     state["session_id"] = ""
     save_state(DATA_DIR, state)

--- a/stashai/plugin/assets/gemini/scripts/on_session_start.py
+++ b/stashai/plugin/assets/gemini/scripts/on_session_start.py
@@ -31,11 +31,8 @@ def main():
     reset_stats(DATA_DIR)
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            create_session_record(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        create_session_record(client, cfg, state, event, DATA_DIR)
 
     spawn_skills_sync(cfg)
     spawn_self_upgrade()

--- a/stashai/plugin/assets/gemini/scripts/on_stop.py
+++ b/stashai/plugin/assets/gemini/scripts/on_stop.py
@@ -24,11 +24,8 @@ def main():
     event = adapt_stop(get_stdin_data())
     remember_transcript_path(state, event, DATA_DIR)
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_assistant_message(client, cfg, state, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_assistant_message(client, cfg, state, event)
     warning = upload_health_warning(cfg, state, event, DATA_DIR)
     if warning:
         print(color_upload_health_warning(warning))

--- a/stashai/plugin/assets/gemini/scripts/on_tool_use.py
+++ b/stashai/plugin/assets/gemini/scripts/on_tool_use.py
@@ -14,11 +14,8 @@ def main():
     if not event.tool_name:
         return
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_tool_use(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_tool_use(client, cfg, state, event, DATA_DIR)
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/hermes/scripts/on_prompt.py
+++ b/stashai/plugin/assets/hermes/scripts/on_prompt.py
@@ -21,11 +21,8 @@ def main():
     cfg = get_config()
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            stream_user_message(client, cfg, state, event.prompt_text, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_user_message(client, cfg, state, event.prompt_text, event)
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/hermes/scripts/on_session_end.py
+++ b/stashai/plugin/assets/hermes/scripts/on_session_end.py
@@ -16,12 +16,9 @@ def main():
     cfg = get_config()
 
     event = adapt_session_end(get_stdin_data())
-    try:
-        with get_client() as client:
-            stream_session_end(client, cfg, state, event)
-            finalize_session_upload(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_session_end(client, cfg, state, event)
+        finalize_session_upload(client, cfg, state, event, DATA_DIR)
 
     state["session_id"] = ""
     save_state(DATA_DIR, state)

--- a/stashai/plugin/assets/hermes/scripts/on_session_start.py
+++ b/stashai/plugin/assets/hermes/scripts/on_session_start.py
@@ -37,11 +37,9 @@ def main():
     reset_stats(DATA_DIR)
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            create_session_record(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    # A failed session create must abort before the background spawns, not vanish silently.
+    with get_client() as client:
+        create_session_record(client, cfg, state, event, DATA_DIR)
 
     spawn_skills_sync(cfg)
     spawn_self_upgrade()

--- a/stashai/plugin/assets/hermes/scripts/on_stop.py
+++ b/stashai/plugin/assets/hermes/scripts/on_stop.py
@@ -26,11 +26,8 @@ def main():
     state = load_state(DATA_DIR)
     event = adapt_stop(get_stdin_data())
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_assistant_message(client, cfg, state, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_assistant_message(client, cfg, state, event)
     warning = upload_health_warning(cfg, state, event, DATA_DIR)
     if warning:
         print(color_upload_health_warning(warning), file=sys.stderr)

--- a/stashai/plugin/assets/hermes/scripts/on_tool_use.py
+++ b/stashai/plugin/assets/hermes/scripts/on_tool_use.py
@@ -16,11 +16,8 @@ def main():
     if not event.tool_name:
         return
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_tool_use(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_tool_use(client, cfg, state, event, DATA_DIR)
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/openclaw/scripts/on_prompt.py
+++ b/stashai/plugin/assets/openclaw/scripts/on_prompt.py
@@ -21,11 +21,8 @@ def main():
     cfg = get_config()
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            stream_user_message(client, cfg, state, event.prompt_text, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_user_message(client, cfg, state, event.prompt_text, event)
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/openclaw/scripts/on_session_end.py
+++ b/stashai/plugin/assets/openclaw/scripts/on_session_end.py
@@ -16,12 +16,9 @@ def main():
     cfg = get_config()
 
     event = adapt_session_end(get_stdin_data())
-    try:
-        with get_client() as client:
-            stream_session_end(client, cfg, state, event)
-            finalize_session_upload(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_session_end(client, cfg, state, event)
+        finalize_session_upload(client, cfg, state, event, DATA_DIR)
 
     state["session_id"] = ""
     save_state(DATA_DIR, state)

--- a/stashai/plugin/assets/openclaw/scripts/on_session_start.py
+++ b/stashai/plugin/assets/openclaw/scripts/on_session_start.py
@@ -31,11 +31,8 @@ def main():
     reset_stats(DATA_DIR)
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            create_session_record(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        create_session_record(client, cfg, state, event, DATA_DIR)
 
     spawn_skills_sync(cfg)
     spawn_self_upgrade()

--- a/stashai/plugin/assets/openclaw/scripts/on_stop.py
+++ b/stashai/plugin/assets/openclaw/scripts/on_stop.py
@@ -26,11 +26,8 @@ def main():
     event = adapt_stop(get_stdin_data())
     cfg = get_config()
 
-    try:
-        with get_client() as client:
-            stream_assistant_message(client, cfg, state, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_assistant_message(client, cfg, state, event)
     warning = upload_health_warning(cfg, state, event, DATA_DIR)
     if warning:
         print(color_upload_health_warning(warning))

--- a/stashai/plugin/assets/opencode/scripts/on_prompt.py
+++ b/stashai/plugin/assets/opencode/scripts/on_prompt.py
@@ -14,11 +14,8 @@ def main():
     event = adapt_prompt(get_stdin_data())
     cfg = get_config()
     state = load_state(DATA_DIR)
-    try:
-        with get_client() as client:
-            stream_user_message(client, cfg, state, event.prompt_text, event)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_user_message(client, cfg, state, event.prompt_text, event)
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/opencode/scripts/on_session_end.py
+++ b/stashai/plugin/assets/opencode/scripts/on_session_end.py
@@ -16,12 +16,9 @@ def main():
     cfg = get_config()
 
     event = adapt_session_end(get_stdin_data())
-    try:
-        with get_client() as client:
-            stream_session_end(client, cfg, state, event)
-            finalize_session_upload(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_session_end(client, cfg, state, event)
+        finalize_session_upload(client, cfg, state, event, DATA_DIR)
 
     state["session_id"] = ""
     save_state(DATA_DIR, state)

--- a/stashai/plugin/assets/opencode/scripts/on_session_start.py
+++ b/stashai/plugin/assets/opencode/scripts/on_session_start.py
@@ -28,12 +28,9 @@ def _flush_stale_session(prior_sid: str, state: dict) -> None:
     cfg = get_config()
     stale_state = {**state, "session_id": prior_sid}
     stale_event = HookEvent(kind="session_end", session_id=prior_sid, cwd="")
-    try:
-        with get_client() as client:
-            stream_session_end(client, cfg, stale_state, stale_event)
-            finalize_session_upload(client, cfg, stale_state, stale_event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_session_end(client, cfg, stale_state, stale_event)
+        finalize_session_upload(client, cfg, stale_state, stale_event, DATA_DIR)
 
 
 def main():
@@ -56,11 +53,8 @@ def main():
     reset_stats(DATA_DIR)
     state = load_state(DATA_DIR)
 
-    try:
-        with get_client() as client:
-            create_session_record(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        create_session_record(client, cfg, state, event, DATA_DIR)
 
     spawn_skills_sync(cfg)
     spawn_self_upgrade()

--- a/stashai/plugin/assets/opencode/scripts/on_tool_use.py
+++ b/stashai/plugin/assets/opencode/scripts/on_tool_use.py
@@ -14,11 +14,8 @@ def main():
     if not event.tool_name:
         return
     cfg = get_config()
-    try:
-        with get_client() as client:
-            stream_tool_use(client, cfg, state, event, DATA_DIR)
-    except Exception:
-        pass
+    with get_client() as client:
+        stream_tool_use(client, cfg, state, event, DATA_DIR)
 
 
 if __name__ == "__main__":

--- a/stashai/plugin/assets/pi/AGENTS.md
+++ b/stashai/plugin/assets/pi/AGENTS.md
@@ -1,0 +1,37 @@
+# Stash
+
+You have the `stash` CLI on your PATH. Run `stash --help` to see commands. Use it to read transcripts, pages, and history from your Stash.
+
+Your activity in this repo is streamed to your Stash, so your other agents and you can see what you're working on.
+
+## What a Skill is
+
+A **Skill** is a *special folder* — one containing a SKILL.md — holding related artifacts (pages, files, tables) that shares like any folder and gains a public URL when published. Use one when you're publishing a *collection* of related things together — a project writeup with its supporting files, a research thread with its sources, a session transcript plus the files it produced.
+
+A Skill is **not** a wrapper to slap on every single file you happen to share. One-item Skills clutter Discover and defeat the model.
+
+## How to share things
+
+- **One file someone should look at** → `stash upload <path> --json` and hand them the returned `app_url`. No Skill needed.
+- **A folder / project into your Stash** → `stash upload <path> --json`. Returns the folder `app_url`. No Skill created by default.
+- **A curated bundle as one shareable thing** → `stash upload <path> --skill "<title>" --json`, or `stash skills create "<name>" --public` to start a fresh one. Returns the Skill `url`.
+- **A coding session (transcript + touched files)** → `stash share <session_id>`. Sessions are inherently a bundle.
+
+Run `stash prompts agent-guidance` any time you want this guidance reprinted in full.
+
+## Browsing
+
+`stash ls` shows everything Stash can reach as one filesystem — your files, session transcripts, and every connected integration (GitHub, Slack, Gong, Gmail, Drive, Notion, …). When asked what you have access to, run it and show the tree; drill in with `stash ls <source>/<path>`.
+
+Use `stash vfs` when you want to browse Stash like a filesystem without mounting anything into the OS. It accepts bash-shaped commands over the virtual Stash tree:
+- `stash vfs ls /me`
+- `stash vfs "find /me -maxdepth 3 -type f"`
+- `stash vfs "rg \"query\" /me"`
+- `stash vfs "cat '/me/README.md' | sed -n '1,80p'"`
+
+## Common reads (all support `--json`)
+
+- `stash search "<query>"` — full-text search across transcripts
+- `stash vfs "cat '/me/sessions/_index.jsonl'"` — recent events
+- `stash sessions agents` — who's been active
+- `stash vfs "find /me -name '*.md'"` — your pages

--- a/stashai/plugin/assets/pi/README.md
+++ b/stashai/plugin/assets/pi/README.md
@@ -1,0 +1,87 @@
+# Stash Plugin for Pi
+
+Streams Pi coding sessions to Stash using Pi's native `~/.pi/hooks/` system.
+
+## Prerequisites
+
+- `stash` CLI installed and logged in
+- `.stash` manifest present in repo (or ancestor)
+- Python 3.10+ and `httpx`
+- Pi installed with hook directory support (`~/.pi/hooks/`)
+
+## Install
+
+The recommended way to install the Pi hooks is through the `stash` CLI, which
+supersedes the manual instructions below: `stash settings` (or the interactive
+`stash connect` flow) detects Pi on your machine and copies the self-contained
+hook runtime into `~/.pi/` (`_run.sh`, `scripts/hooks/*`, and the `on_*.py`
+handlers) from the shipped assets under `stashai/plugin/assets/pi/`. No
+symlinks are created, so the install keeps working even if the stash checkout
+or pipx env moves, and it never depends on this repo's location.
+
+Manual install (fallback, when you cannot run the CLI installer):
+
+```bash
+cd path/to/stash/plugins/pi-plugin
+export PLUGIN_ROOT=$(pwd)
+mkdir -p ~/.pi/hooks
+
+# Symlink each hook wrapper (symlinks auto-update when you pull the repo)
+ln -sf "$PLUGIN_ROOT/scripts/hooks/"* ~/.pi/hooks/
+
+# Agent context — tells Pi it has the stash CLI available
+cat AGENTS.md >> ~/.pi/AGENTS.md
+```
+
+Note that the manual symlink path points at this checkout, so it breaks if the
+repo moves; prefer the CLI installer which copies the runtime into `~/.pi/`.
+
+## How Pi hooks work
+
+Pi reads executable files from `~/.pi/hooks/` — one file per event name.
+Each hook receives JSON on stdin with the event payload and must exit
+with status 0. The hook files in `scripts/hooks/` are thin bash wrappers
+that delegate to `_run.sh`, which resolves the correct Python interpreter
+and dispatches to the corresponding `on_*.py` handler.
+
+## Commands
+
+Everything is a plain `stash` CLI subcommand — no slash commands or skills:
+
+| Command | Description |
+|---------|-------------|
+| `stash connect` | Interactive setup (auth + store) |
+| `stash settings` | Interactive settings page (streaming, scope, endpoint, …) |
+| `stash disconnect` | Pause event streaming across every installed plugin |
+
+## What streams
+
+| Pi event | Stash event | Notes |
+|---|---|---|
+| `session_start` | — (warms cache) | Session record created, skills synced |
+| `user_message` | `user_message` | User prompt streamed |
+| `tool_use` | `tool_use` | Tool invocations streamed (bash, read, write, edit, grep, …) |
+| `assistant_message` | `assistant_message` + transcript upload | Per-turn assistant response; transcript uploaded in background with 60s cooldown |
+| `session_end` | `session_end` | Session finalized, state cleared |
+
+## Known gaps
+
+1. **Pi hook coverage depends on Pi's runtime.** Pi's hook system is still
+   maturing. Check Pi's documentation for which events fire reliably and
+   whether all tool types are covered.
+2. **macOS / Linux only.** Pi runs on macOS and Linux. No Windows support.
+   (Consistent with all existing Stash streaming plugins.)
+
+## Retrieval
+
+Pi has shell access. For reads mid-conversation, have the agent invoke
+the `stash` CLI. Use `stash vfs` for filesystem-style browsing without an OS mount:
+
+```
+stash vfs "find /me -maxdepth 3 -type f"
+stash vfs "rg \"database migration\" /me"
+stash vfs "cat '/me/README.md' | sed -n '1,80p'"
+stash vfs "cat '/me/sessions/_index.jsonl'"
+stash search "<query>"
+stash whoami --json
+```

--- a/stashai/plugin/assets/pi/scripts/_run.sh
+++ b/stashai/plugin/assets/pi/scripts/_run.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Re-exec a plugin hook script under the python that has stashai installed.
+#
+# When stashai ships via pipx or uv (the install.sh defaults), the package
+# lives in an isolated venv — the system `python3` (often a pyenv shim) can't
+# import `stashai.plugin.*`, which breaks every plugin script. We resolve the
+# `stash` binary's symlink to find the venv it lives in, then exec its
+# python. Falls back to system `python3` for the plain `pip install --user`
+# case where stashai is on the user's site-packages directly.
+set -euo pipefail
+
+SCRIPT="$1"
+shift
+
+if [ "$SCRIPT" = "on_session_start" ]; then
+  command -v uv >/dev/null 2>&1 && uv tool install --quiet stashai@latest >/dev/null 2>&1 &
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="$SCRIPT_DIR/$SCRIPT.py"
+
+REPO_ROOT=""
+case "$SCRIPT_DIR" in
+  */stashai/plugin/assets/*/scripts)
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
+    ;;
+  */plugins/*-plugin/scripts)
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+    ;;
+esac
+if [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT/stashai" ] && [ -d "$REPO_ROOT/cli" ]; then
+  export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+fi
+
+PY=""
+if command -v stash >/dev/null 2>&1; then
+  STASH_BIN="$(command -v stash)"
+  # Find the interpreter that can import stashai. On Unix the pipx/uv shim is a
+  # symlink, so the venv python sits next to the resolved binary. On Windows the
+  # shim is a real .exe (not a symlink), so realpath stays in the shim dir and we
+  # also probe the uv tool venv. The path work is done in python because bash
+  # mishandles Windows backslash paths, and we only accept an interpreter that
+  # can actually import stashai — so we never silently pick the wrong one.
+  PY="$(python3 - "$STASH_BIN" <<'PY_EOF' 2>/dev/null || true
+import os, sys, shutil, subprocess
+stash = os.path.realpath(sys.argv[1])
+d = os.path.dirname(stash)
+cands = [os.path.join(d, "python"), os.path.join(d, "python.exe"),
+         os.path.join(d, "Scripts", "python.exe")]
+uv = shutil.which("uv")
+if uv:
+    try:
+        td = subprocess.run([uv, "tool", "dir"], capture_output=True,
+                            text=True, timeout=5).stdout.strip()
+    except (subprocess.TimeoutExpired, OSError) as e:
+        print(f"stash: uv tool dir failed: {e}", file=sys.stderr)
+        td = ""
+    if td:
+        cands += [os.path.join(td, "stashai", "bin", "python"),
+                  os.path.join(td, "stashai", "Scripts", "python.exe")]
+for c in cands:
+    if not os.path.exists(c):
+        continue
+    try:
+        subprocess.run([c, "-c", "import stashai"], check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10)
+    except (subprocess.SubprocessError, OSError) as e:
+        print(f"stash: {c} cannot import stashai: {e}", file=sys.stderr)
+        continue
+    print(c.replace(os.sep, "/"))
+    break
+PY_EOF
+)"
+fi
+
+# pip --user (stashai on system site-packages) or any case the venv-python
+# heuristic missed — fall through to whatever python3 is on PATH.
+if [ -z "$PY" ]; then
+  PY="python3"
+fi
+
+exec "$PY" "$TARGET" "$@"

--- a/stashai/plugin/assets/pi/scripts/adapt.py
+++ b/stashai/plugin/assets/pi/scripts/adapt.py
@@ -1,0 +1,102 @@
+"""Pi agent stdin payload -> canonical HookEvent.
+
+Pi uses executable hook files in ~/.pi/hooks/ — one file per event:
+session_start, user_message, tool_use, assistant_message, session_end.
+Each hook receives JSON on stdin with event-specific fields.
+
+Common input fields (every event): session_id, cwd, hook_event_name.
+Turn-scoped events add turn_id.
+
+Per-event extras:
+  session_start     {model, ...}
+  user_message      {turn_id, prompt}
+  tool_use          {turn_id, tool_name, tool_input, tool_use_id}
+  assistant_message {turn_id, last_assistant_message}
+  session_end       {}
+
+Pi tool names are lowercase native names:
+  bash, read, write, edit, grep, url_open, ask_followup, question,
+  search, memory, think, execute_command, use_mcp_tool
+"""
+
+from __future__ import annotations
+
+from stashai.plugin.event import HookEvent
+
+_TOOL_MAP = {
+    "bash": "bash",
+    "read": "read",
+    "write": "write",
+    "edit": "edit",
+    "grep": "grep",
+    "url_open": "webfetch",
+    "ask_followup": "ask",
+    "question": "ask",
+    "search": "ask",
+    "memory": "think",
+    "think": "think",
+    "execute_command": "bash",
+    "use_mcp_tool": "mcp",
+}
+_EXTRA_KEYS = ("model",)
+
+
+def _normalize(name: str) -> str:
+    return _TOOL_MAP.get(name.lower(), name.lower())
+
+
+def _extras(data: dict) -> dict:
+    return {key: data[key] for key in _EXTRA_KEYS if isinstance(data.get(key), str) and data[key]}
+
+
+def adapt_session_start(data: dict) -> HookEvent:
+    return HookEvent(
+        kind="session_start",
+        session_id=data.get("session_id", ""),
+        cwd=data.get("cwd", ""),
+        extras=_extras(data),
+    )
+
+
+def adapt_prompt(data: dict) -> HookEvent:
+    return HookEvent(
+        kind="prompt",
+        session_id=data.get("session_id", ""),
+        cwd=data.get("cwd", ""),
+        prompt_text=data.get("prompt", ""),
+        extras=_extras(data),
+    )
+
+
+def adapt_tool_use(data: dict) -> HookEvent:
+    tool_input = data.get("tool_input", {}) or {}
+    if isinstance(tool_input, str):
+        tool_input = {"raw": tool_input}
+    return HookEvent(
+        kind="tool_use",
+        session_id=data.get("session_id", ""),
+        cwd=data.get("cwd", ""),
+        tool_name=_normalize(data.get("tool_name", "")),
+        tool_input=tool_input,
+        tool_response=data.get("tool_response"),
+        extras=_extras(data),
+    )
+
+
+def adapt_stop(data: dict) -> HookEvent:
+    return HookEvent(
+        kind="stop",
+        session_id=data.get("session_id", ""),
+        cwd=data.get("cwd", ""),
+        last_assistant_message=data.get("last_assistant_message", ""),
+        extras=_extras(data),
+    )
+
+
+def adapt_session_end(data: dict) -> HookEvent:
+    return HookEvent(
+        kind="session_end",
+        session_id=data.get("session_id", ""),
+        cwd=data.get("cwd", ""),
+        extras=_extras(data),
+    )

--- a/stashai/plugin/assets/pi/scripts/config.py
+++ b/stashai/plugin/assets/pi/scripts/config.py
@@ -1,0 +1,69 @@
+"""Pi agent plugin config. Reads from ~/.stash/config.json (CLI config).
+
+Shared logic lives in `stashai.plugin.agent_config`; this module only
+supplies the per-agent constants.
+"""
+
+from __future__ import annotations
+
+import os
+
+from stashai.plugin import agent_config
+from stashai.plugin.agent_config import get_stdin_data
+from stashai.plugin.stash_client import StashClient
+
+_CLIENT = "pi"
+DATA_DIR = agent_config.data_dir_from_env("STASH_PI_DATA", ".stash/plugins/pi")
+
+__all__ = [
+    "DATA_DIR",
+    "get_client",
+    "get_config",
+    "get_stdin_data",
+    "is_configured",
+    "is_fusion_managed",
+]
+
+
+def get_config() -> dict:
+    return agent_config.get_config(_CLIENT)
+
+
+def get_client() -> StashClient:
+    return agent_config.get_client(_CLIENT, DATA_DIR)
+
+
+def is_configured() -> bool:
+    return agent_config.is_configured(_CLIENT)
+
+
+def is_fusion_managed(cwd: str | None) -> bool:
+    """True when a session runs inside a Fusion project directory.
+
+    Variant-1 guard: pi-plugin must stay silent for sessions whose working
+    directory is inside a Fusion project (a directory containing `.fusion/`).
+    There, Fusion's own engine session capture is the canonical recorder, so
+    recording from pi-hooks as well would double-record the same conversation
+    into Stash (once as `sess_*`, once as `fusion-<taskId>-<hash>`). Sessions
+    outside Fusion projects (standalone `pi` usage) are still recorded.
+
+    An empty/None cwd fails loud with ValueError rather than silently choosing
+    the "record" direction the guard exists to prevent.
+    """
+    if not cwd:
+        raise ValueError(
+            "is_fusion_managed requires a non-empty cwd; refusing to guess the recording direction"
+        )
+    home = os.path.expanduser("~")
+    d = os.path.abspath(cwd)
+    while True:
+        # Marker must never match the global Fusion config dir at $HOME/.fusion
+        # (daemon token / global settings). Walking the whole tree up to /
+        # would classify every Pi session under $HOME as Fusion-managed and
+        # silently stop all recording on the machine.
+        if d != home and os.path.isdir(os.path.join(d, ".fusion")):
+            return True
+        parent = os.path.dirname(d)
+        if parent == d:
+            return False
+        d = parent

--- a/stashai/plugin/assets/pi/scripts/hooks/assistant_message
+++ b/stashai/plugin/assets/pi/scripts/hooks/assistant_message
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/../_run.sh" on_stop "$@"

--- a/stashai/plugin/assets/pi/scripts/hooks/session_end
+++ b/stashai/plugin/assets/pi/scripts/hooks/session_end
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/../_run.sh" on_session_end "$@"

--- a/stashai/plugin/assets/pi/scripts/hooks/session_start
+++ b/stashai/plugin/assets/pi/scripts/hooks/session_start
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/../_run.sh" on_session_start "$@"

--- a/stashai/plugin/assets/pi/scripts/hooks/tool_use
+++ b/stashai/plugin/assets/pi/scripts/hooks/tool_use
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/../_run.sh" on_tool_use "$@"

--- a/stashai/plugin/assets/pi/scripts/hooks/user_message
+++ b/stashai/plugin/assets/pi/scripts/hooks/user_message
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/../_run.sh" on_prompt "$@"

--- a/stashai/plugin/assets/pi/scripts/on_prompt.py
+++ b/stashai/plugin/assets/pi/scripts/on_prompt.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Pi user_message: stream prompt to Stash."""
+
+from adapt import adapt_prompt
+from config import (
+    DATA_DIR,
+    get_client,
+    get_config,
+    get_stdin_data,
+    is_configured,
+    is_fusion_managed,
+)
+
+from stashai.plugin.hooks import stream_user_message
+from stashai.plugin.state import load_state
+
+
+def main():
+    if not is_configured():
+        return
+    event = adapt_prompt(get_stdin_data())
+    if is_fusion_managed(event.cwd):
+        return
+    cfg = get_config()
+    state = load_state(DATA_DIR)
+
+    # A failed upload must surface to the hook runner, not vanish silently.
+    with get_client() as client:
+        stream_user_message(client, cfg, state, event.prompt_text, event)
+
+
+if __name__ == "__main__":
+    main()

--- a/stashai/plugin/assets/pi/scripts/on_session_end.py
+++ b/stashai/plugin/assets/pi/scripts/on_session_end.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Pi session_end: push session_end and finalize."""
+
+from adapt import adapt_session_end
+from config import (
+    DATA_DIR,
+    get_client,
+    get_config,
+    get_stdin_data,
+    is_configured,
+    is_fusion_managed,
+)
+
+from stashai.plugin.hooks import finalize_session_upload, stream_session_end
+from stashai.plugin.state import load_state, save_state
+
+
+def main():
+    if not is_configured():
+        return
+
+    state = load_state(DATA_DIR)
+    cfg = get_config()
+
+    event = adapt_session_end(get_stdin_data())
+    if is_fusion_managed(event.cwd):
+        return
+    # A failed finalize must surface to the hook runner, not vanish silently.
+    with get_client() as client:
+        stream_session_end(client, cfg, state, event)
+        finalize_session_upload(client, cfg, state, event, DATA_DIR)
+
+    state["session_id"] = ""
+    save_state(DATA_DIR, state)
+
+
+if __name__ == "__main__":
+    main()

--- a/stashai/plugin/assets/pi/scripts/on_session_start.py
+++ b/stashai/plugin/assets/pi/scripts/on_session_start.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Pi session_start: save session_id and create the session record."""
+
+import json
+import os
+
+from adapt import adapt_session_start
+from config import (
+    DATA_DIR,
+    get_client,
+    get_config,
+    get_stdin_data,
+    is_fusion_managed,
+)
+
+from cli.formatting import echo_stdout
+from stashai.plugin.hooks import (
+    color_upload_health_warning,
+    create_session_record,
+    reset_session_record_state,
+    uploads_disabled_warning,
+    uploads_enabled,
+)
+from stashai.plugin.session_upload import spawn_session_watcher, spawn_skills_sync
+from stashai.plugin.state import load_state, reset_stats, save_state
+
+
+def main():
+    event = adapt_session_start(get_stdin_data())
+    if is_fusion_managed(event.cwd):
+        return
+    cfg = get_config()
+    state = load_state(DATA_DIR)
+    if not uploads_enabled(cfg, event):
+        warning = uploads_disabled_warning(cfg, state, event, DATA_DIR)
+        if warning:
+            echo_stdout(json.dumps({"systemMessage": color_upload_health_warning(warning)}))
+        return
+
+    reset_session_record_state(state)
+    state["session_id"] = event.session_id
+    save_state(DATA_DIR, state)
+    reset_stats(DATA_DIR)
+    state = load_state(DATA_DIR)
+
+    # A failed session-create must surface to the hook runner, not vanish
+    # silently; the watcher spawns only when the record was actually created.
+    with get_client() as client:
+        create_session_record(client, cfg, state, event, DATA_DIR)
+
+    spawn_skills_sync(cfg)
+
+    if state.get("session_row_id"):
+        spawn_session_watcher(
+            agent_pid=os.getppid(),
+            session_id=event.session_id,
+            agent_name=cfg.get("agent_name", ""),
+            base_url=cfg.get("api_endpoint", ""),
+            api_key=cfg.get("api_key", ""),
+            cwd=event.cwd or "",
+            data_dir=DATA_DIR,
+            session_row_id=state.get("session_row_id", ""),
+            transcript_path=event.transcript_path,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/stashai/plugin/assets/pi/scripts/on_stop.py
+++ b/stashai/plugin/assets/pi/scripts/on_stop.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Pi assistant_message: stream assistant message and upload transcript.
+
+Pi's assistant_message hook fires per-turn. We push assistant_message (not
+session_end) and deliberately do NOT clear session_id — subsequent turns in
+the same session need it for correlation. session_end is handled separately.
+
+Transcript upload is spawned as a detached background process (so it doesn't
+block the hook timeout) with a 60s cooldown between uploads per session.
+"""
+
+import json
+
+from adapt import adapt_stop
+from config import (
+    DATA_DIR,
+    get_client,
+    get_config,
+    get_stdin_data,
+    is_configured,
+    is_fusion_managed,
+)
+
+from cli.formatting import echo_stdout
+from stashai.plugin.hooks import (
+    color_upload_health_warning,
+    remember_transcript_path,
+    stream_assistant_message,
+    upload_health_warning,
+)
+from stashai.plugin.state import load_state
+from stashai.plugin.transcript_upload import spawn_transcript_upload
+
+
+def main():
+    if not is_configured():
+        return
+    state = load_state(DATA_DIR)
+    event = adapt_stop(get_stdin_data())
+    if is_fusion_managed(event.cwd):
+        return
+    remember_transcript_path(state, event, DATA_DIR)
+    cfg = get_config()
+    # A failed stream must surface to the hook runner, not vanish silently.
+    with get_client() as client:
+        stream_assistant_message(client, cfg, state, event)
+
+    spawn_transcript_upload(
+        data_dir=DATA_DIR,
+        transcript_path=event.transcript_path,
+        session_id=state.get("session_id", ""),
+        agent_name=cfg["agent_name"],
+        cwd=event.cwd,
+        base_url=cfg["api_endpoint"],
+        api_key=cfg["api_key"],
+        session_folder_id=cfg.get("session_folder_id", ""),
+    )
+    warning = upload_health_warning(cfg, state, event, DATA_DIR)
+    if warning:
+        echo_stdout(json.dumps({"systemMessage": color_upload_health_warning(warning)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/stashai/plugin/assets/pi/scripts/on_tool_use.py
+++ b/stashai/plugin/assets/pi/scripts/on_tool_use.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Pi tool_use: stream tool use to Stash."""
+
+from adapt import adapt_tool_use
+from config import (
+    DATA_DIR,
+    get_client,
+    get_config,
+    get_stdin_data,
+    is_configured,
+    is_fusion_managed,
+)
+
+from stashai.plugin.hooks import stream_tool_use
+from stashai.plugin.state import load_state
+
+
+def main():
+    if not is_configured():
+        return
+    state = load_state(DATA_DIR)
+    event = adapt_tool_use(get_stdin_data())
+    if is_fusion_managed(event.cwd):
+        return
+    if not event.tool_name:
+        return
+    cfg = get_config()
+    # A failed upload must surface to the hook runner, not vanish silently.
+    with get_client() as client:
+        stream_tool_use(client, cfg, state, event, DATA_DIR)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Release 0.1.368 — self-host images (frontend + backend, no pi), compose orphan fix, pins promoted

**Audience:** self-hosters. joinstash.ai is unaffected by the compose changes (hosted prod runs on Render from the Dockerfiles, not compose) — but remember **any merge to `main` also auto-deploys Render prod**, PyPI, and GHCR.

## What this PR ships
- **Semantic-search / MCP capability** (already committed by you on this branch: `ffbb9115` import + `ac5a79f6` STAS-113 fixture fix): `/me/events/semantic-search`, `/me/pages/semantic-search`, `/{table_id}/rows/semantic-search`, the `stash_search` / `stash_session_search` / `get_stash_info` MCP tools, and the local sentence-transformers embedding provider for self-hosts (`openai → huggingface → local` auto chain). Capability proven pre-push: 8 + 39 + 15 tests green (semantic-search, backend MCP, CLI MCP server).
- **Compose orphan fix:** `docker-compose.local.yml` carried a `collab: ports: 3458` override for the service #982 deleted. Compose *creates* override-only services and then rejects them — the documented pair died with `service "collab" has neither an image nor a build context specified`. The block is removed; `config -q` now exits 0. The `backend`/`frontend`/`caddy-profiles` overrides survive untouched.
- **One version commit** (`chore: bump stash release to 0.1.368 …`): `pyproject.toml` 0.1.367 → **0.1.368** and all five GHCR pins (backend/worker/heavy-worker/beat ×4 + frontend, previously `0.1.365`) → `0.1.368`, plus a CHANGELOG bullet.
- **A release contract test** (`backend/tests/test_docker_release_contract.py`): every local override service must exist in prod (generalizes the collab bug class), neither compose file may mention collab/3458, **GHCR pins must equal the CLI version** (bare tags), the two plugin manifests must agree with each other, and no pi reference may appear in either Dockerfile.

## What this PR deliberately does NOT do
- **No pi in the images.** Operator directive (2026-08-28): *“The Docker image must not install pi at all. pi is not for self-hosting.”* Both Dockerfiles are **byte-identical to `origin/main`** in this diff. No server-side pi harness/provider/local-exec — that all stays on PR #1088's founder-gated lineage.
- **Does not touch** `plugins/claude-plugin/.claude-plugin/plugin.json` or `.claude-plugin/marketplace.json` (0.1.436 — independent marketplace sequence, bumped by its own automation cadence; 436 ≠ 367 is expected).
- **Does not repair or delete** `.github/workflows/bump-plugin-version.yml` (see below) — that call is yours.

## ⚠️ Finding: the release-version automation is structurally dead (decision needed)
`bump-plugin-version.yml` **is** the repo's version automation: on every `main` push touching `cli|stashai|plugins/{claude,codex,cursor,opencode}-plugin|backend|frontend` (this branch touches **78** such files) it bumps pyproject + plugin.json, copies into marketplace.json, rewrites the compose pins, commits, pushes, and dispatches publish.yml.

**Live status:** last green run `31410354104` (2026-08-10). Every run since — all 30 — is a failure: the bump is computed and committed locally, then the push is declined by repository rule **GH013** (“Changes must be made through a pull request”) — newest evidence run `32820397289`:
```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
 ! [remote rejected] main -> main (push declined due to repository rule violations)
```
So it cannot bump main, cannot dispatch publish.yml, and its `Publish release` step never runs. **That is exactly why the compose pins silently drifted two releases behind the CLI (0.1.365 vs 0.1.367), and why v0.1.366/367 only shipped via manual `workflow_dispatch`.** This PR therefore hand-carries the version commit, and the new pin-parity test is the only surviving enforcement. **Please decide its fate:** repair it (open a bump PR / ruleset exemption) or delete it. This PR intentionally does neither. (After merging this PR you will see one more red “Bump release versions” run on `main` — that is this pre-existing GH013 class, **not** a release failure; it will land no commit.)

## Post-release expectations (both namespaces — don't be fooled)
Publishing rides publish.yml's `push: branches:[main]` trigger (the proven v0.1.366/v0.1.367 path): it reads the pyproject version, creates the missing **git tag `v0.1.368`**, dispatches `docker-publish.yml`, and publishes `stashai==0.1.368` to PyPI.
The GHCR matrix (backend + frontend — exactly two images) publishes with `docker/metadata-action pattern={{version}}`, so **image tags are BARE**: `ghcr.io/fergana-labs/stash-backend:0.1.368` + `:0.1` (+ `latest`). The `v` belongs only to the git tag. Pulling `:v0.1.368` returns `manifest not found` — that's the wrong namespace, not a failed release.

## ⚠️ Merge-order conflict with STAS-137 — verified resolution policy (CEO request)

This PR and in-review **STAS-137** (`fusion/stas-137` @ `30d283c7`) both add the pi plugin payload, so **either merge order conflicts**. Verified by blob comparison — exactly 5 paths differ, `test_assets_in_sync.py` included:

| path | this head `d09d2eb8` | STAS-137 `30d283c7` | delta (ours vs theirs) |
|---|---|---|---|
| `plugins/pi-plugin/scripts/on_session_start.py` | `7d7f8dbb` | `020fc7e2` | +3 / −2 |
| `plugins/pi-plugin/scripts/on_stop.py` | `68eb5f80` | `fa08398e` | +3 / −1 |
| `stashai/plugin/assets/pi/scripts/on_session_start.py` | `7d7f8dbb` | `020fc7e2` | mirror (byte-identical to canonical on both sides) |
| `stashai/plugin/assets/pi/scripts/on_stop.py` | `68eb5f80` | `fa08398e` | mirror |
| `plugins/tests/test_assets_in_sync.py` | `7c42dc33` | `ca01d1f1` | +29 / −1 (modify/modify — the file already exists on `main`) |

**Recommendation: STAS-137's hook-script blobs win all four paths** — and the reason is stronger than "post-review fixes". Our copies (carried by `ffbb9115`, the import from the pre-fold lineage) are the only plugin scripts in the tree that are **incompatible with the package API actually on trunk**:

1. Ours call `uploads_enabled(cfg, event)`. `stashai/plugin/hooks.py:140` defines `def uploads_enabled(cfg) -> bool` — **one argument, on both branches**, and every other plugin calls the 1-arg form. This is precisely the class `plugins/tests/test_hook_scripts_execute.py:5` names: *"the historical `uploads_enabled(cfg, event)` TypeError that broke every Codex session start."*
2. Ours do `from cli.formatting import echo_stdout` — a symbol **defined nowhere in this repo**: zero refs on `origin/main`, and `cli/formatting.py` here exports only `output_json` / `format_message` / `print_messages` / `print_user`. The only commits that ever defined it (`dc131c60`, `ab257e68` = STAS-066; `ecd05e5f` = STAS-100) are on the abandoned pre-fold lineage and are **not ancestors of `origin/main` or of this head**. Executing either script raises `ImportError`.
3. Both defects are **latent, not live**: `cli/main.py:820` `_HOOK_EVENTS` has no `pi` entry (pi CLI wiring is STAS-137's own scope) and `test_hook_scripts_execute.py`'s `_AGENT_EVENTS` likewise omits `pi`, so nothing runs these files — which is also why `plugin-test` is green over them. pi additionally **cannot reach either image**: `backend/Dockerfile` copies only `backend/`, `docs/skills/`, `stashvfs/`, `entrypoint.sh`, `alembic.ini`, `pyproject.toml` (no `stashai/`, no `plugins/`) and installs only `requirements.txt`.

**Second-order trap the "take STAS-137's hooks, let byte-parity decide the test" rule does not cover:** `plugins/tests/test_pi_echo_channel.py` exists **only in this PR** (absent from `origin/main` and from `30d283c7`). It *mandates the broken state* — it asserts `"from cli.formatting import echo_stdout" in text` and forbids any `print(json.dumps({"systemMessage"`. STAS-137's scripts do exactly that at `on_session_start.py:36` and `on_stop.py:58`. So **adopting STAS-137's hooks while keeping our `test_pi_echo_channel.py` turns `plugin-test` red** — the naive rule is not merge-safe. The test's invariant is unsatisfiable on trunk until something like `echo_stdout` actually exists there.

**Suggested policy for the merger (do not improvise):**
1. STAS-137's four hook-script blobs win (`test_assets_in_sync` byte-parity is preserved either way — STAS-137 mirrors canonical→shipped identically).
2. `test_assets_in_sync.py`: take STAS-137's, then re-run byte parity over both pi trees.
3. `test_pi_echo_channel.py` cannot survive step 1 — it is removed together with our hook versions, or pi stays exactly as this PR ships it and remains inert.
4. **Cleanest sequencing:** merge this PR first as-is (pi payload inert: no `_HOOK_EVENTS` wiring, absent from images, `pi` CLI not installable), then let **STAS-137** resolve the payload to the trunk API and drop that test in its own commit. This PR deliberately does not touch pi payload files — they are founder-carried content outside this release's scope.

## Current check posture (re-verified live)

- **`CI` run `33177507507`** and **`Dependency audit` run `33177507491`** at head `d09d2eb8`: both `conclusion=action_required`. This is the first-time-contributor Actions approval for a cross-repo fork PR, **not a code red** — an owner must click **Approve and run**. (Correction to my earlier note: these were not yet approved.)
- **`Vercel – stash-web`**: reports failure with *"Authorization required to deploy"* — needs the one-click Vercel auth link in the PR checks. It is **not** a required status check, so it does not block merge; founder should authorize it separately.
- Local gates re-run on this exact head before requesting merge: `ruff check backend/ cli/` → *All checks passed!*; `ruff format --check backend/ cli/` → *629 files already formatted*; `pytest backend/tests/test_docker_release_contract.py -q --no-cov` → **6 passed**; `docker compose -f docker-compose.prod.yml -f docker-compose.local.yml config -q` → **exit 0** (was exit 1 with `service "collab" has neither an image nor a build context specified` before this PR); narrow pi grep over both Dockerfiles → zero matches; both Dockerfiles + `backend/entrypoint.sh` byte-identical to `origin/main`; commit shape = 2 carried + 4 new, version subject `chore: bump stash release …` (matches the automation's own recursion guard); diff contains no `.env`, `.fusion/`, `imported/`, workflow, or plugin-manifest change.

## Merge mechanics
- **Merge as a merge commit (not squash)** — the version commit's `chore: bump stash release` subject is the automation's own recursion-guard shape and must survive.
- `dependency-audit` runs on this PR because `pyproject.toml` is in its paths; it audits **live** advisory databases, so a red may be a brand-new external advisory unrelated to this diff.
- This PR comes from the fork because direct branch pushes to Fergana-Labs are declined for `ischindl` (403); a first-time fork Actions approval may be needed for PR CI.
- A `.changeset/` root dir is new in this PR purely because the task framework mandates a removal record (compose collab override); nothing consumes it — **feel free to delete that file**. `CHANGELOG.md` is the real release note.

Please confirm before merging — merge consequences: Render prod redeploy, PyPI publish, GHCR images at 0.1.368.
