### PR TITLE
Assign Drive folders to orgs from the developer console

### DIFF
--- a/frontend/src/app/(app)/developer/users/[userId]/page.tsx
+++ b/frontend/src/app/(app)/developer/users/[userId]/page.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft } from "lucide-react";
 
 import DeveloperGate from "@/components/developer/DeveloperGate";
 import { Code, PageHeading, SectionHeading } from "@/components/developer/DocsPrimitives";
+import UserDriveSourceControls from "@/components/developer/UserDriveSourceControls";
 import WikiToggle from "@/components/developer/WikiToggle";
 import WikiGraph from "@/components/memory/WikiGraph";
 import {
@@ -208,6 +209,14 @@ function UserDetail() {
         )}
         <div className="mt-6 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
           Connected sources
+        </div>
+        <div className="mt-3 rounded border border-border bg-surface px-5 py-4">
+          <div className="text-[14.5px] text-foreground">Assign a Google Drive folder</div>
+          <p className="mt-1 text-[13px] leading-6 text-muted-foreground">
+            Only this user&apos;s agent can browse the folder. Other users in the workspace
+            cannot see it.
+          </p>
+          <UserDriveSourceControls externalUserId={user.external_id} onAdded={refresh} />
         </div>
         {sources.length === 0 ? (
           <Empty>

--- a/frontend/src/components/developer/UserDriveSourceControls.test.tsx
+++ b/frontend/src/components/developer/UserDriveSourceControls.test.tsx
@@ -1,0 +1,77 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import UserDriveSourceControls from "./UserDriveSourceControls";
+
+const addSource = vi.fn();
+const listIntegrations = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  addSource: (...args: unknown[]) => addSource(...args),
+}));
+
+vi.mock("@/lib/integrations", () => ({
+  listIntegrations: () => listIntegrations(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("UserDriveSourceControls", () => {
+  it("assigns one Drive folder to the selected external user", async () => {
+    listIntegrations.mockResolvedValue({
+      providers: [{ provider: "google", enabled: true, connected: true }],
+    });
+    addSource.mockResolvedValue({});
+    const onAdded = vi.fn();
+    render(<UserDriveSourceControls externalUserId="org_acme" onAdded={onAdded} />);
+
+    fireEvent.change(await screen.findByPlaceholderText("Paste a Drive folder link"), {
+      target: { value: "https://drive.google.com/drive/folders/1AbC_dEf-234567890" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/Name \(optional/), {
+      target: { value: "Acme fleet records" },
+    });
+    fireEvent.click(screen.getByText("Add folder"));
+
+    await waitFor(() => {
+      expect(addSource).toHaveBeenCalledWith({
+        source_type: "google_drive_folder",
+        external_ref: "1AbC_dEf-234567890",
+        display_name: "Acme fleet records",
+        user_id: "org_acme",
+      });
+    });
+    expect(onAdded).toHaveBeenCalledOnce();
+    expect(screen.queryByText("Add My Drive")).not.toBeInTheDocument();
+  });
+
+  it("sends the user to connect Google Drive before assigning a folder", async () => {
+    listIntegrations.mockResolvedValue({
+      providers: [{ provider: "google", enabled: true, connected: false }],
+    });
+    render(<UserDriveSourceControls externalUserId="org_acme" onAdded={() => {}} />);
+
+    const link = await screen.findByRole("link", { name: "Connect Google Drive" });
+    expect(link).toHaveAttribute("href", "/integrations/google");
+    expect(screen.queryByPlaceholderText("Paste a Drive folder link")).not.toBeInTheDocument();
+  });
+
+  it("keeps the folder form available when assignment fails", async () => {
+    listIntegrations.mockResolvedValue({
+      providers: [{ provider: "google", enabled: true, connected: true }],
+    });
+    addSource.mockRejectedValue(new Error("This Google account cannot read that folder."));
+    render(<UserDriveSourceControls externalUserId="org_acme" onAdded={() => {}} />);
+
+    fireEvent.change(await screen.findByPlaceholderText("Paste a Drive folder link"), {
+      target: { value: "https://drive.google.com/drive/folders/1AbC_dEf-234567890" },
+    });
+    fireEvent.click(screen.getByText("Add folder"));
+
+    expect(await screen.findByText("This Google account cannot read that folder.")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Paste a Drive folder link")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/developer/UserDriveSourceControls.tsx
+++ b/frontend/src/components/developer/UserDriveSourceControls.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { addSource } from "@/lib/api";
+import { listIntegrations, type IntegrationStatus } from "@/lib/integrations";
+
+import { DriveFolderControls } from "../integrations/pickers";
+
+export default function UserDriveSourceControls({
+  externalUserId,
+  onAdded,
+}: {
+  externalUserId: string;
+  onAdded: () => void;
+}) {
+  const [google, setGoogle] = useState<IntegrationStatus | null | undefined>(undefined);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    listIntegrations()
+      .then((result) => {
+        const provider = result.providers.find((item) => item.provider === "google");
+        setGoogle(provider === undefined ? null : provider);
+      })
+      .catch((cause) => {
+        if (!(cause instanceof Error)) throw cause;
+        setError(cause.message);
+      });
+  }, []);
+
+  async function addFolder(folderId: string, displayName: string): Promise<boolean> {
+    setBusy(true);
+    setError("");
+    try {
+      await addSource({
+        source_type: "google_drive_folder",
+        external_ref: folderId,
+        ...(displayName ? { display_name: displayName } : {}),
+        user_id: externalUserId,
+      });
+      onAdded();
+      return true;
+    } catch (cause) {
+      if (!(cause instanceof Error)) throw cause;
+      setError(cause.message);
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (google === undefined) {
+    if (error) {
+      return <div className="mt-3 text-[12.5px] text-error">{error}</div>;
+    }
+    return <div className="mt-3 text-[12.5px] text-muted-foreground">Checking Google Drive…</div>;
+  }
+
+  if (google === null) {
+    return (
+      <div className="mt-3 text-[12.5px] text-muted-foreground">
+        Google Drive is not available for this workspace.
+      </div>
+    );
+  }
+
+  if (!google.enabled) {
+    if (google.disabled_reason === null) {
+      throw new Error("Disabled Google Drive integration has no reason");
+    }
+    return <div className="mt-3 text-[12.5px] text-muted-foreground">{google.disabled_reason}</div>;
+  }
+
+  if (!google.connected) {
+    return (
+      <div className="mt-3 text-[12.5px] text-muted-foreground">
+        <Link href="/integrations/google" className="font-medium text-brand hover:underline">
+          Connect Google Drive
+        </Link>{" "}
+        before assigning a folder to this user.
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-3">
+      <DriveFolderControls busy={busy} onAddFolder={addFolder} />
+      {error && <div className="mt-2 text-[12.5px] text-error">{error}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/integrations/pickers.tsx
+++ b/frontend/src/components/integrations/pickers.tsx
@@ -138,9 +138,19 @@ export function AddSourceControls({
   if (connector.kind === "drive") {
     return (
       <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void add({ external_ref: "root", display_name: "Google Drive" })}
+            disabled={busy}
+            className={secondaryButton()}
+          >
+            {busy ? "Adding..." : "Add My Drive"}
+          </button>
+          <span className="text-[11.5px] text-muted-foreground">or sync just one folder:</span>
+        </div>
         <DriveFolderControls
           busy={busy}
-          onAddMyDrive={() => add({ external_ref: "root", display_name: "Google Drive" })}
           onAddFolder={(folderId, displayName) =>
             add({
               source_type: "google_drive_folder",
@@ -265,13 +275,11 @@ export function parseDriveFolderId(input: string): string | null {
   return null;
 }
 
-function DriveFolderControls({
+export function DriveFolderControls({
   busy,
-  onAddMyDrive,
   onAddFolder,
 }: {
   busy: boolean;
-  onAddMyDrive: () => Promise<boolean>;
   // Blank name means the server names the source after the Drive folder.
   onAddFolder: (folderId: string, displayName: string) => Promise<boolean>;
 }) {
@@ -290,12 +298,6 @@ function DriveFolderControls({
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center gap-2">
-        <button type="button" onClick={() => void onAddMyDrive()} disabled={busy} className={secondaryButton()}>
-          {busy ? "Adding..." : "Add My Drive"}
-        </button>
-        <span className="text-[11.5px] text-muted-foreground">or sync just one folder:</span>
-      </div>
       <input
         value={link}
         onChange={(event) => setLink(event.target.value)}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -599,6 +599,7 @@ export async function addSource(body: {
   external_ref?: string;
   display_name?: string;
   settings?: Record<string, unknown>;
+  user_id?: string;
 }): Promise<{ id: string; display_name: string }> {
   return apiFetch(`${ME}/sources`, {
     method: "POST",


### PR DESCRIPTION
This is a frontend-only change that makes it possible to add a Google drive folder associated with a specific `user_id`. We always had this backend capability, but it was never exposed in the frontend. This is useful, eg if you have a folder of PDFs of org-specific rules that you want to add to memory for one organization only.



# Slop

## Why

Stash already supports scoping a connected Drive folder to one external user, but the developer console could only display those sources. Developers had to call the API directly to assign a customer's folder, leaving the org-isolation workflow only partially productized.

## What changed

- Added an “Assign a Google Drive folder” control to each developer user page
- Sends the selected user's external ID with the existing source-creation request
- Reuses the Drive folder-link parser and optional folder naming behavior
- Requires an active Google Drive connection and links to the connection flow when absent
- Deliberately omits “Add My Drive” from the user-scoped surface so only an explicit folder can be exposed
- Keeps assignment failures visible alongside the form so the developer can correct and retry

## What to look at

The important boundary is `user_id: externalUserId` in `UserDriveSourceControls`: that is what stamps the source to one user and makes it invisible to every other user's scoped VFS. The generic Drive integration page is unchanged apart from extracting its folder-only controls for reuse.

## How it was verified

- `npm test` — 61 files, 306 tests passed
- `npm run lint` — 0 errors; 10 pre-existing warnings in unrelated files
- `NEXT_PUBLIC_API_URL=http://localhost:3456 npm run build` — production build and TypeScript passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Stamps sources with `user_id` for per-user VFS isolation; a wrong ID would mis-scope Drive data, though the UI binds it to the page’s `external_id`.
> 
> **Overview**
> Adds **Assign a Google Drive folder** on the developer **user detail** page so folders can be scoped to that user’s `external_id` without calling the API manually.
> 
> New **`UserDriveSourceControls`** checks workspace Google Drive status (unavailable, disabled, or not connected → link to `/integrations/google`), then reuses exported **`DriveFolderControls`** to paste a folder link and optional name. Creation goes through **`addSource`** with `source_type: google_drive_folder` and **`user_id`** set to the viewed user; **`onAdded`** refreshes the connected-sources list. Errors stay on the form for retry.
> 
> **`addSource`**’s TypeScript body now includes optional **`user_id`**. In **`pickers.tsx`**, **Add My Drive** stays on the workspace integrations Drive flow only; **`DriveFolderControls`** is exported and folder-only so the per-user UI cannot attach whole My Drive.
> 
> Vitest covers happy path, connect-first gating, and failed assignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8355338161b14a8e619fb994b7282e94d7b82a97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->