### PR TITLE
add embeddings viz job to the heavy queue

### DIFF
--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -52,8 +52,8 @@ celery.conf.update(
     # Two queues, split by task weight. Anything that can hold a worker slot
     # for minutes — subprocess extractions, Playwright renders, exports,
     # source crawls, bulk URL fetches, headless agent runs — routes to
-    # "heavy" and gets its own worker pool. Everything else (every beat
-    # sweep, every cheap bounded task) stays on "default", which therefore
+    # "heavy" and gets its own worker pool. Everything else (cheap beat
+    # sweeps and bounded tasks) stays on "default", which therefore
     # never stalls: cadence-sensitive tasks like X token keep-fresh (its
     # 45-min refresh_margin assumes a tick roughly every 30 min) get their
     # guarantee without being enumerated. Interactive agent replies
@@ -73,6 +73,7 @@ celery.conf.update(
         "backend.exports.gslides.export_to_google_slides": {"queue": "heavy"},
         "backend.tasks.agent_schedules.run_scheduled_agent": {"queue": "heavy"},
         "backend.tasks.agent_schedules.run_curator_now": {"queue": "heavy"},
+        "backend.tasks.viz.precompute": {"queue": "heavy"},
     },
     task_acks_late=True,
     task_reject_on_worker_lost=True,

--- a/backend/tests/test_celery_routing.py
+++ b/backend/tests/test_celery_routing.py
@@ -14,6 +14,7 @@ from backend.tasks.clips import process_url_imports
 from backend.tasks.drive_extraction import extract_drive_document
 from backend.tasks.extraction import extract_file_text
 from backend.tasks.sources import sync_source
+from backend.tasks.viz import precompute
 
 HEAVY_TASKS = {
     extract_file_text.name,
@@ -25,6 +26,7 @@ HEAVY_TASKS = {
     export_to_google_slides.name,
     run_scheduled_agent.name,
     run_curator_now.name,
+    precompute.name,
 }
 
 
@@ -37,12 +39,11 @@ def test_heavy_tasks_route_off_the_default_queue():
         assert routes[task_name] == {"queue": "heavy"}
 
 
-def test_no_beat_task_is_heavy():
-    # The whole point of the split: every beat tick must stay cheap. A beat
-    # task routed to heavy (or doing heavy work inline, like run_due before
-    # it became a dispatcher) couples its cadence to long-running work.
+def test_only_expensive_viz_beat_task_is_heavy():
+    # Beat dispatchers stay on default so their cadence cannot be starved.
+    # Viz is the one exception because the task itself fits UMAP inline.
     beat_tasks = {entry["task"] for entry in celery.conf.beat_schedule.values()}
-    assert beat_tasks.isdisjoint(HEAVY_TASKS)
+    assert beat_tasks & HEAVY_TASKS == {precompute.name}
 
 
 def test_bare_worker_consumes_both_queues():


### PR DESCRIPTION
We have two separate queues of tasks in celery. There's one for easy tasks, and one for hard tasks that could block the queue for a while. This PR moves embeddings viz computation to the "hard tasks" queue.

## Why

The 2 GiB default Celery worker OOM-restarted twice because each visualization precompute UMAP fit permanently raised a prefork child’s RSS by roughly 280–530 MB. Production runs four default-worker children, so their combined memory can cross the container limit without any child reaching the existing 800 MB recycle threshold.

## What changed

- Route `backend.tasks.viz.precompute` to the 8 GiB, two-child heavy worker
- Preserve the invariant that cadence-sensitive Beat dispatchers stay on the default queue
- Pin visualization precompute as the sole intentionally heavy Beat task in the routing regression test

## What to look at

The behavioral change is only the Celery route. Visualization refreshes may wait behind other heavy work, but their cache TTL is six hours and Beat checks every five minutes, so they are not latency-sensitive.

## How it was verified

- `pytest -q -o addopts='' --noconftest backend/tests/test_celery_routing.py` — 3 passed
- `ruff check backend/ cli/`
- `ruff format --check backend/ cli/`
- Confirmed the configured route resolves to `{"queue": "heavy"}`

The normal focused pytest command could not initialize the repository-wide fixture because no local Postgres is running in this worktree; the routing tests were rerun without `conftest.py` because they do not access the database.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Celery route change with regression tests; main tradeoff is viz precompute latency behind other heavy tasks, not correctness or security.
> 
> **Overview**
> Moves **`backend.tasks.viz.precompute`** from the default Celery queue to **`heavy`**, so memory-heavy UMAP work runs on the larger worker pool instead of contributing to OOM on the 2 GiB default workers.
> 
> Beat still fires viz precompute every five minutes; only the execution queue changes. Precompute may queue behind other heavy jobs, which is acceptable given the six-hour cache TTL.
> 
> The routing test is updated to treat viz precompute as the **sole** beat task allowed on `heavy`, replacing the previous rule that no beat task could be heavy. A small comment tweak in `celery_app.py` clarifies the default-queue policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03a0220284f4b3fe4fbd2f68bf4018d0736caca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->