### PR TITLE
fix(STAS-144): remove dead collab-service leftovers from docs and self-host config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,14 +50,6 @@ CORS_ORIGINS=http://localhost:3457,http://localhost:3456
 # Must be an HTTPS origin without a path when managed Auth0 is enabled.
 # APP_BASE_URL=https://app.yourcompany.com
 
-# ── Live Collaboration ───────────────────────
-# The frontend defaults to ws://localhost:3458 in local dev and /collab on
-# deployed same-origin installs. Keep Caddy's /collab route when using the
-# prebuilt self-host frontend image.
-
-# Used by the collab sidecar to authorize users through FastAPI.
-BACKEND_URL=http://localhost:3456
-
 # ── Embeddings ──────────────────────────────────────────────────
 # Provider: openai | huggingface | local | none | auto (default).
 # "auto" detects from available keys: OPENAI_API_KEY → openai, HF_TOKEN → huggingface, else → local.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,7 +78,6 @@ of the current architecture. Privacy is mediated by Skills.
 - `backend/routers/tables.py`: structured table CRUD + row search.
 - `backend/routers/shares.py`: person-to-person folder shares.
 - `backend/routers/sources.py`: GitHub / Google Drive / Notion OAuth + imports.
-- `backend/routers/collab.py`: Yjs WebSocket sidecar for live page editing.
 - `backend/routers/trash.py`: soft-delete listing + restore/purge.
 
 Object-level privacy is enforced inline in each router that returns a

