### PR TITLE
docs(STAS-143): drop dead collab service references from security readiness

### DIFF
--- a/docs/security-readiness.md
+++ b/docs/security-readiness.md
@@ -84,7 +84,7 @@ The CI workflow includes checks that fail when:
 - Backend Python requirements have known vulnerabilities.
 - The CLI Python package has known vulnerabilities.
 - The SDK Python package has known vulnerabilities.
-- Frontend, www, or collab npm lockfiles contain moderate-or-higher advisories.
+- Frontend and www npm lockfiles contain moderate-or-higher advisories.
 - Backend tests, plugin tests, frontend tests, backend lint, and frontend lint fail.
 
 Run these checks locally before changing dependency versions:
@@ -95,7 +95,6 @@ python -m pip_audit .
 python -m pip_audit sdk
 (cd frontend && npm audit --audit-level=moderate --package-lock-only)
 (cd www && npm audit --audit-level=moderate --package-lock-only)
-(cd collab && npm audit --audit-level=moderate --package-lock-only)
 ```
 
 ## Production Evidence Required Before A High-Trust Customer Demo


### PR DESCRIPTION
## STAS-143 — docs/security-readiness.md still references the removed collab service

PR #982 removed the `collab` service, but `docs/security-readiness.md` still referenced it in two places, leaving a broken copy-paste command and an overclaimed CI coverage bullet.

### Changes (docs only, single file)
- Dropped the `(cd collab && npm audit ...)` line from the Continuous Checks local-runs bash fence — that project directory no longer exists, so the documented command failed immediately with `cd: collab: No such file or directory`.
- Reworded the checklist bullet to `- Frontend and www npm lockfiles contain moderate-or-higher advisories.` (was "Frontend, www, or collab ...").

`diff --stat`: `docs/security-readiness.md | 3 +--` — exactly 1 insertion, 2 deletions. The ordinary prose "collaboration documents" earlier in the file is untouched.

### doc ↔ CI parity evidence
`.github/workflows/dependency-audit.yml` audits exactly: pip_audit x3 (backend reqs, CLI, SDK) + npm audit for `frontend` (working-directory frontend) and `www` (working-directory www) — nothing else. `grep -rni collab .github/` is empty. After this PR the doc's named lockfiles and runnable local commands match CI exactly.

### Verification (deterministic grep gates, all green)
- Red state before: the documented collab audit command failed with `cd: collab: No such file or directory` / exit=1; `grep -nw collab docs/security-readiness.md` printed 2 lines (the bullet and the command).
- After: `grep -nw collab docs/security-readiness.md` exits 1 with no output.
- Plain `grep -n collab` on the file now prints only the kept "collaboration documents" prose line.
- Remaining `(cd ...)` fence targets: `frontend` and `www` — both directories exist (MISSING: NONE); the bash fence still opens/closes with matching triple-backtick markers.
- `git diff --check` clean; lint/typecheck/test suites are N/A (markdown-only change; no code, config, or CI file touched).

### Provenance
Origin of this work: recorded as an unfiled completion recommendation in STAS-101's task document `gate-park-run-59-2026-09-03` (that executor session had no task-creation tools). Same dead-service-rot class as STAS-142 (dead release automation); sibling STAS-144 owns collab leftovers outside the `docs` directory (ARCHITECTURE.md, render.yaml, .env.example, docker-compose.local.yml).

Independent of the in-flight STAS-101 release PR — that PR never touches this file, so no conflict.
