### PR TITLE
Make VFS reads without user_id shared-only

### DIFF
--- a/backend/routers/vfs.py
+++ b/backend/routers/vfs.py
@@ -20,9 +20,9 @@ MAX_SCRIPT_LENGTH = 4096
 
 class VfsRequest(BaseModel):
     # Unknown fields are refused, not dropped: a misspelled user_id would
-    # otherwise run UNSCOPED — the whole workspace instead of one user's
-    # view — which is an isolation failure, not a typo. Strictness is safe
-    # here because only our own clients call this surface.
+    # otherwise run the developer workspace's shared-only view instead of one
+    # user's view. Strictness is safe because only our own clients call this
+    # surface.
     model_config = ConfigDict(extra="forbid")
 
     script: str = Field(max_length=MAX_SCRIPT_LENGTH)
@@ -30,13 +30,13 @@ class VfsRequest(BaseModel):
     user_id: str | None = Field(
         None,
         max_length=128,
-        description="External Multiplayer: narrow the tree to this end user — "
-        "shared wiki at /memory, the user's own wiki and files under /files, "
-        "the user's transcripts under /sessions",
+        description="External Multiplayer: omit for the shared wiki only, or narrow "
+        "the tree to this end user — shared wiki at /memory, the user's own wiki "
+        "and files under /files, the user's transcripts under /sessions",
     )
 
 
-async def _end_user_ctx(current_user: dict, user_id: str | None) -> dict | None:
+async def _external_vfs_ctx(current_user: dict, user_id: str | None) -> dict | None:
     """The developer contract: the caller's key belongs to the workspace's
     scope user, and user_id is asserted by their backend. Isolation between one
     developer's users is enforced at the developer boundary, not here.
@@ -47,14 +47,21 @@ async def _end_user_ctx(current_user: dict, user_id: str | None) -> dict | None:
     right: the accumulated cross-user knowledge is what a new user benefits
     from on day one. The user appears once their first session is uploaded.
     """
-    if user_id is None:
-        return None
     workspace = await end_user_service.workspace_for_scope(current_user["id"])
     if workspace is None or workspace["external_wiki_folder_id"] is None:
+        if user_id is None:
+            return None
         raise HTTPException(
             status_code=400,
             detail="user_id requires a developer workspace scope — activate the platform first",
         )
