### PR TITLE
Hand a user files and sessions from the developer console

### DIFF
--- a/backend/routers/transcripts.py
+++ b/backend/routers/transcripts.py
@@ -21,6 +21,7 @@ from fastapi.responses import PlainTextResponse
 from ..auth import get_current_user, get_scope
 from ..database import get_pool
 from ..services import (
+    end_user_service,
     memory_service,
     security_audit_service,
     session_service,
@@ -52,6 +53,9 @@ async def upload_transcript(
     session_id: str = Form(...),
     agent_name: str = Form(...),
     cwd: str | None = Form(None),
+    # External Multiplayer: file the session under this end user (the
+    # developer's own id for them). The user must already exist.
+    user_id: str | None = Form(None),
     # LEGACY filing lane for installed clients: honored when sent.
     session_folder_id: UUID | None = Form(None),
     replace: bool = Form(False),
@@ -74,6 +78,20 @@ async def upload_transcript(
     body = await file.read()
     if len(body) > MAX_TRANSCRIPT_SIZE:
         raise HTTPException(status_code=413, detail="Transcript too large (max 50 MB)")
+
+    # end_user_id is set at session insert only (the user a session is born
+    # into is its privacy boundary), so the end user must resolve before any
+    # session row is written — and a session already born into a different
+    # user (or none) must refuse the upload rather than migrate.
+    end_user = None
+    if user_id is not None:
+        try:
+            end_user = await end_user_service.resolve_end_user_for_scope(owner_user_id, user_id)
+            await memory_service.reject_cross_user_sessions(
+                owner_user_id, [{"session_id": session_id, "user_id": user_id}]
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
 
     pool = get_pool()
     existing = await pool.fetchval(
@@ -119,6 +137,7 @@ async def upload_transcript(
                 agent_name=agent_name,
                 cwd=cwd,
                 created_by=current_user["id"],
+                end_user_id=end_user["id"] if end_user else None,
                 session_folder_id=session_folder_id,
             )
             return {
@@ -146,6 +165,7 @@ async def upload_transcript(
             agent_name=agent_name,
             cwd=cwd,
             created_by=current_user["id"],
+            end_user_id=end_user["id"] if end_user else None,
             session_folder_id=session_folder_id,
             started_at=transcript_started_at,
         )

--- a/backend/tests/test_developer_platform.py
+++ b/backend/tests/test_developer_platform.py
@@ -16,6 +16,8 @@ What matters here:
   that is the entire product promise to the developer's customers.
 """
 
+import io
+import json
 import uuid
 
 import pytest
@@ -330,6 +332,124 @@ async def test_user_scoped_source_is_visible_to_that_user_only(client: AsyncClie
 
     assert "google" in await sources_listing("org_acme")
     assert "google" not in await sources_listing("org_beta")
+
+
+# --- Manual per-user material (console) ---
+
+_TRANSCRIPT = (
+    json.dumps({"type": "user", "message": {"content": "hi"}, "timestamp": "2026-05-10T20:00:00Z"})
+    + "\n"
+    + json.dumps(
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "hello"}]},
+            "timestamp": "2026-05-10T20:00:01Z",
+        }
+    )
+    + "\n"
+).encode()
+
+
+async def _developer_with_user(client: AsyncClient) -> tuple[dict, dict]:
+    """An activated workspace with one end user (org_acme).
+    Returns (scope_headers, workspace)."""
+    api_key, _, workspace = await _developer(client)
+    machine_key = await _mint_workspace_key(client, api_key, workspace)
+    await _push(client, machine_key, [_event("sess-seed", user_id="org_acme", user_name="Acme")])
+    return {**_auth(api_key), "X-Stash-Scope": workspace["scope_user_id"]}, workspace
+
+
+@pytest.mark.asyncio
+async def test_transcript_upload_with_user_files_session_under_them(client: AsyncClient, pool):
+    """The console can hand a user a session by uploading its transcript —
+    it must land inside that user's privacy boundary exactly as if their
+    product's backend had streamed it."""
+    scope, workspace = await _developer_with_user(client)
+
+    resp = await client.post(
+        "/api/v1/me/transcripts",
+        files={"file": ("s.jsonl", io.BytesIO(_TRANSCRIPT), "application/jsonl")},
+        data={"session_id": "sess-manual-1", "agent_name": "support-bot", "user_id": "org_acme"},
+        headers=scope,
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["imported"] == 2
+
+    row = await pool.fetchrow(
+        "SELECT eu.external_id FROM sessions s JOIN end_users eu ON eu.id = s.end_user_id "
+        "WHERE s.owner_user_id = $1 AND s.session_id = 'sess-manual-1'",
+        uuid.UUID(workspace["scope_user_id"]),
+    )
+    assert row and row["external_id"] == "org_acme"
+
+
+@pytest.mark.asyncio
+async def test_transcript_upload_for_unknown_user_fails_loud(client: AsyncClient):
+    scope, _ = await _developer_with_user(client)
+    resp = await client.post(
+        "/api/v1/me/transcripts",
+        files={"file": ("s.jsonl", io.BytesIO(_TRANSCRIPT), "application/jsonl")},
+        data={"session_id": "sess-x", "agent_name": "support-bot", "user_id": "org_never_seen"},
+        headers=scope,
+    )
+    assert resp.status_code == 400
+    assert "unknown user" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_transcript_upload_cannot_move_a_session_between_users(client: AsyncClient):
+    """sess-seed was born into org_acme's boundary; re-uploading it under
+    another user must refuse rather than migrate or cross-file events."""
+    scope, workspace = await _developer_with_user(client)
+    machine_key_scope = scope
+
+    resp = await client.post(
+        "/api/v1/me/sessions/events/batch",
+        json={"events": [_event("sess-b", user_id="org_beta", user_name="Beta")]},
+        headers=machine_key_scope,
+    )
+    assert resp.status_code == 201, resp.text
+
+    resp = await client.post(
+        "/api/v1/me/transcripts",
+        files={"file": ("s.jsonl", io.BytesIO(_TRANSCRIPT), "application/jsonl")},
+        data={"session_id": "sess-seed", "agent_name": "support-bot", "user_id": "org_beta"},
+        headers=scope,
+    )
+    assert resp.status_code == 400
+    assert "already belongs" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_file_upload_with_user_scopes_the_file(client: AsyncClient, pool, monkeypatch):
+    """The console's manual file upload rides the existing user_id form
+    field: the file row is stamped to the user, so only their agent sees it."""
+    from backend.services import storage_service
+    from backend.tasks import extraction
+
+    async def _upload(owner_user_id, filename, content, content_type):
+        return f"test/{owner_user_id}/{filename}"
+
+    monkeypatch.setattr(storage_service, "is_configured", lambda: True)
+    monkeypatch.setattr(storage_service, "upload_file", _upload)
+    monkeypatch.setattr(extraction.extract_file_text, "delay", lambda *a, **k: None)
+
+    scope, workspace = await _developer_with_user(client)
+
+    resp = await client.post(
+        "/api/v1/me/files",
+        files={"file": ("coverage.pdf", io.BytesIO(b"%PDF-1.4 test"), "application/pdf")},
+        data={"user_id": "org_acme"},
+        headers=scope,
+    )
+    assert resp.status_code == 201, resp.text
+
+    row = await pool.fetchrow(
+        "SELECT eu.external_id FROM files f JOIN end_users eu ON eu.id = f.end_user_id "
+        "WHERE f.owner_user_id = $1 AND f.name = 'coverage.pdf'",
+        uuid.UUID(workspace["scope_user_id"]),
+    )
+    assert row and row["external_id"] == "org_acme"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/app/(app)/developer/users/[userId]/page.tsx
+++ b/frontend/src/app/(app)/developer/users/[userId]/page.tsx
@@ -8,6 +8,8 @@ import { ArrowLeft } from "lucide-react";
 import DeveloperGate from "@/components/developer/DeveloperGate";
 import { Code, PageHeading, SectionHeading } from "@/components/developer/DocsPrimitives";
 import UserDriveSourceControls from "@/components/developer/UserDriveSourceControls";
+import UserFileUploadControls from "@/components/developer/UserFileUploadControls";
+import UserSessionUploadControls from "@/components/developer/UserSessionUploadControls";
 import WikiToggle from "@/components/developer/WikiToggle";
 import WikiGraph from "@/components/memory/WikiGraph";
 import {
@@ -149,6 +151,7 @@ function UserDetail() {
 
       <section className="mb-12">
         <SectionHeading>Sessions</SectionHeading>
+        <UserSessionUploadControls externalUserId={user.external_id} onAdded={refresh} />
         {sessions.length === 0 ? (
           <Empty>No sessions yet for this user.</Empty>
         ) : (
@@ -184,10 +187,11 @@ function UserDetail() {
           uploaded with their <Code>user_id</Code>, and integrations connected for them
           alone. Your other users never see any of it.
         </p>
+        <UserFileUploadControls externalUserId={user.external_id} onAdded={refresh} />
         {files.length === 0 ? (
           <Empty>
-            No files yet. Files arrive when your backend uploads one with this user&apos;s{" "}
-            <Code>user_id</Code>.
+            No files yet. Upload one here, or have your backend upload one with this
+            user&apos;s <Code>user_id</Code>.
           </Empty>
         ) : (
           <div className="mt-4 overflow-hidden rounded border border-border bg-surface">

--- a/frontend/src/components/developer/UserFileUploadControls.test.tsx
+++ b/frontend/src/components/developer/UserFileUploadControls.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import UserFileUploadControls from "./UserFileUploadControls";
+
+const uploadFile = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  uploadFile: (...args: unknown[]) => uploadFile(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("UserFileUploadControls", () => {
+  it("uploads the picked file scoped to the user", async () => {
+    uploadFile.mockResolvedValue({});
+    const onAdded = vi.fn();
+    render(<UserFileUploadControls externalUserId="org_acme" onAdded={onAdded} />);
+
+    const file = new File(["%PDF-1.4"], "coverage.pdf", { type: "application/pdf" });
+    fireEvent.change(screen.getByTestId("user-file-input"), { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(uploadFile).toHaveBeenCalledWith(file, null, "org_acme");
+    });
+    expect(onAdded).toHaveBeenCalledOnce();
+  });
+
+  it("shows the server error and stays usable", async () => {
+    uploadFile.mockRejectedValue(new Error("File too large (max 100 MB)"));
+    const onAdded = vi.fn();
+    render(<UserFileUploadControls externalUserId="org_acme" onAdded={onAdded} />);
+
+    const file = new File(["x"], "huge.bin");
+    fireEvent.change(screen.getByTestId("user-file-input"), { target: { files: [file] } });
+
+    expect(await screen.findByText("File too large (max 100 MB)")).toBeTruthy();
+    expect(screen.getByText("Upload a file")).toBeEnabled();
+    expect(onAdded).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/developer/UserFileUploadControls.tsx
+++ b/frontend/src/components/developer/UserFileUploadControls.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+import { uploadFile } from "@/lib/api";
+
+// Hand this user a file from the console. The server stamps the file row's
+// end_user_id, so only this user's agent (and the developer) can read it.
+export default function UserFileUploadControls({
+  externalUserId,
+  onAdded,
+}: {
+  externalUserId: string;
+  onAdded: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  async function upload(file: File) {
+    setBusy(true);
+    setError("");
+    try {
+      await uploadFile(file, null, externalUserId);
+      onAdded();
+    } catch (cause) {
+      if (!(cause instanceof Error)) throw cause;
+      setError(cause.message);
+    } finally {
+      setBusy(false);
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  }
+
+  return (
+    <div className="mt-3">
+      <input
+        ref={inputRef}
+        type="file"
+        hidden
+        data-testid="user-file-input"
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          if (file) void upload(file);
+        }}
+      />
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        disabled={busy}
+        className="cursor-pointer rounded-md border border-border px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-raised disabled:opacity-60"
+      >
+        {busy ? "Uploading..." : "Upload a file"}
+      </button>
+      {error && <div className="mt-2 text-[12.5px] text-error">{error}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/developer/UserSessionUploadControls.test.tsx
+++ b/frontend/src/components/developer/UserSessionUploadControls.test.tsx
@@ -1,0 +1,114 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import UserSessionUploadControls from "./UserSessionUploadControls";
+
+const uploadTranscript = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  uploadTranscript: (...args: unknown[]) => uploadTranscript(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+async function openForm() {
+  await userEvent.click(screen.getByLabelText("Session actions"));
+  await userEvent.click(await screen.findByText("Upload a session transcript"));
+}
+
+const transcript = new File(['{"type":"user"}\n'], "sess-support-42.jsonl");
+
+describe("UserSessionUploadControls", () => {
+  it("keeps the form behind the menu until asked for", () => {
+    render(<UserSessionUploadControls externalUserId="org_acme" onAdded={() => {}} />);
+    expect(screen.queryByPlaceholderText("Session id")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Session actions")).toBeInTheDocument();
+  });
+
+  it("uploads the transcript under the user, prefilled from the filename", async () => {
+    uploadTranscript.mockResolvedValue({ session_id: "sess-support-42", imported: 2, skipped: false });
+    const onAdded = vi.fn();
+    render(<UserSessionUploadControls externalUserId="org_acme" onAdded={onAdded} />);
+
+    await openForm();
+    fireEvent.change(screen.getByTestId("user-transcript-input"), {
+      target: { files: [transcript] },
+    });
+    // The filename stem lands in the session id field.
+    expect(screen.getByPlaceholderText("Session id")).toHaveValue("sess-support-42");
+    fireEvent.change(screen.getByPlaceholderText(/Agent name/), {
+      target: { value: "support-bot" },
+    });
+    fireEvent.click(screen.getByText("Upload"));
+
+    await waitFor(() => {
+      expect(uploadTranscript).toHaveBeenCalledWith(
+        transcript,
+        "sess-support-42",
+        "support-bot",
+        undefined,
+        "org_acme",
+      );
+    });
+    expect(onAdded).toHaveBeenCalledOnce();
+    expect(screen.queryByPlaceholderText("Session id")).not.toBeInTheDocument();
+  });
+
+  it("surfaces a skipped upload instead of pretending it imported", async () => {
+    uploadTranscript.mockResolvedValue({
+      session_id: "sess-support-42",
+      imported: 0,
+      skipped: true,
+      reason: "session already has events",
+    });
+    const onAdded = vi.fn();
+    render(<UserSessionUploadControls externalUserId="org_acme" onAdded={onAdded} />);
+
+    await openForm();
+    fireEvent.change(screen.getByTestId("user-transcript-input"), {
+      target: { files: [transcript] },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/Agent name/), { target: { value: "bot" } });
+    fireEvent.click(screen.getByText("Upload"));
+
+    expect(
+      await screen.findByText("Nothing imported: session already has events."),
+    ).toBeTruthy();
+    expect(onAdded).not.toHaveBeenCalled();
+  });
+
+  it("shows the server error and keeps the form open", async () => {
+    uploadTranscript.mockRejectedValue(
+      new Error("session 'sess-support-42' already belongs to org_beta"),
+    );
+    render(<UserSessionUploadControls externalUserId="org_acme" onAdded={() => {}} />);
+
+    await openForm();
+    fireEvent.change(screen.getByTestId("user-transcript-input"), {
+      target: { files: [transcript] },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/Agent name/), { target: { value: "bot" } });
+    fireEvent.click(screen.getByText("Upload"));
+
+    expect(
+      await screen.findByText("session 'sess-support-42' already belongs to org_beta"),
+    ).toBeTruthy();
+    expect(screen.getByPlaceholderText("Session id")).toHaveValue("sess-support-42");
+  });
+
+  it("disables the upload until a file, session id, and agent name are set", async () => {
+    render(<UserSessionUploadControls externalUserId="org_acme" onAdded={() => {}} />);
+    await openForm();
+    expect(screen.getByText("Upload")).toBeDisabled();
+    fireEvent.change(screen.getByTestId("user-transcript-input"), {
+      target: { files: [transcript] },
+    });
+    expect(screen.getByText("Upload")).toBeDisabled();
+    fireEvent.change(screen.getByPlaceholderText(/Agent name/), { target: { value: "bot" } });
+    expect(screen.getByText("Upload")).toBeEnabled();
+  });
+});

--- a/frontend/src/components/developer/UserSessionUploadControls.tsx
+++ b/frontend/src/components/developer/UserSessionUploadControls.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { MoreHorizontal, X } from "lucide-react";
+import { useState } from "react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { uploadTranscript } from "@/lib/api";
+
+// Hand this user a session by uploading its .jsonl transcript. Behind a "…"
+// menu: sessions normally arrive from the product's backend, so uploading
+// one by hand is the unexpected path.
+export default function UserSessionUploadControls({
+  externalUserId,
+  onAdded,
+}: {
+  externalUserId: string;
+  onAdded: () => void;
+}) {
+  const [formOpen, setFormOpen] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+  const [sessionId, setSessionId] = useState("");
+  const [agentName, setAgentName] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  function pickFile(picked: File) {
+    setFile(picked);
+    // The filename stem is the natural session id; editable for collisions.
+    if (!sessionId.trim()) setSessionId(picked.name.replace(/\.jsonl(\.gz)?$/i, ""));
+  }
+
+  async function upload() {
+    if (!file) return;
+    setBusy(true);
+    setError("");
+    try {
+      const result = await uploadTranscript(
+        file,
+        sessionId.trim(),
+        agentName.trim(),
+        undefined,
+        externalUserId,
+      );
+      if (result.skipped) {
+        setError(`Nothing imported: ${result.reason}.`);
+        return;
+      }
+      setFile(null);
+      setSessionId("");
+      setAgentName("");
+      setFormOpen(false);
+      onAdded();
+    } catch (cause) {
+      if (!(cause instanceof Error)) throw cause;
+      setError(cause.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!formOpen) {
+    return (
+      <div className="flex justify-end">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              aria-label="Session actions"
+              className="cursor-pointer rounded p-1.5 text-muted-foreground hover:bg-raised hover:text-foreground"
+            >
+              <MoreHorizontal className="h-4 w-4" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => setFormOpen(true)}>
+              Upload a session transcript
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4 rounded border border-border bg-surface px-5 py-4">
+      <div className="flex items-start justify-between">
+        <div className="text-[14.5px] text-foreground">Upload a session transcript</div>
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={() => setFormOpen(false)}
+          className="cursor-pointer rounded p-1 text-muted-foreground hover:bg-raised hover:text-foreground"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <p className="mt-1 text-[13px] leading-6 text-muted-foreground">
+        A <span className="font-mono text-[12px]">.jsonl</span>{" "}
+        transcript lands in this user&apos;s sessions exactly as if their agent had streamed it.
+      </p>
+      <div className="mt-3 space-y-2">
+        <input
+          type="file"
+          accept=".jsonl,.gz"
+          data-testid="user-transcript-input"
+          onChange={(event) => {
+            const picked = event.target.files?.[0];
+            if (picked) pickFile(picked);
+          }}
+          disabled={busy}
+          className="w-full text-[12px] text-foreground file:mr-3 file:cursor-pointer file:rounded-md file:border file:border-border file:bg-background file:px-3 file:py-1.5 file:text-[12px] file:font-medium file:text-foreground"
+        />
+        <div className="flex items-center gap-2">
+          <input
+            value={sessionId}
+            onChange={(event) => setSessionId(event.target.value)}
+            placeholder="Session id"
+            className="w-full rounded-md border border-border bg-background px-2 py-1.5 font-mono text-[12px] text-foreground placeholder:font-sans placeholder:text-muted-foreground"
+            disabled={busy}
+          />
+          <input
+            value={agentName}
+            onChange={(event) => setAgentName(event.target.value)}
+            placeholder="Agent name (e.g. support-bot)"
+            className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-[12px] text-foreground placeholder:text-muted-foreground"
+            disabled={busy}
+          />
+          <button
+            type="button"
+            onClick={() => void upload()}
+            disabled={busy || !file || sessionId.trim() === "" || agentName.trim() === ""}
+            className="shrink-0 cursor-pointer rounded-md border border-border px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-raised disabled:opacity-60"
+          >
+            {busy ? "Uploading..." : "Upload"}
+          </button>
+        </div>
+      </div>
+      {error && <div className="mt-2 text-[12.5px] text-error">{error}</div>}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1286,7 +1286,10 @@ export const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
 
 async function uploadAny(
   file: File,
-  folderId?: string | null
+  folderId?: string | null,
+  // External Multiplayer: scope the file to one end user (the developer's
+  // own id for them). The server stamps the file row's end_user_id.
+  userId?: string
 ): Promise<UploadApiResponse> {
   if (file.size > MAX_UPLOAD_BYTES) {
     throw new Error(`${file.name} is too large (max 100 MB)`);
@@ -1295,6 +1298,7 @@ async function uploadAny(
   const formData = new FormData();
   formData.append("file", file);
   if (folderId) formData.append("folder_id", folderId);
+  if (userId) formData.append("user_id", userId);
   // Hand-rolled fetch (FormData must set its own Content-Type), so the scope
   // header has to be attached here too — without it the server resolves the
   // upload to the personal scope and rejects any workspace-scoped folder_id.
@@ -1325,9 +1329,10 @@ async function uploadAny(
 // server didn't route it to the pages table.
 export async function uploadFile(
   file: File,
-  folderId?: string | null
+  folderId?: string | null,
+  userId?: string
 ): Promise<FileInfo> {
-  const result = await uploadAny(file, folderId);
+  const result = await uploadAny(file, folderId, userId);
   if (result.kind === "page") {
     throw new Error(
       `uploadFile got a page back from the server (${file.name}); ` +
@@ -2052,7 +2057,9 @@ export async function uploadTranscript(
   file: File,
   sessionId: string,
   agentName: string,
-  cwd?: string
+  cwd?: string,
+  // External Multiplayer: file the session under this end user.
+  userId?: string
 ): Promise<UploadedTranscript> {
   const token = await getAuthToken();
   const formData = new FormData();
@@ -2060,6 +2067,7 @@ export async function uploadTranscript(
   formData.append("session_id", sessionId);
   formData.append("agent_name", agentName);
   if (cwd) formData.append("cwd", cwd);
+  if (userId) formData.append("user_id", userId);
 
   // Hand-rolled fetch (FormData); the scope header must ride along or the
   // server files the transcript under the personal scope.


### PR DESCRIPTION
This PR makes it possible to manually add a file or a session to the developer console, as a developer convenience

# Slop

> **Stacked on #1102** — based on `codex/org-drive-source-ui` so the diff shows only this work; retarget to `main` lands automatically when 1102 merges. Together with #1102 (Drive sources) and #1104 (manual user creation), this completes manual setup of an end user from the console.

## Why

The user detail page could only display a user's material — files and sessions had to arrive through the product backend's API calls. A developer setting a user up ahead of onboarding (dogfooding feedback) had no way to hand them a file or a session transcript.

## What changed

- **Files**: an "Upload a file" button in the Files section. Rides the pre-existing `user_id` form field on `POST /me/files` (which turned out to have no test — added one); the file row is stamped `end_user_id`, so only that user's agent sees it.
- **Sessions**: a transcript upload hidden behind a "…" menu — sessions normally stream from the product backend, so uploading one by hand is the unexpected path. The form takes a `.jsonl` file (session id prefills from the filename stem, editable) and an agent name.
- **Backend**: the transcript endpoint gains an optional `user_id`. Two deliberate constraints: the end user must already exist (unknown id → 400), and a session born into a different user — or none — refuses the upload with "already belongs to…" rather than migrating. `end_user_id` is set-at-insert-only (it is the session's privacy boundary), so the user is resolved before any session row is written.
- A "skipped" upload (session already has events) surfaces inline as "Nothing imported: …" instead of pretending it imported.

## How it was verified

- `pytest backend/tests/test_developer_platform.py backend/tests/test_transcripts.py` — 44 passed, including new tests: transcript files the session under the user, unknown user 400s, cannot move a session between users, file upload stamps `end_user_id`
- `npm test` — 63 files, 313 tests passed (7 new component cases across both controls)
- `ruff check` / `ruff format --check` / `npm run lint` — clean (10 pre-existing warnings in unrelated files)
- Clicked through live: uploaded a file and a 2-event transcript for a user; both appeared in their sections and both DB rows are stamped to that user; the transcript's own timestamps date the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rq2QegXVmXAm4ptrTN8RFU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch end-user privacy boundaries (session `end_user_id` at insert and cross-user rejection); behavior is guarded by new tests but transcript upload is a new code path for `user_id`.
> 
> **Overview**
> Developers can **manually attach files and session transcripts to a specific end user** from the user detail page in the developer console, without going through the product backend.
> 
> **Backend:** `POST /me/transcripts` gains an optional `user_id` form field. When set, the handler resolves the end user (must already exist → 400 if unknown), runs the same cross-user session guard as event batch uploads, and passes `end_user_id` into `upsert_session` so the session is born in that user's privacy boundary. Re-uploading a transcript for a session that already belongs to another user is rejected instead of migrating.
> 
> **Frontend:** New **Upload a file** control on the Files section (uses existing `user_id` on `POST /me/files`). Sessions get a **… → Upload a session transcript** flow with `.jsonl`, session id (prefilled from filename), and agent name; skipped imports show inline (*Nothing imported: …*) rather than refreshing the list.
> 
> **Client API:** `uploadFile` and `uploadTranscript` accept an optional `userId` that is sent as `user_id` in the multipart form.
> 
> **Tests:** Integration coverage for user-scoped transcript upload, unknown user, session user collision, and file `end_user_id` stamping; component tests for both upload controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec46893b97093d8b78101582b41b07df811b1962. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->