--- a/backend/tests/test_no_dead_service_references.py
+++ b/backend/tests/test_no_dead_service_references.py
@@ -1,0 +1,88 @@
+"""The collab sidecar is gone (PR #982); the repo must stop describing it.
+
+The Yjs/Hocuspocus collaboration service was deleted — `collab/` and
+`backend/routers/collab.py` no longer exist and migration 0182 dropped its
+table — yet the architecture document and the self-hosting files kept naming
+it. One of those stale references (`collab:` in docker-compose.local.yml) made
+the exact self-host command README.md tells you to run fail outright with
+`service "collab" has neither an image nor a build context specified`.
+
+These are static source-level guards in the shape of
+test_cli_release_header.py: they read repo files as plain text and assert the
+invariant, so no one can quietly re-add a service description for something
+that was deleted. docs/ is deliberately NOT scanned — docs/security-readiness.md
+is owned by STAS-143, and asserting on a surface this task does not clean would
+go RED whichever of the two independent PRs merges first.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+ARCHITECTURE_DOC = REPO_ROOT / "ARCHITECTURE.md"
+ENV_EXAMPLE = REPO_ROOT / ".env.example"
+
+# Surfaces that advertise what actually runs. docs/ is absent on purpose (see
+# the module docstring): STAS-143 owns the collab lines there.
+DEPLOYMENT_SURFACES = (
+    ARCHITECTURE_DOC,
+    REPO_ROOT / "render.yaml",
+    ENV_EXAMPLE,
+    REPO_ROOT / "docker-compose.prod.yml",
+    REPO_ROOT / "docker-compose.local.yml",
+)
+
+ROUTER_REFERENCE = re.compile(r"backend/routers/([A-Za-z0-9_-]+\.py)")
+COLLAB_MENTION = re.compile(r"\bcollab\b", re.IGNORECASE)
+
+
+def test_architecture_doc_names_only_existing_routers():
+    """Every router file ARCHITECTURE.md names must exist in the tree.
+
+    The reverse assertion — every real router is documented — is deliberately
+    absent: most real routers are undocumented today, so it would fail for
+    unrelated reasons and bury the one discrepancy this guard exists to catch.
+    """
+    text = ARCHITECTURE_DOC.read_text()
+    missing = sorted(
+        name
+        for name in set(ROUTER_REFERENCE.findall(text))
+        if not (REPO_ROOT / "backend" / "routers" / name).is_file()
+    )
+    assert missing == [], f"ARCHITECTURE.md names routers that do not exist: {missing}"
+
+
+def test_deployment_surfaces_do_not_mention_the_deleted_collab_service():
+    """No surface describing the running system may name collab or port 3458.
+
+    Both were properties of the deleted sidecar. The word-boundary match keeps
+    real prose (`collaboration`) and the unrelated `prosemirror-collab` npm
+    library out of scope; the port is checked plainly because a mapping such as
+    `3458:3458` has no word boundary to anchor on.
+    """
+    offenders: list[str] = []
+    for path in DEPLOYMENT_SURFACES:
+        lines = path.read_text().splitlines()
+        hits = [
+            f"{path.name}:{number} {line.strip()}"
+            for number, line in enumerate(lines, start=1)
+            if COLLAB_MENTION.search(line) or "3458" in line
+        ]
+        offenders.extend(hits)
+    assert offenders == [], f"deleted collab service is still advertised at: {offenders}"
+
+
+def test_env_example_declares_no_dead_backend_url():
+    """.env.example must not advertise a variable that nothing reads.
+
+    BACKEND_URL sat under the collab header, documented as "used by the collab
+    sidecar". With the sidecar gone it has zero consumers repo-wide, and
+    docker-compose.prod.yml passes the differently-named BACKEND_INTERNAL_URL
+    instead. Project rules forbid keeping a dead key as an alias or fallback,
+    so the invariant to protect is that it stays deleted.
+    """
+    dead = [
+        line for line in ENV_EXAMPLE.read_text().splitlines() if line.startswith("BACKEND_URL=")
+    ]
+    assert dead == [], f".env.example declares unread variables: {dead}"

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -15,10 +15,6 @@ services:
     ports:
       - "3457:3457"
 
-  collab:
-    ports:
-      - "3458:3458"
-
   caddy:
     profiles:
       - production-domain

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@
 #
 # This is the only hosted service DEFINED as a render.yaml blueprint. It is
 # NOT the only Render-managed service: our whole hosted prod (backend →
-# api.joinstash.ai, frontend, collab, celery worker + beat) also runs on
+# api.joinstash.ai, frontend, celery worker + beat) also runs on
 # Render, auto-deploying on every commit to main — those services are
 # configured in the Render dashboard, not in this file, so the repo has no
 # blueprint for them. docker-compose.prod.yml is for SELF-HOSTERS only and is


### PR DESCRIPTION
## What

Delete the last live-looking references to the collab sidecar that PR #982 removed, in the four non-`docs/` surfaces, and pin the invariant with a static guard test so this rot class cannot silently return.

The collab service (`collab/`, `backend/routers/collab.py`, the Yjs/Hocuspocus server; table dropped by migration `0182`) no longer exists, but four surfaces still described it as running — and one of them made the **documented self-host command fail outright**:

```
service "collab" has neither an image nor a build context specified: invalid compose project
```

`README.md` tells a self-hoster to run exactly the failing pair of compose files.

## Changes

| Surface | Change |
|---|---|
| `ARCHITECTURE.md` | drop the `backend/routers/collab.py` bullet (file absent) |
| `render.yaml` | drop `collab` from the hosted-prod list in the header comment; the only service this file *defines* is `aspose-pptx` |
| `.env.example` | delete the "Live Collaboration" block (`ws://localhost:3458`, the nonexistent `/collab` Caddy route) and `BACKEND_URL` |
| `docker-compose.local.yml` | delete the orphaned `collab:` ports override |
| `backend/tests/test_no_dead_service_references.py` | **new** static guard: 3 tests |

### `BACKEND_URL` is deleted, not renamed

It is the only key in `.env.example` with **zero consumers** repo-wide (case-insensitive search over `backend`, `cli`, `frontend/src`, `www`, `plugins`, `docker-compose.prod.yml`). Its own comment said "used by the collab sidecar". `docker-compose.prod.yml` passes the differently-named `BACKEND_INTERNAL_URL`, which is a different variable with many consumers. Per repo rules there is no alias, shim, or fallback.

## Deliberate overlap with STAS-101 / PR #1097

- `87f87d3e` (STAS-101, on `fusion/stas-101`) deletes the **same 4 lines** of `docker-compose.local.yml`. Our result is **byte-identical** to `git show 87f87d3e:docker-compose.local.yml`, so the two branches converge at merge (identical deletions auto-resolve). We did not rebase onto or cherry-pick it — this branch stays on `origin/main`.
- Rationale for not waiting: #1097 was **OPEN** (`mergedAt: null`, head `d09d2eb8`) and `87f87d3e` is not an ancestor of `origin/main`, while the self-host command is broken *now*.
- #1097 also adds `test_compose_files_do_not_mention_collab`, which asserts the same compose invariant. The overlap is intentional; **once #1097 merges, its contract test subsumes the compose half of ours** and the compose entries can be dropped from our file.
- Our other two guards (architecture router existence, dead `BACKEND_URL`) cover surfaces #1097 does not touch.

## Deliberate non-coupling with STAS-143

The guard test **does not scan `docs/`**: `docs/security-readiness.md:87,98` is owned by STAS-143, and asserting on a surface this PR does not clean would go RED whichever of the two independent PRs merges first. Likewise the router guard is one-directional (docs → disk); the reverse ("every router is documented") would be red today for unrelated reasons — 28 real routers are undocumented.

## Explicitly untouched (not dead-service references)

`CHANGELOG.md:44,47` (historical release notes), `backend/tests/test_page_events.py` docstrings documenting the removal, migrations `0064`/`0182` (immutable history), `frontend/package-lock.json` `prosemirror-collab` (a real npm library), `collaboration`/`collaborations` prose, `docs/security-readiness.md`, `.github/` (zero collab mentions).

## Verification

**Symptom red → green** (the `config -q` run follows README's sequence, i.e. after `cp .env.example .env`; compose validates merged services before env-file, which is why the collab error masked the env check before):

```
$ docker compose -f docker-compose.prod.yml -f docker-compose.local.yml config -q
- service "collab" has neither an image nor a build context specified   exit=1   (before)
                                                                        exit=0   (after)
$ docker compose ... config --services
postgres redis backend worker heavy-worker beat frontend      # caddy is declared but
                                                              # profile-gated by design
```

**Guard test red → green** (the red transcript names exactly the offenders this PR deletes):

```
before: 3 failed
  AssertionError: ARCHITECTURE.md names routers that do not exist: ['collab.py']
  AssertionError: deleted collab service is still advertised at:
    ['ARCHITECTURE.md:81 ...', 'render.yaml:6 ...', '.env.example:54 ...',
     '.env.example:55 ...', '.env.example:58 ...', 'docker-compose.local.yml:18 ...',
     'docker-compose.local.yml:20 - "3458:3458"']
  AssertionError: .env.example declares unread variables: ['BACKEND_URL=http://localhost:3456']
after:  3 passed
```

**Grep invariant:**

```
$ grep -rn --exclude-dir=node_modules --exclude-dir=.git -iw collab \
    ARCHITECTURE.md render.yaml .env.example docker-compose.local.yml
(no matches)          # CHANGELOG collab count unchanged at 2, same as origin/main
```

**Lint:** `ruff check backend/ cli/ && ruff format --check backend/ cli/` with the CI-pinned `ruff==0.15.6` → "All checks passed!" + "625 files already formatted". No Python module and no TypeScript changed, so ruff + the scoped pytest run are the complete gates.

## Related

- **STAS-143** — same rot class, owns `docs/security-readiness.md`. Merges in either order with this PR, by the design above.
- **STAS-145** — the `www/package.json` dead editor dependency block (`@hocuspocus/provider`, `yjs`, the `@tiptap/*` suite with zero imports in `www/`) is already filed there; not duplicated.

🤖 Generated with [Fusion](https://runfusion.ai)