+    if user_id is None:
+        return {
+            "external_id": None,
+            "shared_wiki_folder_id": str(workspace["external_wiki_folder_id"]),
+            "wiki_folder_id": None,
+            "source_ids": set(),
+        }
     end_user = await end_user_service.find_end_user(workspace["id"], user_id)
     if end_user is None:
         return {
@@ -98,7 +105,7 @@ async def run_vfs(
             status_code=401,
             detail="The VFS runs every read as the calling credential; use an API key, not a cookie.",
         )
-    end_user_ctx = await _end_user_ctx(current_user, body.user_id)
+    end_user_ctx = await _external_vfs_ctx(current_user, body.user_id)
     try:
         return await vfs_service.run_vfs_script(
             request.app, authorization, body.script, body.cwd, end_user_ctx

--- a/backend/services/vfs_service.py
+++ b/backend/services/vfs_service.py
@@ -222,15 +222,17 @@ def _error_detail(response: httpx.Response) -> str:
     return f"HTTP {response.status_code}"
 
 
-class EndUserVfsClient(InProcessVfsClient):
-    """External Multiplayer: the caller's Stash narrowed to one end user.
+class ExternalVfsClient(InProcessVfsClient):
+    """External Multiplayer: the caller's Stash narrowed to shared knowledge,
+    optionally plus one end user's private knowledge.
 
     `/memory` becomes the workspace's shared external wiki (the memory-folder
     call answers with the wiki folder, and the model re-roots whatever that
     returns), `/files` holds the user's own wiki and the user's own uploads,
     `/sessions` only the user's transcripts, and `/sources` the sources
-    connected for this user. Skills and tables are developer-side surfaces and
-    don't exist in a user's view.
+    connected for this user. Without an end user, only the shared wiki remains.
+    Skills and tables are developer-side surfaces and don't exist in either
+    external view.
     """
 
     def __init__(self, http, loop, end_user_ctx: dict) -> None:
@@ -285,11 +287,15 @@ class EndUserVfsClient(InProcessVfsClient):
 
         return {
             **overview,
-            "sessions": [
-                s
-                for s in overview.get("sessions", [])
-                if s.get("end_user_external_id") == external_id
-            ],
+            "sessions": (
+                []
+                if external_id is None
+                else [
+                    s
+                    for s in overview.get("sessions", [])
+                    if s.get("end_user_external_id") == external_id
+                ]
+            ),
             "skills": [],
             "files": {
                 "folders": kept_folders,
@@ -297,7 +303,8 @@ class EndUserVfsClient(InProcessVfsClient):
                 "files": [
                     f
                     for f in tree.get("files", [])
-                    if f.get("end_user_external_id") == external_id or f["folder_id"] in kept_ids
+                    if f["folder_id"] in kept_ids
+                    or (external_id is not None and f.get("end_user_external_id") == external_id)
                 ],
             },
         }
@@ -308,7 +315,7 @@ def _build_model(
 ) -> StashVfsModel:
     if end_user_ctx is None:
         return StashVfsModel(InProcessVfsClient(http, loop), include_computer=False)
-    return StashVfsModel(EndUserVfsClient(http, loop, end_user_ctx), include_computer=False)
+    return StashVfsModel(ExternalVfsClient(http, loop, end_user_ctx), include_computer=False)
 
 
 def _run_script(
@@ -339,8 +346,8 @@ async def run_vfs_script(
 
     `authorization` is forwarded verbatim onto every nested request, so the VFS
     sees precisely what that credential sees anywhere else in the API.
-    `end_user_ctx` (External Multiplayer) narrows the tree to one end user —
-    see EndUserVfsClient.
+    `end_user_ctx` (External Multiplayer) narrows the tree to shared knowledge,
+    optionally plus one end user — see ExternalVfsClient.
     """
     loop = asyncio.get_running_loop()
     transport = httpx.ASGITransport(app=app)

--- a/backend/tests/test_developer_platform.py
+++ b/backend/tests/test_developer_platform.py
@@ -232,6 +232,62 @@ async def test_user_vfs_isolates_users(client: AsyncClient, pool):
 
 
 @pytest.mark.asyncio
+async def test_developer_workspace_without_user_id_reads_only_shared_wiki(
+    client: AsyncClient, pool
+):
+    """A developer can search shared product knowledge without impersonating an
+    end user. Omitting user_id must narrow access to the shared wiki; it must
+    never expose any user's private wiki or transcripts."""
+    api_key, _, workspace = await _developer(client)
+    machine_key = await _mint_workspace_key(client, api_key, workspace)
+    await _push(
+        client,
+        machine_key,
+        [
+            _event("sess-acme-1", user_id="org_acme", user_name="Acme"),
+            _event("sess-beta-1", user_id="org_beta", user_name="Beta"),
+            _event("sess-internal"),
+        ],
+    )
+
+    end_users = {
+        r["external_id"]: r
+        for r in await pool.fetch(
+            "SELECT external_id, wiki_folder_id FROM end_users WHERE workspace_id = $1",
+            uuid.UUID(workspace["id"]),
+        )
+    }
+    scope_id = uuid.UUID(workspace["scope_user_id"])
+    for name, folder_id in [
+        ("Fault codes", uuid.UUID(workspace["external_wiki_folder_id"])),
+        ("Acme notes", end_users["org_acme"]["wiki_folder_id"]),
+        ("Beta notes", end_users["org_beta"]["wiki_folder_id"]),
+    ]:
+        await pool.execute(
+            "INSERT INTO pages (owner_user_id, name, content_markdown, folder_id, created_by) "
+            "VALUES ($1, $2, 'body', $3, $1)",
+            scope_id,
+            name,
+            folder_id,
+        )
+
+    resp = await client.post(
+        "/api/v1/me/vfs",
+        json={"script": "find / -type f"},
+        headers=_auth(machine_key),
+    )
+    assert resp.status_code == 200, resp.text
+    listing = resp.json()["stdout"]
+
+    assert "Fault codes" in listing
+    assert "Acme notes" not in listing
+    assert "Beta notes" not in listing
+    assert "sess-acme-1" not in listing
+    assert "sess-beta-1" not in listing
+    assert "sess-internal" not in listing
+
+
+@pytest.mark.asyncio
 async def test_new_user_reads_the_shared_wiki_before_they_have_written(client: AsyncClient, pool):
     """A customer's agent reads context before it records anything, so its very
     first call names a user that has no row yet. That has to work, and it has to
@@ -330,6 +386,14 @@ async def test_user_scoped_source_is_visible_to_that_user_only(client: AsyncClie
 
     assert "google" in await sources_listing("org_acme")
     assert "google" not in await sources_listing("org_beta")
+
+    resp = await client.post(
+        "/api/v1/me/vfs",
+        json={"script": "ls /sources"},
+        headers=_auth(machine_key),
+    )
+    assert resp.status_code == 200, resp.text
+    assert "google" not in resp.json()["stdout"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This changes the default behavior for a call to read our VFS  (POST /api/v1/me/vfs)  when a `user_id`is omitted. Previously, no `user_id` meant "see everything, including other private orgs". This is a total footgun. Now `user_id` defaults to "see only the shared external wiki"


## Summary

Developer-workspace VFS calls that omit `user_id` now return only the shared external wiki. This makes shared searches possible without impersonating an org while preventing an omitted ID from exposing private org material.

## Changes

- resolve an active developer workspace with no `user_id` to a shared-only VFS context
- hide every org private wiki, file, source, and transcript from that context
- preserve existing behavior when `user_id` is present: shared wiki plus that org private material
- preserve ordinary unscoped VFS behavior outside developer workspaces

## Review guide

Start in `backend/routers/vfs.py`, where an omitted `user_id` becomes a shared-only context. Then review `ExternalVfsClient` in `backend/services/vfs_service.py`, which filters the mounted tree. The regression tests demonstrate both the visible shared page and the excluded org material.

## Test plan

- [x] `pytest backend/tests/test_developer_platform.py -q --no-cov` — 21 passed
- [x] Ruff lint and format checks on all changed files
- [x] New regression coverage for missing-user wiki, session, and source isolation

## Checklist

- [x] No hardcoded secrets or credentials
- [x] API field documentation updated for the new behavior
- [ ] CHANGELOG.md updated — omitted; this is a security correction to an unreleased developer-platform path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a security/isolation fix on the developer-platform VFS path: wrong behavior previously could expose cross-customer private material when `user_id` was omitted.
> 
> **Overview**
> Developer-workspace **`POST /api/v1/me/vfs`** calls that omit **`user_id`** now mount a **shared-only** tree instead of the full scoped workspace, so developers can search product wiki knowledge without impersonating an end user and an omitted ID can’t leak other orgs’ wikis, files, sessions, or sources.
> 
> **`_external_vfs_ctx`** (renamed from `_end_user_ctx`) resolves an active developer workspace with no `user_id` to a context with only the shared external wiki folder and empty per-user fields. **`ExternalVfsClient`** (renamed from `EndUserVfsClient`) treats `external_id: None` as no sessions, no per-user file matches, and no connected sources; behavior with a `user_id` is unchanged. Non–developer-workspace callers still get `None` context and the ordinary unscoped VFS.
> 
> Regression tests cover `find` and `ls /sources` without `user_id`, and API field docs describe omitting `user_id` for shared wiki only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1c2eca192b1dc4e6ce85624741aecd1f6b38dc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->